### PR TITLE
Add tenant range migration option for IS 5.4.0 and IS 5.5.0 migration clients.

### DIFF
--- a/modules/migration/migration-resources/migration-config.yaml
+++ b/modules/migration/migration-resources/migration-config.yaml
@@ -7,6 +7,10 @@ continueOnError: "true"
 batchUpdate: "true"
 ignoreForInactiveTenants: "true"
 
+migrateTenantRange: "false"
+migrationStartingTenantID: "0"
+migrationEndingTenantID: "0"
+
 versions:
  -
   version: "5.0.0-SP1"

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/MigrationClientImpl.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/MigrationClientImpl.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.identity.core.migrate.MigrationClient;
 import org.wso2.carbon.identity.core.migrate.MigrationClientException;
 import org.wso2.carbon.is.migration.config.Config;
 import org.wso2.carbon.is.migration.util.Constant;
+import org.wso2.carbon.is.migration.util.Utility;
 
 import java.util.List;
 
@@ -66,6 +67,10 @@ public class MigrationClientImpl implements MigrationClient {
             }
 
             boolean isMigrationStarted = false ;
+            if (Utility.isMigrateTenantRange()) {
+                log.info("Migration started for the tenant range " + Utility.getMigrationStartingTenantID() + " - "
+                        + Utility.getMigrationEndingTenantID());
+            }
 
             for(VersionMigration versionMigration : versionMigrationList){
                 log.info(Constant.MIGRATION_LOG + "Start Version : " + versionMigration.getPreviousVersion() + " to "

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/config/Config.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/config/Config.java
@@ -41,6 +41,10 @@ public class Config {
     private boolean batchUpdate;
     private boolean ignoreForInactiveTenants;
 
+    private boolean migrateTenantRange;
+    private int migrationStartingTenantID;
+    private int migrationEndingTenantID;
+
     private List<Version> versions = new ArrayList<>();
 
     private static Config config = null;
@@ -143,5 +147,27 @@ public class Config {
         this.ignoreForInactiveTenants = ignoreForInactiveTenants;
     }
 
+    public boolean isMigrateTenantRange() {
+        return migrateTenantRange;
+    }
 
+    public void setMigrateTenantRange(boolean migrateTenantRange) {
+        this.migrateTenantRange = migrateTenantRange;
+    }
+
+    public int getMigrationStartingTenantID() {
+        return migrationStartingTenantID;
+    }
+
+    public void setMigrationStartingTenantID(int migrationStartingTenantID) {
+        this.migrationStartingTenantID = migrationStartingTenantID;
+    }
+
+    public int getMigrationEndingTenantID() {
+        return migrationEndingTenantID;
+    }
+
+    public void setMigrationEndingTenantID(int migrationEndingTenantID) {
+        this.migrationEndingTenantID = migrationEndingTenantID;
+    }
 }

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/migrator/ClaimDataMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/migrator/ClaimDataMigrator.java
@@ -450,7 +450,7 @@ public class ClaimDataMigrator extends Migrator{
             migrateLocalClaimData(SUPER_TENANT_ID);
 
             // Migrate other tenants.
-            List<Tenant> tenants = Utility.getTenants();
+            Set<Tenant> tenants = Utility.getTenants();
             List<Integer> inactiveTenants = Utility.getInactiveTenants();
             boolean ignoreForInactiveTenants = isIgnoreForInactiveTenants();
             for (Tenant tenant : tenants) {

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v540/migrator/ClaimDataMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v540/migrator/ClaimDataMigrator.java
@@ -90,13 +90,23 @@ public class ClaimDataMigrator extends Migrator {
             migrateClaimData(Constant.SUPER_TENANT_ID);
 
             // Migrate other tenants.
-            List<Tenant> tenants = Utility.getTenants();
+            Set<Tenant> tenants = Utility.getTenants();
             List<Integer> inactiveTenants = Utility.getInactiveTenants();
             boolean ignoreForInactiveTenants = isIgnoreForInactiveTenants();
+            Set<Integer> tenantRangeID = new HashSet<>();
+            if (Utility.isMigrateTenantRange()) {
+                for (Tenant tenant : Utility.getTenants()) {
+                    tenantRangeID.add(tenant.getId());
+                }
+            }
             for (Tenant tenant : tenants) {
                 int tenantId = tenant.getId();
                 if (ignoreForInactiveTenants && inactiveTenants.contains(tenantId)) {
                     log.info("Skipping claim data migration for Inactive tenant : " + tenantId);
+                    continue;
+                }
+                if (Utility.isMigrateTenantRange() && !tenantRangeID.contains(tenantId)) {
+                    log.info("Tenant " + tenantId + " is not in range, Skipping claim data migration.");
                     continue;
                 }
                 migrateClaimData(tenant.getId());

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v540/migrator/OAuthDataMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v540/migrator/OAuthDataMigrator.java
@@ -30,11 +30,14 @@ import org.wso2.carbon.is.migration.service.v540.dao.OAuthDAO;
 import org.wso2.carbon.is.migration.service.v540.util.RegistryUtil;
 import org.wso2.carbon.is.migration.util.Constant;
 import org.wso2.carbon.is.migration.util.Utility;
+import org.wso2.carbon.user.api.Tenant;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class handles the OAuth data migration.
@@ -111,10 +114,20 @@ public class OAuthDataMigrator extends Migrator {
 
         boolean ignoreForInactiveTenants = isIgnoreForInactiveTenants();
         List<Integer> inactiveTenants = Utility.getInactiveTenants();
+        Set<Integer> tenantRangeID = new HashSet<>();
+        if (Utility.isMigrateTenantRange()) {
+            for (Tenant tenant : Utility.getTenants()) {
+                tenantRangeID.add(tenant.getId());
+            }
+        }
         for (OAuthConsumerApp consumerApp : consumerApps) {
             if (ignoreForInactiveTenants && inactiveTenants.contains(consumerApp.getTenantId())) {
                 log.info("Skipping OAuth2 consumer apps table migration for inactive tenant: " +
                         consumerApp.getTenantId());
+                continue;
+            }
+            if (Utility.isMigrateTenantRange() && !tenantRangeID.contains(consumerApp.getTenantId())) {
+                log.info("Skipping OAuth2 consumer apps table migration for tenant : " + consumerApp.getTenantId());
                 continue;
             }
             SpOAuth2ExpiryTimeConfiguration expiryTimeConfiguration = RegistryUtil.getSpTokenExpiryTimeConfig

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/RegistryDataManager.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/RegistryDataManager.java
@@ -23,10 +23,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.identity.core.migrate.MigrationClientException;
 import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.is.migration.internal.ISMigrationServiceDataHolder;
 import org.wso2.carbon.is.migration.service.v550.util.EncryptionUtil;
+import org.wso2.carbon.is.migration.util.Utility;
 import org.wso2.carbon.registry.core.Collection;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
@@ -40,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -81,7 +84,8 @@ public class RegistryDataManager {
         carbonContext.setTenantDomain(tenant.getDomain());
     }
 
-    public void migrateSubscriberPassword(boolean migrateActiveTenantsOnly) throws UserStoreException {
+    public void migrateSubscriberPassword(boolean migrateActiveTenantsOnly)
+            throws UserStoreException, MigrationClientException {
 
         //migrating super tenant configurations
         try {
@@ -92,7 +96,7 @@ public class RegistryDataManager {
         }
 
         //migrating tenant configurations
-        Tenant[] tenants = ISMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+        Set<Tenant> tenants = Utility.getTenants();
         for (Tenant tenant : tenants) {
             if (migrateActiveTenantsOnly && !tenant.isActive()) {
                 log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping Subscriber migration!");
@@ -128,10 +132,10 @@ public class RegistryDataManager {
         }
 
         //migrating tenant configurations
-        Tenant[] tenants = ISMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+        Set<Tenant> tenants = Utility.getTenants();
         for (Tenant tenant : tenants) {
             if (migrateActiveTenantsOnly && !tenant.isActive()) {
-                log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping Subscriber migration!");
+                log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping keystore passwords migration!");
                 continue;
             }
             try {
@@ -151,10 +155,10 @@ public class RegistryDataManager {
      * Method to migrate encrypted password of SYSLOG_PROPERTIES registry resource
      *
      * @param migrateActiveTenantsOnly
-     * @throws UserStoreException
+     * @throws UserStoreException,RegistryException,CryptoException,MigrationClientException
      */
     public void migrateSysLogPropertyPassword(boolean migrateActiveTenantsOnly)
-            throws UserStoreException, RegistryException, CryptoException {
+            throws UserStoreException, RegistryException, CryptoException, MigrationClientException {
 
         //migrating super tenant configurations
         try {
@@ -163,7 +167,7 @@ public class RegistryDataManager {
         } catch (Exception e) {
             log.error("Error while migrating Sys log property password for tenant : " + SUPER_TENANT_DOMAIN_NAME, e);
         }
-        Tenant[] tenants = ISMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+        Set<Tenant> tenants = Utility.getTenants();
         for (Tenant tenant : tenants) {
             if (migrateActiveTenantsOnly && !tenant.isActive()) {
                 log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping SYSLOG_PROPERTIES file migration. ");
@@ -184,10 +188,10 @@ public class RegistryDataManager {
      * @param migrateActiveTenantsOnly
      * @throws CryptoException
      * @throws RegistryException
-     * @throws UserStoreException
+     * @throws UserStoreException,RegistryException,CryptoException,MigrationClientException
      */
     public void migrateServicePrinciplePassword(boolean migrateActiveTenantsOnly) throws
-            CryptoException, RegistryException, UserStoreException {
+            CryptoException, RegistryException, UserStoreException, MigrationClientException {
 
         //migrating super tenant configurations
         try {
@@ -198,7 +202,7 @@ public class RegistryDataManager {
         }
 
         //migrating tenant configurations
-        Tenant[] tenants = ISMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+        Set<Tenant> tenants = Utility.getTenants();
         for (Tenant tenant : tenants) {
             if (migrateActiveTenantsOnly && !tenant.isActive()) {
                 log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping Service Principle Password migration!");

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/migrator/UserStorePasswordMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/migrator/UserStorePasswordMigrator.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.is.migration.internal.ISMigrationServiceDataHolder;
 import org.wso2.carbon.is.migration.service.Migrator;
 import org.wso2.carbon.is.migration.service.v550.util.EncryptionUtil;
 import org.wso2.carbon.is.migration.util.Constant;
+import org.wso2.carbon.is.migration.util.Utility;
 import org.wso2.carbon.user.api.Tenant;
 
 import java.io.File;
@@ -39,6 +40,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Iterator;
+import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -56,9 +58,8 @@ public class UserStorePasswordMigrator extends Migrator {
     }
 
     private void updateTenantConfigs() {
-        Tenant[] tenants;
         try {
-            tenants = ISMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+            Set<Tenant> tenants = Utility.getTenants();
             for (Tenant tenant : tenants) {
                 if (isIgnoreForInactiveTenants() && !tenant.isActive()) {
                     log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping secondary userstore migration!");

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v560/migrator/ClaimDataMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v560/migrator/ClaimDataMigrator.java
@@ -97,7 +97,7 @@ public class ClaimDataMigrator extends Migrator {
             migrateClaimData(Constant.SUPER_TENANT_ID);
 
             // Migrate other tenants.
-            List<Tenant> tenants = Utility.getTenants();
+            Set<Tenant> tenants = Utility.getTenants();
             List<Integer> inactiveTenants = Utility.getInactiveTenants();
             boolean ignoreForInactiveTenants = isIgnoreForInactiveTenants();
             for (Tenant tenant : tenants) {


### PR DESCRIPTION
This will add the capability to migrate the selected tenant by specifying following in the "migration-config.yaml"

migrateTenantRange: "true"
migrationStartingTenantID: "100"
migrationEndingTenantID: "200"

Note: This fix is only for the IS 5.4.0 and IS 5.5.0 migration clients.