### PR TITLE
Fix testGetAllFederatedAuthenticators testcase [5.2.0]

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
@@ -446,8 +446,6 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
                             "Default federated authenticator OpenIDConnectAuthenticator not found");
         Assert.assertEquals(allFedAuthenticators.containsKey("MicrosoftWindowsLiveAuthenticator"), true,
                             "Default federated authenticator MicrosoftWindowsLiveAuthenticator not found");
-        Assert.assertEquals(allFedAuthenticators.containsKey("OpenIDAuthenticator"), true,
-                            "Default federated authenticator OpenIDAuthenticator not found");
         Assert.assertEquals(allFedAuthenticators.containsKey("YahooOAuth2Authenticator"), true,
                             "Default federated authenticator YahooOAuth2Authenticator not found");
         Assert.assertEquals(allFedAuthenticators.containsKey("SAMLSSOAuthenticator"), true,


### PR DESCRIPTION
$subject since OpenID federated authenticator is no longer packed.