### PR TITLE
Update identity.inbound.auth.oauth version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1615,7 +1615,7 @@
         <!--Identity Repo Versions-->
         <identity.carbon.auth.saml2.version>5.2.4</identity.carbon.auth.saml2.version>
         <identity.inbound.auth.saml.version>5.4.3</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>5.6.20</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>5.6.27</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.2.4</identity.inbound.auth.openid.version>
         <identity.agent.sso.version>5.1.14</identity.agent.sso.version>
         <identity.inbound.auth.sts.version>5.2.14</identity.inbound.auth.sts.version>


### PR DESCRIPTION
Update identity inbound oauth oauth version because the changes in XACML based scope validator for access token 