### PR TITLE
IDENTITY-6499 : fix product-is build size issue

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -383,6 +383,7 @@
                             <descriptors>
                                 <descriptor>src/assembly/dist.xml</descriptor>
                             </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>
                     <execution>
@@ -397,6 +398,21 @@
                             </filters>
                             <descriptors>
                                 <descriptor>src/assembly/bin.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>src-doc</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>${basedir}/src/assembly/filter.properties</filter>
+                            </filters>
+                            <descriptors>
                                 <descriptor>src/assembly/src.xml</descriptor>
                                 <descriptor>src/assembly/docs.xml</descriptor>
                             </descriptors>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -17,6 +17,7 @@
  ~ under the License.
  -->
 <assembly>
+    <id>WSO2 Identity Server - Bin</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/modules/distribution/src/assembly/dist.xml
+++ b/modules/distribution/src/assembly/dist.xml
@@ -17,6 +17,7 @@
  ~ under the License.
  -->
 <assembly>
+    <id>WSO2 Identity Server - Dist</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/pom.xml
+++ b/pom.xml
@@ -493,10 +493,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.2-beta-2</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.4</version>


### PR DESCRIPTION
public jira : https://wso2.org/jira/browse/IDENTITY-6499
maven-assembly plugin updated version 2.5.1 will be inherited from carbon-parent.
With version upgrade it is mandatory to have an id element in assembly descriptor.
Added ids for dist.xml and bin.xml assembly descriptors