### PR TITLE
Add userstore migration in IS 5.3 migration

### DIFF
--- a/modules/migration/migration-resources/migration-config.yaml
+++ b/modules/migration/migration-resources/migration-config.yaml
@@ -82,33 +82,38 @@ versions:
       location: "step1"
       schema: "identity"
    -
-    name: "ClaimDataMigrator"
+    name: "UserStorePasswordMigrator"
     order: 2
     parameters:
-      schema: "um"
+      schema: "identity"
    -
-    name: "PermissionDataMigrator"
+    name: "ClaimDataMigrator"
     order: 3
     parameters:
       schema: "um"
    -
-    name: "EmailTemplateDataMigrator"
+    name: "PermissionDataMigrator"
     order: 4
     parameters:
-      schema: "identity"
+      schema: "um"
    -
-    name: "ChallengeQuestionDataMigrator"
+    name: "EmailTemplateDataMigrator"
     order: 5
     parameters:
       schema: "identity"
    -
-    name: "ResidentIdpMetadataMigrator"
+    name: "ChallengeQuestionDataMigrator"
     order: 6
     parameters:
       schema: "identity"
    -
-    name: "OIDCScopeDataMigrator"
+    name: "ResidentIdpMetadataMigrator"
     order: 7
+    parameters:
+      schema: "identity"
+   -
+    name: "OIDCScopeDataMigrator"
+    order: 8
     parameters:
       schema: "identity"
  -

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/migrator/UserStorePasswordMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/migrator/UserStorePasswordMigrator.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.is.migration.service.v530.migrator;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.migrate.MigrationClientException;
+import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
+import org.wso2.carbon.is.migration.internal.ISMigrationServiceDataHolder;
+import org.wso2.carbon.is.migration.service.v530.util.EncryptionUtil;
+import org.wso2.carbon.is.migration.util.Constant;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.is.migration.service.Migrator;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+public class UserStorePasswordMigrator extends Migrator{
+
+    private static final Log log = LogFactory.getLog(UserStorePasswordMigrator.class);
+
+    @Override
+    public void migrate() throws MigrationClientException {
+        log.info(Constant.MIGRATION_LOG + "Migration starting on Secondary User Stores");
+        updateSuperTenantConfigs();
+        updateTenantConfigs();
+    }
+
+    private void updateTenantConfigs() {
+        Tenant[] tenants;
+        try {
+            tenants = ISMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+            for (Tenant tenant : tenants) {
+                if (isIgnoreForInactiveTenants() && !tenant.isActive()) {
+                    log.info("Tenant " + tenant.getDomain() + " is inactive. Skipping secondary userstore migration!");
+                    continue;
+                }
+                File[] userstoreConfigs = getUserStoreConfigFiles(tenant.getId());
+                for(File file : userstoreConfigs) {
+                    if(file.isFile()){
+                        updatePassword(file.getAbsolutePath());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error while updating secondary user store password for tenant", e);
+        }
+    }
+
+    private void updateSuperTenantConfigs() {
+        try {
+            File[] userstoreConfigs = getUserStoreConfigFiles(Constant.SUPER_TENANT_ID);
+            for(File file : userstoreConfigs) {
+                if(file.isFile()){
+                    updatePassword(file.getAbsolutePath());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error while updating secondary user store password for super tenant", e);
+        }
+    }
+
+    private File[] getUserStoreConfigFiles(int tenantId) throws FileNotFoundException, IdentityException {
+
+        String carbonHome = System.getProperty(Constant.CARBON_HOME);
+        String userStorePath;
+        if(tenantId == Constant.SUPER_TENANT_ID) {
+            userStorePath = Paths.get(carbonHome,
+                    new String[]{"repository", "deployment", "server", "userstores"}).toString();
+        } else {
+            userStorePath = Paths.get(carbonHome,
+                    new String[]{"repository", "tenants", String.valueOf(tenantId), "userstores"}).toString();
+        }
+        File[] files = new File(userStorePath).listFiles();
+        return files != null ? files : new File[0];
+    }
+
+    private void updatePassword(String filePath) throws FileNotFoundException, CryptoException {
+
+        XMLStreamReader parser = null;
+        FileInputStream stream = null;
+        try {
+            log.info("Migrating password in: " + filePath);
+            stream = new FileInputStream(filePath);
+            parser = XMLInputFactory.newInstance().createXMLStreamReader(stream);
+            StAXOMBuilder builder = new StAXOMBuilder(parser);
+            OMElement documentElement = builder.getDocumentElement();
+            Iterator it = documentElement.getChildElements();
+            String newEncryptedPassword = null;
+            while (it.hasNext()) {
+                OMElement element = (OMElement) it.next();
+                if ("password".equals(element.getAttributeValue(new QName("name"))) ||
+                        "ConnectionPassword".equals(element.getAttributeValue(new QName("name")))) {
+                    String encryptedPassword = element.getText();
+                    newEncryptedPassword = EncryptionUtil.getNewEncryptedValue(encryptedPassword);
+                    if (StringUtils.isNotEmpty(newEncryptedPassword)) {
+                        element.setText(newEncryptedPassword);
+                    }
+                }
+            }
+
+            if (newEncryptedPassword != null) {
+                OutputStream outputStream = new FileOutputStream(filePath);
+                documentElement.serialize(outputStream);
+            }
+        } catch (XMLStreamException ex) {
+            log.error("Error while updating password for: " + filePath);
+        } finally {
+            try {
+                if(parser != null) {
+                    parser.close();
+                }
+                if(stream != null) {
+                    IdentityIOStreamUtils.closeInputStream(stream);
+                }
+            } catch (XMLStreamException ex) {
+                log.error("Error while closing XML stream", ex);
+            }
+
+        }
+    }
+}

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/migrator/UserStorePasswordMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/migrator/UserStorePasswordMigrator.java
@@ -44,7 +44,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-public class UserStorePasswordMigrator extends Migrator{
+public class UserStorePasswordMigrator extends Migrator {
 
     private static final Log log = LogFactory.getLog(UserStorePasswordMigrator.class);
 
@@ -65,8 +65,8 @@ public class UserStorePasswordMigrator extends Migrator{
                     continue;
                 }
                 File[] userstoreConfigs = getUserStoreConfigFiles(tenant.getId());
-                for(File file : userstoreConfigs) {
-                    if(file.isFile()){
+                for (File file : userstoreConfigs) {
+                    if (file.isFile()) {
                         updatePassword(file.getAbsolutePath());
                     }
                 }
@@ -79,8 +79,8 @@ public class UserStorePasswordMigrator extends Migrator{
     private void updateSuperTenantConfigs() {
         try {
             File[] userstoreConfigs = getUserStoreConfigFiles(Constant.SUPER_TENANT_ID);
-            for(File file : userstoreConfigs) {
-                if(file.isFile()){
+            for (File file : userstoreConfigs) {
+                if (file.isFile()) {
                     updatePassword(file.getAbsolutePath());
                 }
             }
@@ -93,12 +93,13 @@ public class UserStorePasswordMigrator extends Migrator{
 
         String carbonHome = System.getProperty(Constant.CARBON_HOME);
         String userStorePath;
-        if(tenantId == Constant.SUPER_TENANT_ID) {
-            userStorePath = Paths.get(carbonHome,
-                    new String[]{"repository", "deployment", "server", "userstores"}).toString();
+        if (tenantId == Constant.SUPER_TENANT_ID) {
+            userStorePath = Paths.get(carbonHome, new String[] { "repository", "deployment", "server", "userstores" })
+                    .toString();
         } else {
-            userStorePath = Paths.get(carbonHome,
-                    new String[]{"repository", "tenants", String.valueOf(tenantId), "userstores"}).toString();
+            userStorePath = Paths
+                    .get(carbonHome, new String[] { "repository", "tenants", String.valueOf(tenantId), "userstores" })
+                    .toString();
         }
         File[] files = new File(userStorePath).listFiles();
         return files != null ? files : new File[0];
@@ -118,8 +119,8 @@ public class UserStorePasswordMigrator extends Migrator{
             String newEncryptedPassword = null;
             while (it.hasNext()) {
                 OMElement element = (OMElement) it.next();
-                if ("password".equals(element.getAttributeValue(new QName("name"))) ||
-                        "ConnectionPassword".equals(element.getAttributeValue(new QName("name")))) {
+                if ("password".equals(element.getAttributeValue(new QName("name"))) || "ConnectionPassword"
+                        .equals(element.getAttributeValue(new QName("name")))) {
                     String encryptedPassword = element.getText();
                     newEncryptedPassword = EncryptionUtil.getNewEncryptedValue(encryptedPassword);
                     if (StringUtils.isNotEmpty(newEncryptedPassword)) {
@@ -136,10 +137,10 @@ public class UserStorePasswordMigrator extends Migrator{
             log.error("Error while updating password for: " + filePath);
         } finally {
             try {
-                if(parser != null) {
+                if (parser != null) {
                     parser.close();
                 }
-                if(stream != null) {
+                if (stream != null) {
                     IdentityIOStreamUtils.closeInputStream(stream);
                 }
             } catch (XMLStreamException ex) {

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/EncryptionUtil.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v530/util/EncryptionUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.is.migration.service.v530.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.core.util.CryptoUtil;
+
+public class EncryptionUtil {
+
+    public static String getNewEncryptedValue(String encryptedValue) throws CryptoException {
+        if (StringUtils.isNotEmpty(encryptedValue) && !isNewlyEncrypted(encryptedValue)) {
+            byte[] decryptedPassword = CryptoUtil.getDefaultCryptoUtil().base64DecodeAndDecrypt(encryptedValue, "RSA");
+            return CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(decryptedPassword);
+        }
+        return null;
+    }
+
+    public static boolean isNewlyEncrypted(String encryptedValue) throws CryptoException {
+        return CryptoUtil.getDefaultCryptoUtil().base64DecodeAndIsSelfContainedCipherText(encryptedValue);
+    }
+}

--- a/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/migrator/UserStorePasswordMigrator.java
+++ b/modules/migration/migration-service/src/main/java/org/wso2/carbon/is/migration/service/v550/migrator/UserStorePasswordMigrator.java
@@ -66,8 +66,8 @@ public class UserStorePasswordMigrator extends Migrator {
                     continue;
                 }
                 File[] userstoreConfigs = getUserStoreConfigFiles(tenant.getId());
-                for(File file : userstoreConfigs) {
-                    if(file.isFile()){
+                for (File file : userstoreConfigs) {
+                    if (file.isFile()) {
                         updatePassword(file.getAbsolutePath());
                     }
                 }
@@ -80,8 +80,8 @@ public class UserStorePasswordMigrator extends Migrator {
     private void updateSuperTenantConfigs() {
         try {
             File[] userstoreConfigs = getUserStoreConfigFiles(Constant.SUPER_TENANT_ID);
-            for(File file : userstoreConfigs) {
-                if(file.isFile()){
+            for (File file : userstoreConfigs) {
+                if (file.isFile()) {
                     updatePassword(file.getAbsolutePath());
                 }
             }
@@ -94,12 +94,13 @@ public class UserStorePasswordMigrator extends Migrator {
 
         String carbonHome = System.getProperty(Constant.CARBON_HOME);
         String userStorePath;
-        if(tenantId == Constant.SUPER_TENANT_ID) {
-            userStorePath = Paths.get(carbonHome,
-                    new String[]{"repository", "deployment", "server", "userstores"}).toString();
+        if (tenantId == Constant.SUPER_TENANT_ID) {
+            userStorePath = Paths.get(carbonHome, new String[] { "repository", "deployment", "server", "userstores" })
+                    .toString();
         } else {
-            userStorePath = Paths.get(carbonHome,
-                    new String[]{"repository", "tenants", String.valueOf(tenantId), "userstores"}).toString();
+            userStorePath = Paths
+                    .get(carbonHome, new String[] { "repository", "tenants", String.valueOf(tenantId), "userstores" })
+                    .toString();
         }
         File[] files = new File(userStorePath).listFiles();
         return files != null ? files : new File[0];
@@ -119,8 +120,8 @@ public class UserStorePasswordMigrator extends Migrator {
             String newEncryptedPassword = null;
             while (it.hasNext()) {
                 OMElement element = (OMElement) it.next();
-                if ("password".equals(element.getAttributeValue(new QName("name"))) ||
-                        "ConnectionPassword".equals(element.getAttributeValue(new QName("name")))) {
+                if ("password".equals(element.getAttributeValue(new QName("name"))) || "ConnectionPassword"
+                        .equals(element.getAttributeValue(new QName("name")))) {
                     String encryptedPassword = element.getText();
                     newEncryptedPassword = EncryptionUtil.getNewEncryptedValue(encryptedPassword);
                     if (StringUtils.isNotEmpty(newEncryptedPassword)) {
@@ -137,10 +138,10 @@ public class UserStorePasswordMigrator extends Migrator {
             log.error("Error while updating password for: " + filePath);
         } finally {
             try {
-                if(parser != null) {
+                if (parser != null) {
                     parser.close();
                 }
-                if(stream != null) {
+                if (stream != null) {
                     IdentityIOStreamUtils.closeInputStream(stream);
                 }
             } catch (XMLStreamException ex) {


### PR DESCRIPTION
When doing direct migrations from IS 5.2->5.6, the 5.3 claim migrator try to load user store configurations.
Since the IS 5.6 is by default OAEP enabled, we need to migrate the userstores to OAEP encryption, during 5.3 migration to avoid encryption/decryption errors due to direct migration.