### PR TITLE
Fix test cases

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
@@ -26,6 +26,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProviderProperty;
 import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvider;
@@ -52,6 +53,8 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
     private boolean residentIdpPrimary;
     private String residentIdpName;
     private String residentIDPDefaultRealm;
+    private IdentityProviderProperty[] idpProperties;
+
     private String defaultSamlSSOEntityID = "localhost";
     private final String SAML2SSO_NAME = "samlsso";
     private final String SAML2SSO_IDP_ENTITY_ID = "IdPEntityId";
@@ -80,6 +83,7 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
         identityProvider.setPrimary(residentIdpPrimary);
         identityProvider.setIdentityProviderName(residentIdpName);
         identityProvider.setHomeRealmId(residentIDPDefaultRealm);
+        identityProvider.setIdpProperties(idpProperties);
 
         FederatedAuthenticatorConfig samlFedAuthn = new FederatedAuthenticatorConfig();
         samlFedAuthn.setName(SAML2SSO_NAME);
@@ -480,6 +484,8 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
         residentIdpPrimary = residentProvider.getPrimary();
         residentIdpName = residentProvider.getIdentityProviderName();
         residentIDPDefaultRealm = residentProvider.getHomeRealmId();
+
+        idpProperties = residentProvider.getIdpProperties();
 
         IdentityProvider identityProvider = new IdentityProvider();
         identityProvider.setEnable(true);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -129,8 +129,8 @@
             <class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>
 
             <!--Identity Provider Management Test Cases-->
-            <!--<class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />-->
-            <!--<class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />-->
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
             <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathAuthenticatorBaseTestCase" />
             <!--Entitlement Test Cases-->
             <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementPIPAttributeCacheTestCase"/>-->


### PR DESCRIPTION
If the resident idp is updated without properly setting idp properties, it will override the expected properties in the resident idp. Without these properties, authentication flow will not work properly.

There should be a array size check for the below code, as there can be ArrayIndexOutOfBoundsExceptions.
https://github.com/wso2-extensions/identity-governance/blob/v0.1.15/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java#L286