### PR TITLE
Fixing tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/analytics/config/identit_original.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/analytics/config/identit_original.xml
@@ -425,8 +425,6 @@
                        orderId="50" enable="false"/>
         <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener" name="org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
                        orderId="90" enable="true"/>
-        <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener" name="org.wso2.carbon.identity.governance.listener.IdentityMgtEventListener"
-                       orderId="95" enable="false"/>
         <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener" name="org.wso2.carbon.identity.governance.listener.IdentityStoreEventListener"
                        orderId="100" enable="false">
             <Property name="Data.Store">org.wso2.carbon.identity.governance.store.UserStoreBasedIdentityDataStore</Property>


### PR DESCRIPTION
Without this fix analytics tests doesn't revert back to original state of the carbon server which makes other tests to be broken.