### PR TITLE
Issue fix for timestamp comparing assertion failure in testSAMLSSOLog…

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/authentication/AnalyticsLoginTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/authentication/AnalyticsLoginTestCase.java
@@ -573,7 +573,7 @@ public class AnalyticsLoginTestCase extends ISIntegrationTest {
      *Introduced user delayed time period in between each request to match the test method with the real user behaviour.
      * @param
      */
-    private void introduceUserDelay (int delayTimeInMilliseconds)throws Exception  {
+    private void introduceUserDelay(int delayTimeInMilliseconds) throws Exception  {
         Thread.sleep(delayTimeInMilliseconds);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/authentication/AnalyticsLoginTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/analytics/authentication/AnalyticsLoginTestCase.java
@@ -335,6 +335,7 @@ public class AnalyticsLoginTestCase extends ISIntegrationTest {
                         httpClient);
             }
 
+            introduceUserDelay(2000);
             String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
             EntityUtils.consume(response.getEntity());
             response = Utils.sendPOSTMessage(sessionKey, COMMON_AUTH_URL, USER_AGENT, ACS_URL, config.getApp()
@@ -345,6 +346,7 @@ public class AnalyticsLoginTestCase extends ISIntegrationTest {
                 Assert.assertNotNull(pastrCookie, "pastr cookie not found in response.");
                 EntityUtils.consume(response.getEntity());
 
+                introduceUserDelay(2000);
                 response = Utils.sendPOSTConsentMessage(response,
                         String.format(COMMON_AUTH_URL, DEFAULT_PORT),
                         USER_AGENT, ACS_URL, httpClient, pastrCookie);
@@ -354,6 +356,7 @@ public class AnalyticsLoginTestCase extends ISIntegrationTest {
             response = Utils.sendRedirectRequest(response, USER_AGENT, ACS_URL, config.getApp().getArtifact(), httpClient);
             String samlResponse = Utils.extractDataFromResponse(response, CommonConstants.SAML_RESPONSE_PARAM, 5);
             EntityUtils.consume(response.getEntity());
+            introduceUserDelay(2000);
             response = sendSAMLMessage(String.format(ACS_URL, config.getApp().getArtifact()), CommonConstants
                     .SAML_RESPONSE_PARAM, samlResponse);
             EntityUtils.consume(response.getEntity());
@@ -566,6 +569,13 @@ public class AnalyticsLoginTestCase extends ISIntegrationTest {
         }
     }*/
 
+    /**
+     *Introduced user delayed time period in between each request to match the test method with the real user behaviour.
+     * @param
+     */
+    private void introduceUserDelay (int delayTimeInMilliseconds)throws Exception  {
+        Thread.sleep(delayTimeInMilliseconds);
+    }
 
     @DataProvider(name = "samlConfigProvider")
     public static SAMLConfig[][] samlConfigProvider() {


### PR DESCRIPTION
Issue fix for timestamp comparing assertion failure in testSAMLSSOLogin method. 
Introduced user delayed time period in between each request to match the test method with the real user behavior. Unless the renewTimestamp and timestamp comparison assertion get fail.

Issue detected at released tag v5.8.0-m1
