### PR TITLE
 Identity Server 5.4.0-Alpha8 release version update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <url>http://wso2.org/projects/identity</url>
 
     <modules>
-        <module>modules/migration/migration-5.2.0_to_5.3.0/wso2-is-migration-client</module>
+        <!--<module>modules/migration/migration-5.2.0_to_5.3.0/wso2-is-migration-client</module>-->
         <module>modules/features</module>
         <module>modules/p2-profile-gen</module>
         <module>modules/connectors</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1537,15 +1537,15 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.10.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.10.22</carbon.identity.framework.version>
 
         <!--Identity Repo Versions-->
         <identity.carbon.auth.saml2.version>5.2.3</identity.carbon.auth.saml2.version>
-        <identity.inbound.auth.saml.version>5.3.39</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>5.5.101</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.saml.version>5.3.41</identity.inbound.auth.saml.version>
+        <identity.inbound.auth.oauth.version>5.5.108</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.2.2</identity.inbound.auth.openid.version>
         <identity.agent.sso.version>5.1.13</identity.agent.sso.version>
-        <identity.inbound.auth.sts.version>5.2.7</identity.inbound.auth.sts.version>
+        <identity.inbound.auth.sts.version>5.2.8</identity.inbound.auth.sts.version>
         <identity.outbound.auth.requestpath.basicauth.version>5.1.5</identity.outbound.auth.requestpath.basicauth.version>
         <identity.carbon.auth.mutual.ssl.version>5.1.2</identity.carbon.auth.mutual.ssl.version>
         <identity.user.account.association.version>5.1.4</identity.user.account.association.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <url>http://wso2.org/projects/identity</url>
 
     <modules>
-        <!--<module>modules/migration/migration-5.2.0_to_5.3.0/wso2-is-migration-client</module>-->
+        <module>modules/migration/migration-5.2.0_to_5.3.0/wso2-is-migration-client</module>
         <module>modules/features</module>
         <module>modules/p2-profile-gen</module>
         <module>modules/connectors</module>
@@ -1525,6 +1525,29 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>wso2-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration> <!-- add this to disable checking -->
+                                    <additionalparam>-Xdoclint:none</additionalparam>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Removed the doc lint validation from product IS level.