### PR TITLE
Fix test failure and updating components to latest versions

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/SelfSignUpConsentTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/SelfSignUpConsentTest.java
@@ -76,7 +76,7 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
     private static final String ERROR_MESSAGE_SELF_REGISTRATION_DISABLED = "Self registration is disabled for tenant" +
             " - %s";
     private static final String ERROR_MESSAGE_INVALID_TENANT = "Invalid tenant domain - %s";
-    private static final String ERROR_MESSAGE_USERNAME_TAKEN = "Username '%s' is already taken. Please pick a " +
+    private static final String ERROR_MESSAGE_USERNAME_TAKEN = "Username &#39;%s&#39; is already taken. Please pick a " +
             "different username";
 
     private String tenantAdminUserName;

--- a/pom.xml
+++ b/pom.xml
@@ -1680,7 +1680,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.11.231</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.11.235</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.11.0, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--Identity Repo Versions-->
@@ -1710,7 +1710,7 @@
         <identity.governance.version>1.1.14</identity.governance.version>
         <carbon.identity.auth.version>1.1.18</carbon.identity.auth.version>
         <identity.event.handler.account.lock.version>1.1.12</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.0.20</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.0.21</identity.event.handler.notification.version>
         <identity.app.authz.xacml.version>2.0.2</identity.app.authz.xacml.version>
         <identity.oauth2.validators.xacml.version>1.0.8</identity.oauth2.validators.xacml.version>
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
@@ -1747,7 +1747,7 @@
         <identity.metadata.saml.version>1.0.5</identity.metadata.saml.version>
 
         <!-- Connectors -->
-        <authenticator.totp.version>2.0.9</authenticator.totp.version>
+        <authenticator.totp.version>2.0.11</authenticator.totp.version>
         <authenticator.office365.version>1.0.4</authenticator.office365.version>
         <authenticator.smsotp.version>2.0.12</authenticator.smsotp.version>
         <authenticator.emailotp.version>2.0.9</authenticator.emailotp.version>
@@ -1761,7 +1761,7 @@
         <identity.notification.json.version>5.1.1</identity.notification.json.version>
 
         <!-- Forget-me tool -->
-        <forgetme.tool.version>1.1.15</forgetme.tool.version>
+        <forgetme.tool.version>1.1.19</forgetme.tool.version>
 
         <!--Identity Repo Versions End-->
 
@@ -1797,7 +1797,7 @@
         <junit.version>3.8.1</junit.version>
         <carbon.kernel.version>4.4.30</carbon.kernel.version>
         <carbon.commons.version>4.6.21</carbon.commons.version>
-        <carbon.dashboards.version>2.0.16</carbon.dashboards.version>
+        <carbon.dashboards.version>2.0.19</carbon.dashboards.version>
         <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
         <oauth2.client.version>1.0.0</oauth2.client.version>
         <orbit.version.axis2>1.6.1.wso2v11</orbit.version.axis2>
@@ -1833,7 +1833,7 @@
         <operadriver.version>0.8.1</operadriver.version>
         <selenium.version>2.40.0</selenium.version>
         <testng.version>6.1.1</testng.version>
-        <carbon.deployment.version>4.7.15</carbon.deployment.version>
+        <carbon.deployment.version>4.7.17</carbon.deployment.version>
         <carbon.registry.version>4.6.34</carbon.registry.version>
         <carbon.multitenancy.version>4.6.11</carbon.multitenancy.version>
         <jaggery.extensions.version>1.5.5</jaggery.extensions.version>
@@ -1849,9 +1849,9 @@
         <javax.servlet.version>2.5</javax.servlet.version>
         <slf4j.version>1.7.0</slf4j.version>
         <apache.openejb.version>4.5.2</apache.openejb.version>
-        <axis2.client.version>1.6.1-wso2v23</axis2.client.version>
-        <axis2.wso2.version>1.6.1-wso2v23</axis2.wso2.version>
-        <axis2-transports.version>1.1.0-wso2v13</axis2-transports.version>
+        <axis2.client.version>1.6.1-wso2v25</axis2.client.version>
+        <axis2.wso2.version>1.6.1-wso2v25</axis2.wso2.version>
+        <axis2-transports.version>2.0.0-wso2v21</axis2-transports.version>
         <json-smart.version>1.3</json-smart.version>
         <nimbusds.version>5.8.0.wso2v1</nimbusds.version>
         <nimbus.oidc.sdk.version>5.52</nimbus.oidc.sdk.version>
@@ -1883,7 +1883,7 @@
         <ds-annotations.version>1.2.10</ds-annotations.version>
         <snakeyaml.version>1.16.0.wso2v1</snakeyaml.version>
         <json.version>3.0.0.wso2v1</json.version>
-        <carbon.consent.mgt.version>1.0.52</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>1.0.53</carbon.consent.mgt.version>
         <carbon.database.utils.version>2.0.6</carbon.database.utils.version>
         <carbon.identity.oauth.uma.version>1.0.3</carbon.identity.oauth.uma.version>
         <liberty.maven.plugin.version>2.2</liberty.maven.plugin.version>


### PR DESCRIPTION
testAfterEnablingSelfRegistrationInvalidUser and selfSignUpWithConsents tests were failing due to a change in response content. Changed the assertion message to fix the failing tests.

Updates following components
- carbon.identity.framework.version
- identity.event.handler.notification.version
- authenticator.totp.version
- forgetme.tool.version
- carbon.dashboards.version
- carbon.deployment.version
- axis2.wso2.version
- axis2-transports.version
- carbon.consent.mgt.version