### PR TITLE
Updating migration client pom with correct properties

### DIFF
--- a/modules/migration/migration-5.0.0_to_5.1.0/wso2-is-migration-client/pom.xml
+++ b/modules/migration/migration-5.0.0_to_5.1.0/wso2-is-migration-client/pom.xml
@@ -100,7 +100,7 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.apache.commons.logging; version="${version.commons.logging}",
-                            org.wso2.carbon.identity.core.*; version="${carbon.identity.version}",
+                            org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.version}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>


### PR DESCRIPTION
`carbon.identity.version` no longer defined in the root pom. Should use `carbon.identity.framework.version` instead