### PR TITLE
IDENTITY-5285: Adding support for having different hostnames for carbon server and load balancer

### DIFF
--- a/modules/jaggery-apps/user-dashboard/dashboard/login.jag
+++ b/modules/jaggery-apps/user-dashboard/dashboard/login.jag
@@ -69,13 +69,10 @@ function initAuthenticationProtocol(){
 				if(prop === "SAML.KeyStore"){
 					value = value.replace("{carbon.home}", carbonHome);
 				}
-				if(prop === "SAML.IdPUrl"){
-					if(prop.indexOf("http") > -1){
-						value = value;
-					}else{
+				if (prop === "SAML.IdPUrl") {
+					if (value.indexOf("http") == -1) {
 						value = serverCoreUrl + "/" + (value);
 					}
-
 				}
 				properties[prop] = value;
 			}


### PR DESCRIPTION
Need to define the new saml Idp url in auth_config.json.
Eg: "SAML.IdPUrl" : "htttps://wso2.is.com/samlsso"