### PR TITLE
x509Certificate validation feature

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -1031,5 +1031,13 @@
             <outputDirectory>wso2is-${pom.version}/repository/conf/identity</outputDirectory>
             <fileMode>644</fileMode>
         </file>
+        <file>
+            <source>
+                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/security/certificate-validation.xml
+            </source>
+            <outputDirectory>wso2is-${pom.version}/repository/conf/security</outputDirectory>
+            <fileMode>644</fileMode>
+        </file>
+
     </files>
 </assembly>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -445,6 +445,9 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.oauth.uma:org.wso2.carbon.identity.oauth.uma.server.feature:${carbon.identity.oauth.uma.version}
                                 </featureArtifactDef>
+                                <featureArtifactDef>
+                                    org.wso2.carbon.extension.identity.x509certificate:org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature:${org.wso2.carbon.extension.identity.x509certificate.version}
+                                </featureArtifactDef>
                             </featureArtifacts>
                         </configuration>
                     </execution>
@@ -910,6 +913,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.oauth.uma.server.feature.group</id>
                                     <version>${carbon.identity.oauth.uma.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature.group</id>
+                                    <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
                                 </feature>
 
                             </features>
@@ -1386,6 +1393,10 @@
                                     <id>org.wso2.carbon.identity.oauth.uma.server.feature.group</id>
                                     <version>${carbon.identity.oauth.uma.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature.group</id>
+                                    <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
+                                </feature>
 
                             </features>
                         </configuration>
@@ -1803,7 +1814,7 @@
                                 </feature>
 
                                 <!-- captcha for tomcat filter  -->
-			        <feature>
+                                <feature>
                                     <id>org.wso2.carbon.identity.captcha.server.feature.group</id>
                                     <version>${identity.governance.version}</version>
                                 </feature>
@@ -1822,6 +1833,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.oauth.uma.server.feature.group</id>
                                     <version>${carbon.identity.oauth.uma.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature.group</id>
+                                    <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
                                 </feature>
 
                             </features>
@@ -2035,6 +2050,11 @@
                                 <feature>
                                     <id>org.wso2.carbon.event.stream.server.feature.group</id>
                                     <version>${carbon.analytics-common.version}</version>
+                                </feature>
+
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature.group</id>
+                                    <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
                                 </feature>
 
                             </features>

--- a/pom.xml
+++ b/pom.xml
@@ -1621,6 +1621,11 @@
                 <artifactId>org.wso2.carbon.identity.oauth.uma.server.feature</artifactId>
                 <version>${carbon.identity.oauth.uma.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
+                <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature</artifactId>
+                <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1713,6 +1718,7 @@
         <identity.event.handler.notification.version>1.0.20</identity.event.handler.notification.version>
         <identity.app.authz.xacml.version>2.0.2</identity.app.authz.xacml.version>
         <identity.oauth2.validators.xacml.version>1.0.8</identity.oauth2.validators.xacml.version>
+        <org.wso2.carbon.extension.identity.x509certificate.version>1.0.3</org.wso2.carbon.extension.identity.x509certificate.version>
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->
         <!--<identity.userstore.cassandra.version>5.1.1</identity.userstore.cassandra.version>-->


### PR DESCRIPTION
Should be merged after merging https://github.com/wso2-extensions/identity-x509-revocation/pull/5 and changing the "org.wso2.carbon.extension.identity.x509certificate.version".