### PR TITLE
Switching to individual insert queries from batch inserts in IS 5.3.0 migration client

### DIFF
--- a/modules/migration/migration-5.2.0_to_5.3.0/wso2-is-migration-client/src/main/java/org/wso2/carbon/is/migration/dao/IdpMetaDataDAO.java
+++ b/modules/migration/migration-5.2.0_to_5.3.0/wso2-is-migration-client/src/main/java/org/wso2/carbon/is/migration/dao/IdpMetaDataDAO.java
@@ -125,12 +125,11 @@ public class IdpMetaDataDAO {
                 prepStmt.setString(3, idpMetaData.getValue());
                 prepStmt.setString(4, idpMetaData.getDisplayName());
                 prepStmt.setInt(5, idpMetaData.getTenantId());
-                prepStmt.addBatch();
+                prepStmt.executeUpdate();
             }
-
-            prepStmt.executeBatch();
             connection.commit();
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new ISMigrationException("Error while inserting default resident idp property values.", e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);


### PR DESCRIPTION
This is done to avoid possible complications with oracle jdbc driver versions that do not support batch queries.