### PR TITLE
IDENTITY-6119: Test case

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/UserProfileMgtServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/UserProfileMgtServiceClient.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.user.profile.stub.UserProfileMgtServiceStub;
 import org.wso2.carbon.identity.user.profile.stub.UserProfileMgtServiceUserProfileExceptionException;
+import org.wso2.carbon.identity.user.profile.stub.types.AssociatedAccountDTO;
 import org.wso2.carbon.identity.user.profile.stub.types.UserProfileDTO;
 
 import java.rmi.RemoteException;
@@ -135,5 +136,16 @@ public class UserProfileMgtServiceClient {
 
     public boolean isReadOnlyUserStore() throws RemoteException, UserProfileMgtServiceUserProfileExceptionException {
         return userProfileMgtServiceStub.isReadOnlyUserStore();
+    }
+
+    public void addFedIdpAccountAssociation(String idpName,
+                                            String idpAssociatedId) throws Exception{
+
+        userProfileMgtServiceStub.associateID(idpName, idpAssociatedId);
+    }
+
+    public AssociatedAccountDTO[] getAssociatedFedUserAccountIds() throws Exception {
+
+        return userProfileMgtServiceStub.getAssociatedIDs();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1509,7 +1509,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.8.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.8.26</carbon.identity.framework.version>
 
         <!--Identity Repo Versions-->
         <identity.carbon.auth.saml2.version>5.2.2</identity.carbon.auth.saml2.version>
@@ -1521,7 +1521,7 @@
         <identity.inbound.auth.sts.version>5.2.2</identity.inbound.auth.sts.version>
         <identity.outbound.auth.requestpath.basicauth.version>5.1.3</identity.outbound.auth.requestpath.basicauth.version>
         <identity.carbon.auth.mutual.ssl.version>5.1.2</identity.carbon.auth.mutual.ssl.version>
-        <identity.user.account.association.version>5.1.3</identity.user.account.association.version>
+        <identity.user.account.association.version>5.1.4</identity.user.account.association.version>
         <identity.user.workflow.version>5.1.3</identity.user.workflow.version>
         <identity.user.ws.version>5.1.4</identity.user.ws.version>
         <identity.userstore.ldap.version>5.1.2</identity.userstore.ldap.version>
@@ -1537,8 +1537,8 @@
         <identity.data.publisher.audit.version>1.0.0</identity.data.publisher.audit.version>
         <!--<identity.carbon.auth.thrift.version>5.5.0-SNAPSHOT</identity.carbon.auth.thrift.version>-->
         <!--<identity.application.auth.oidc.version>5.1.2-SNAPSHOT</identity.application.auth.oidc.version>-->
-        <identity.governance.version>1.0.5</identity.governance.version>
-        <carbon.identity.auth.version>1.1.3</carbon.identity.auth.version>
+        <identity.governance.version>1.0.7</identity.governance.version>
+        <carbon.identity.auth.version>1.1.4</carbon.identity.auth.version>
         <identity.event.handler.account.lock.version>1.1.2</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.0.0</identity.event.handler.notification.version>
         <identity.app.authz.xacml.version>1.0.1</identity.app.authz.xacml.version>


### PR DESCRIPTION
Test case for clearing federated IDP account association removal when a user is deleted.