### PR TITLE
Change File.separator in test cases to "/"

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/identity/integration/common/utils/ISIntegrationTest.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/identity/integration/common/utils/ISIntegrationTest.java
@@ -27,20 +27,16 @@ import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
 import org.wso2.carbon.automation.test.utils.common.TestConfigurationProvider;
-import org.wso2.carbon.identity.user.store.configuration.stub.api.Properties;
-import org.wso2.carbon.identity.user.store.configuration.stub.api.Property;
-import org.wso2.carbon.identity.user.store.configuration.stub.dto.PropertyDTO;
-import org.wso2.carbon.identity.user.store.configuration.stub.dto.UserStoreDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
 
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.net.URL;
-import java.util.ArrayList;
 
 public class ISIntegrationTest {
 
+    public static final String URL_SEPARATOR = "/";
     protected Log log = LogFactory.getLog(getClass());
     protected AutomationContext isServer;
     protected String backendURL;
@@ -133,8 +129,8 @@ public class ISIntegrationTest {
 //    }
 
     public void setSystemproperties() {
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(URL_SEPARATOR + "keystores" + URL_SEPARATOR
+                + "products" + URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword",
                 "wso2carbon");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/authentication/AnalyticsLoginTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/authentication/AnalyticsLoginTestCase.java
@@ -265,7 +265,7 @@ public class AnalyticsLoginTestCase extends ISIntegrationTest {
         log.info("Starting Tomcat");
         tomcatServer = Utils.getTomcat(getClass());
 
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + config.getApp()
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + config.getApp()
                 .getArtifact() + ".war");
         Utils.startTomcat(tomcatServer, "/" + config.getApp().getArtifact(), resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/oauth/OAuth2TokenIssuance.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/oauth/OAuth2TokenIssuance.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.analytics.commons.ThriftServer;
 import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
@@ -105,7 +106,7 @@ public class OAuth2TokenIssuance extends OAuth2ServiceAbstractIntegrationTest {
         try {
             tomcat = getTomcat();
             URL resourceUrl =
-                    getClass().getResource(File.separator + "samples" + File.separator +
+                    getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
                             "playground2.war");
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTenantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTenantTestCase.java
@@ -35,6 +35,7 @@ import org.wso2.identity.integration.common.clients.application.mgt.ApplicationM
 import org.wso2.identity.integration.common.clients.entitlement.EntitlementPolicyServiceClient;
 import org.wso2.identity.integration.common.clients.sso.saml.SAMLSSOConfigServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 
@@ -110,7 +111,7 @@ public class ApplicationAuthzTenantTestCase extends AbstractApplicationAuthzTest
         tomcatServer = Utils.getTomcat(getClass());
 
         URL resourceUrl = getClass()
-                .getResource(File.separator + "samples" + File.separator + "travelocity.com-saml-tenantwithoutsigning.war");
+                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com-saml-tenantwithoutsigning.war");
         Utils.startTomcat(tomcatServer, "/" + APPLICATION_NAME, resourceUrl.getPath());
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTestCase.java
@@ -37,6 +37,7 @@ import org.wso2.identity.integration.common.clients.application.mgt.ApplicationM
 import org.wso2.identity.integration.common.clients.entitlement.EntitlementPolicyServiceClient;
 import org.wso2.identity.integration.common.clients.sso.saml.SAMLSSOConfigServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 
@@ -111,7 +112,7 @@ public class ApplicationAuthzTestCase extends AbstractApplicationAuthzTestCase {
         tomcatServer = Utils.getTomcat(getClass());
 
         URL resourceUrl = getClass()
-                .getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
         Utils.startTomcat(tomcatServer, "/" + APPLICATION_NAME, resourceUrl.getPath());
 
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/AbstractIdentityFederationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/AbstractIdentityFederationTestCase.java
@@ -291,7 +291,7 @@ public abstract class AbstractIdentityFederationTestCase extends ISIntegrationTe
     }
 
     private void setSystemProperties() {
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword", "wso2carbon");
         System.setProperty("javax.net.ssl.trustStoreType", "JKS");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantCacheDisabledTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantCacheDisabledTestCase.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
@@ -120,7 +121,7 @@ public class OAuth2ServiceAuthCodeGrantCacheDisabledTestCase extends OAuth2Servi
         try {
             tomcat = getTomcat();
             URL resourceUrl =
-                    getClass().getResource(File.separator + "samples" + File.separator +
+                    getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
                             "playground2.war");
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.um.ws.api.stub.ClaimValue;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.identity.integration.common.clients.claim.metadata.mgt.ClaimMetadataManagementServiceClient;
 import org.wso2.identity.integration.common.clients.oauth.Oauth2TokenValidationClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -163,7 +164,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         try {
             tomcat = getTomcat();
             URL resourceUrl =
-                    getClass().getResource(File.separator + "samples" + File.separator +
+                    getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
                             "playground2.war");
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
         } catch (Exception e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.carbon.um.ws.api.stub.ClaimValue;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.identity.integration.common.clients.oauth.Oauth2TokenValidationClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -129,7 +130,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
         try {
             tomcat = getTomcat();
             URL resourceUrl =
-                    getClass().getResource(File.separator + "samples" + File.separator +
+                    getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
                             "playground2.war");
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
         } catch (Exception e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
@@ -128,7 +129,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
 		try {
 			tomcat = getTomcat();
 			URL resourceUrl =
-			                  getClass().getResource(File.separator + "samples" + File.separator +
+			                  getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
 			                                                 "playground2.war");
 			startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -29,6 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
@@ -84,7 +85,7 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
 		try {
 			tomcat = getTomcat();
 			URL resourceUrl =
-			                  getClass().getResource(File.separator + "samples" + File.separator +
+			                  getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
 			                                                 "playground2.war");
 			startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceImplicitGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceImplicitGrantTestCase.java
@@ -30,6 +30,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -91,7 +92,7 @@ public class OAuth2ServiceImplicitGrantTestCase extends OAuth2ServiceAbstractInt
 		try {
 			tomcat = getTomcat();
 			URL resourceUrl =
-			                  getClass().getResource(File.separator + "samples" + File.separator +
+			                  getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
 			                                                 "playground2.war");
 			startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceIntrospectionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceIntrospectionTestCase.java
@@ -27,6 +27,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 import org.apache.catalina.startup.Tomcat;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
@@ -84,7 +85,7 @@ public class OAuth2ServiceIntrospectionTestCase extends OAuth2ServiceAbstractInt
         try {
             tomcat = getTomcat();
             URL resourceUrl =
-                    getClass().getResource(File.separator + "samples" + File.separator +
+                    getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
                             "playground2.war");
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceRegexCallbackUrlTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceRegexCallbackUrlTestCase.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -76,7 +77,7 @@ public class OAuth2ServiceRegexCallbackUrlTestCase extends OAuth2ServiceAbstract
 
 		tomcat = getTomcat();
 		URL resourceUrl =
-				getClass().getResource(File.separator + "samples" + File.separator +
+				getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
 						"playground2.war");
 		startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 	}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
@@ -91,7 +92,7 @@ public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractInt
 		try {
 			tomcat = getTomcat();
 			URL resourceUrl =
-			                  getClass().getResource(File.separator + "samples" + File.separator +
+			                  getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
 			                                                 "playground2.war");
 			startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceSAML2BearerGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceSAML2BearerGrantTestCase.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.sso.saml.stub.IdentitySAMLSSOConfigServiceIdentityException;
 import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
 import org.wso2.identity.integration.common.clients.sso.saml.SAMLSSOConfigServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -354,7 +355,7 @@ public class OAuth2ServiceSAML2BearerGrantTestCase extends OAuth2ServiceAbstract
     private void deployTravelocity() throws Exception {
 
         tomcat = getTomcat();
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator +
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR +
                 "travelocity.com.war");
         startTomcat(tomcat, OAuth2Constant.TRAVELOCITY_APP_CONTEXT_ROOT, resourceUrl.getPath());
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2HashAlgorithmTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2HashAlgorithmTestCase.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -242,7 +243,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
 
     private void registerAndDeployApplication() throws Exception {
         tomcat = getTomcat();
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + "playground2.war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "playground2.war");
         try {
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
         } catch (LifecycleException e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2PersistenceProcessorInsertTokenTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2PersistenceProcessorInsertTokenTestCase.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -241,7 +242,7 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
 
     private void registerAndDeployApplication() throws Exception {
         tomcat = getTomcat();
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + "playground2.war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "playground2.war");
         try {
             startTomcat(tomcat, OAuth2Constant.PLAYGROUND_APP_CONTEXT_ROOT, resourceUrl.getPath());
         } catch (LifecycleException e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAuthCodeGrantSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAuthCodeGrantSSOTestCase.java
@@ -38,6 +38,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.oidc.bean.OIDCUser;
 import org.wso2.identity.integration.test.util.Utils;
@@ -438,7 +439,7 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
     protected void deployApplications() {
 
         for (Map.Entry<String, OIDCApplication> entry : applications.entrySet()) {
-            URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + entry.getKey() +
+            URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + entry.getKey() +
                     "" + ".war");
             tomcat.addWebapp(tomcat.getHost(), entry.getValue().getApplicationContext(), resourceUrl.getPath());
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/openid/OpenIDSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/openid/OpenIDSSOTestCase.java
@@ -183,7 +183,7 @@ public class OpenIDSSOTestCase extends ISIntegrationTest {
         log.info("Starting Tomcat");
         tomcatServer = getTomcat();
         URL resourceURL =
-                getClass().getResource(File.separator + "samples" + File.separator + config.getAppType().getArtifact()
+                getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + config.getAppType().getArtifact()
                                        + ".war");
         tomcatServer.addWebapp(tomcatServer.getHost(), "/" + config.getAppType().getArtifact(), resourceURL.getPath());
         tomcatServer.start();
@@ -291,8 +291,8 @@ public class OpenIDSSOTestCase extends ISIntegrationTest {
     }
 
     private void setSystemProperties() {
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword",
                 "wso2carbon");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/postAuthnHandler/ChallengeQuestionPostAuthnHandlerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/postAuthnHandler/ChallengeQuestionPostAuthnHandlerTestCase.java
@@ -144,7 +144,7 @@ public class ChallengeQuestionPostAuthnHandlerTestCase extends ISIntegrationTest
         tomcatServer = Utils.getTomcat(getClass());
 
         URL resourceUrl = getClass()
-                .getResource(File.separator + "samples" + File.separator + config.getApp().getArtifact() + ".war");
+                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + config.getApp().getArtifact() + ".war");
         Utils.startTomcat(tomcatServer, "/" + config.getApp().getArtifact(), resourceUrl.getPath());
 
         AuthenticatorClient logManager = new AuthenticatorClient(backendURL);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/requestPathAuthenticator/SAMLWithRequestPathAuthenticationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/requestPathAuthenticator/SAMLWithRequestPathAuthenticationTest.java
@@ -109,7 +109,7 @@ public class SAMLWithRequestPathAuthenticationTest extends ISIntegrationTest {
         try {
             tomcat = getTomcat();
             URL resourceUrl = getClass()
-                    .getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+                    .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
             startTomcat(tomcat, "/travelocity.com", resourceUrl.getPath());
 
         } catch (Exception e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/ChangeACSUrlTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/ChangeACSUrlTestCase.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.application.common.model.xsd.InboundAuthenticati
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
 import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
@@ -110,7 +111,7 @@ public class ChangeACSUrlTestCase extends AbstractIdentityFederationTestCase {
 
         super.startTomcat(TOMCAT_8490);
 
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
         super.addWebAppToTomcat(TOMCAT_8490, "/travelocity.com", resourceUrl.getPath());
 
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
@@ -150,7 +150,7 @@ public class RegistryMountTestCase extends ISIntegrationTest {
         log.info("Starting Tomcat");
         tomcatServer = getTomcat();
 
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + artifact + ".war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + artifact + ".war");
         startTomcat(tomcatServer, "/" + artifact, resourceUrl.getPath());
 
         ssoConfigServiceClient

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLErrorResponseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLErrorResponseTestCase.java
@@ -115,7 +115,7 @@ public class SAMLErrorResponseTestCase extends ISIntegrationTest {
         tomcatServer = getTomcat();
 
         URL resourceUrl = getClass()
-                .getResource(File.separator + "samples" + File.separator + ARTIFACT_ID + ".war");
+                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + ARTIFACT_ID + ".war");
         startTomcat(tomcatServer, "/" + ARTIFACT_ID, resourceUrl.getPath());
     }
 
@@ -235,8 +235,8 @@ public class SAMLErrorResponseTestCase extends ISIntegrationTest {
 
     private void setSystemProperties() {
 
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty(JAVAX_NET_SSL_TRUSTORE, resourceUrl.getPath());
         System.setProperty(JAVAX_NET_SSL_TRUSTORE_PASSWORD, "wso2carbon");
         System.setProperty(JAVAX_NET_SSL_TRUSTORE_TYPE, "JKS");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLFederationDynamicQueryParametersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLFederationDynamicQueryParametersTestCase.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
 import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.common.clients.application.mgt.ApplicationManagementServiceClient;
 import org.wso2.identity.integration.common.clients.sso.saml.SAMLSSOConfigServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.IdentityConstants;
@@ -93,7 +94,7 @@ public class SAMLFederationDynamicQueryParametersTestCase extends AbstractIdenti
         try {
             tomcat = getTomcat();
             URL resourceUrl = getClass()
-                    .getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+                    .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
             tomcat.addWebapp(tomcat.getHost(), "/travelocity.com", resourceUrl.getPath());
             tomcat.start();
         } catch (Exception e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLFederationWithFileBasedSPAndIDPTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLFederationWithFileBasedSPAndIDPTestCase.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilExcepti
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.carbon.um.ws.api.stub.ClaimValue;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
@@ -102,7 +103,7 @@ public class SAMLFederationWithFileBasedSPAndIDPTestCase extends AbstractIdentit
         startCarbonServer(PORT_OFFSET_1, secondaryISServer, startupParameters);
         // Deploy webapp in Tomcat
         super.startTomcat(TOMCAT_8490);
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
         super.addWebAppToTomcat(TOMCAT_8490, "/travelocity.com", resourceUrl.getPath());
         // Create service clients
         super.createServiceClients(PORT_OFFSET_1, null, new IdentityConstants.ServiceClientType[]{IdentityConstants

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdentityFederationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdentityFederationTestCase.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
 import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
 import org.wso2.identity.integration.common.clients.UserManagementClient;
 import org.wso2.carbon.user.mgt.stub.UserAdminUserAdminException;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
@@ -110,10 +111,10 @@ public class SAMLIdentityFederationTestCase extends AbstractIdentityFederationTe
 
 //TODO: Need to fix tomcat issue
         super.startTomcat(TOMCAT_8490);
-//        super.addWebAppToTomcat(TOMCAT_8490, "/travelocity.com", getClass().getResource(File.separator + "samples" +
-//                                                                                        File.separator + "org.wso2.sample.is.sso.agent.war").getPath());
+//        super.addWebAppToTomcat(TOMCAT_8490, "/travelocity.com", getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" +
+//                                                                                        ISIntegrationTest.URL_SEPARATOR + "org.wso2.sample.is.sso.agent.war").getPath());
 
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
         super.addWebAppToTomcat(TOMCAT_8490, "/travelocity.com", resourceUrl.getPath());
 
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLInvalidIssuerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLInvalidIssuerTestCase.java
@@ -144,8 +144,8 @@ public class SAMLInvalidIssuerTestCase extends ISIntegrationTest {
 
         //TODO: Uncomment below once the tomcat dependency issue is resolved
 //        URL resourceUrl = getClass()
-//                .getResource(File.separator + "samples" + File.separator + "org.wso2.sample.is .sso.agent.war");
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + "travelocity.com.war");
+//                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "org.wso2.sample.is .sso.agent.war");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "travelocity.com.war");
         startTomcat(tomcatServer, "/travelocity.com", resourceUrl.getPath());
 
     }
@@ -210,8 +210,8 @@ public class SAMLInvalidIssuerTestCase extends ISIntegrationTest {
     }
 
     private void setSystemProperties() {
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                                                 + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                                                 + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword",
                            "wso2carbon");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLLocalAndOutboundAuthenticatorsTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLLocalAndOutboundAuthenticatorsTestCase.java
@@ -263,7 +263,7 @@ public class SAMLLocalAndOutboundAuthenticatorsTestCase extends ISIntegrationTes
         log.info("Starting Tomcat");
         tomcatServer = Utils.getTomcat(getClass());
 
-        URL resourceUrl = getClass().getResource(File.separator + "samples" + File.separator + config.getApplication
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + config.getApplication
                 ().getArtifact() + "" + ".war");
         Utils.startTomcat(tomcatServer, "/" + config.getApplication().getArtifact(), resourceUrl.getPath());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLQueryProfileTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLQueryProfileTestCase.java
@@ -189,7 +189,7 @@ public class SAMLQueryProfileTestCase extends ISIntegrationTest {
         tomcatServer = getTomcat();
 
         URL resourceUrl = getClass()
-                .getResource(File.separator + "samples" + File.separator + config.getApp().getArtifact() + ".war");
+                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + config.getApp().getArtifact() + ".war");
         startTomcat(tomcatServer, "/" + config.getApp().getArtifact(), resourceUrl.getPath());
 
     }
@@ -286,8 +286,8 @@ public class SAMLQueryProfileTestCase extends ISIntegrationTest {
         try {
             log.info("RESPONSE " + this.samlResponse);
             String id = QueryClientUtils.getAssertionId(this.samlResponse);
-            URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                    + "products" + File.separator + "wso2carbon.jks");
+            URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                    + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
             ClientSignKeyDataHolder signKeyDataHolder = null;
             try {
                 signKeyDataHolder = new ClientSignKeyDataHolder(resourceUrl.getPath(),
@@ -309,8 +309,8 @@ public class SAMLQueryProfileTestCase extends ISIntegrationTest {
     public void testSAMLAttributeQueryRequest() throws Exception {
 
         try {
-            URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                    + "products" + File.separator + "wso2carbon.jks");
+            URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                    + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
             ClientSignKeyDataHolder signKeyDataHolder = new ClientSignKeyDataHolder(resourceUrl.getPath(),
                     "wso2carbon", "wso2carbon");
             String serverURL = TestUserMode.TENANT_ADMIN.equals(config.getUserMode()) ? WSO2IS_TENANT_URL : WSO2IS_URL;
@@ -373,8 +373,8 @@ public class SAMLQueryProfileTestCase extends ISIntegrationTest {
 
 
     private void setSystemProperties() {
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword",
                 "wso2carbon");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLSSOTestCase.java
@@ -274,7 +274,7 @@ public class SAMLSSOTestCase extends ISIntegrationTest {
         tomcatServer = Utils.getTomcat(getClass());
 
         URL resourceUrl = getClass()
-                .getResource(File.separator + "samples" + File.separator + config.getApp().getArtifact() + ".war");
+                .getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + config.getApp().getArtifact() + ".war");
         Utils.startTomcat(tomcatServer, "/" + config.getApp().getArtifact(), resourceUrl.getPath());
 
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTS.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTS.java
@@ -97,8 +97,8 @@ public class TestPassiveSTS extends ISIntegrationTest {
     public void testDeployPassiveSTSSampleApp() {
         try {
             tomcat = getTomcat();
-            URL resourceUrl = getClass().getResource(File.separator + "samples"
-                    + File.separator + "PassiveSTSSampleApp.war");
+            URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples"
+                    + ISIntegrationTest.URL_SEPARATOR + "PassiveSTSSampleApp.war");
             startTomcat(tomcat, PASSIVE_STS_SAMPLE_APP_NAME, resourceUrl.getPath());
 
         } catch (Exception e) {
@@ -334,8 +334,8 @@ public class TestPassiveSTS extends ISIntegrationTest {
     }
 
     private void setSystemProperties() {
-        URL resourceUrl = getClass().getResource(File.separator + "keystores" + File.separator
-                + "products" + File.separator + "wso2carbon.jks");
+        URL resourceUrl = getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR
+                + "products" + ISIntegrationTest.URL_SEPARATOR + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword",
                 "wso2carbon");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTSFederation.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTSFederation.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvide
 import org.wso2.carbon.identity.application.common.model.idp.xsd.Property;
 import org.wso2.carbon.identity.application.common.model.xsd.*;
 import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
@@ -82,7 +83,7 @@ public class TestPassiveSTSFederation extends AbstractIdentityFederationTestCase
 
         super.startTomcat(TOMCAT_8490);
         super.addWebAppToTomcat(TOMCAT_8490, PASSIVE_STS_SAMPLE_APP_NAME,
-                                getClass().getResource(File.separator + "samples" + File.separator + "PassiveSTSSampleApp.war").getPath());
+                                getClass().getResource(ISIntegrationTest.URL_SEPARATOR + "samples" + ISIntegrationTest.URL_SEPARATOR + "PassiveSTSSampleApp.war").getPath());
         //servers getting ready...
         Thread.sleep(10000);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/util/Utils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/util/Utils.java
@@ -34,6 +34,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.mgt.stub.types.carbon.FlaggedName;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 
@@ -104,7 +105,7 @@ public class Utils {
     }
 
     public static void setSystemProperties(Class classIn) {
-        URL resourceUrl = classIn.getResource(File.separator + "keystores" + File.separator + "products" + File
+        URL resourceUrl = classIn.getResource(ISIntegrationTest.URL_SEPARATOR + "keystores" + ISIntegrationTest.URL_SEPARATOR + "products" + File
                 .separator + "wso2carbon.jks");
         System.setProperty("javax.net.ssl.trustStore", resourceUrl.getPath());
         System.setProperty("javax.net.ssl.trustStorePassword", "wso2carbon");

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/identity/ui/integration/test/oidc/OIDCAuthCodeSessionTestCase.java
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/identity/ui/integration/test/oidc/OIDCAuthCodeSessionTestCase.java
@@ -289,7 +289,7 @@ public class OIDCAuthCodeSessionTestCase extends OIDCAbstractUIIntegrationTest {
 
         for (Map.Entry<String, OIDCApplication> entry : applications.entrySet()) {
             URL resourceUrl =
-                    getClass().getResource(File.separator + "samples" + File.separator + entry.getKey() + ".war");
+                    getClass().getResource(URL_SEPARATOR + "samples" + URL_SEPARATOR + entry.getKey() + ".war");
             tomcat.addWebapp(tomcat.getHost(), entry.getValue().getApplicationContext(), resourceUrl.getPath());
         }
     }


### PR DESCRIPTION
Change File.separator in test cases of the getResource method to "/" as File.separator is giving "\\" in windows causing test failures.