### PR TITLE
Excluding liberty-plugin execution from the build

### DIFF
--- a/modules/samples/microprofile/microprofile-jwt/pom.xml
+++ b/modules/samples/microprofile/microprofile-jwt/pom.xml
@@ -54,25 +54,25 @@
                         <default.https.port>8443</default.https.port>
                     </bootstrapProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>install-server</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>install-server</goal>
-                            <goal>create-server</goal>
-                            <goal>install-feature</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>package-server-with-apps</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>install-apps</goal>
-                            <goal>package-server</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>install-server</id>-->
+                        <!--<phase>prepare-package</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>install-server</goal>-->
+                            <!--<goal>create-server</goal>-->
+                            <!--<goal>install-feature</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                    <!--<execution>-->
+                        <!--<id>package-server-with-apps</id>-->
+                        <!--<phase>package</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>install-apps</goal>-->
+                            <!--<goal>package-server</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                <!--</executions>-->
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Possible fix for the build failure.

Removing the execution part of the maven liberty plugin as maven-3.0.5 does not support Eclipse Aether. Microprofile JWT sample uses liberty maven plugin which requires Eclipse Aether.

https://wiki.eclipse.org/Aether/Using_Aether_in_Maven_Plugins