### PR TITLE
fix for build error due to plugin version

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -375,7 +375,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.3</version>
                 <configuration>
                     <reportPlugins>
                         <plugin>


### PR DESCRIPTION
This will fix the following exception while building on latest Maven version due to plugin version mis-match.

java.lang.ClassNotFoundException: org.sonatype.aether.graph.DependencyFilter