### PR TITLE
Fix SCIM2MeTest failure when running alone.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2MeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2MeTestCase.java
@@ -41,7 +41,7 @@ import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.TYPE_PA
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.USER_NAME_ATTRIBUTE;
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.VALUE_PARAM;
 
-public class SCIM2MeTestCase extends ISIntegrationTest {
+public class SCIM2MeTestCase extends SCIM2BaseTestCase {
 
     private static final String FAMILY_NAME_CLAIM_VALUE = "scim";
     private static final String GIVEN_NAME_CLAIM_VALUE = "user";

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -79,7 +79,6 @@
 
     <test name="is-tests-scim2" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>


### PR DESCRIPTION
Add SCIM2BaseTestCase as superclass of SCIM2MeTestCase and remove SCIM2MeTestCase in testng.xml. This will enforce the identity.xml have changed before running SCIM2MeTestCase tests.