### PR TITLE
Add SCIM2 scenario tests

### DIFF
--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/TestCases.md
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/TestCases.md
@@ -2,13 +2,12 @@
 
 ### 1.1.1 Provision user in identity server using SCIM2 API
 
-| TestCaseID | TestCase                                             | Test steps                                                            | Status      |
-|------------|------------------------------------------------------|-----------------------------------------------------------------------|-------------|
-| 1.1.1.1    | Provision a single user in IS using the SCIM2 API    | **Given**: Test environment is set properly                           | Automated   |
-|            |                                                      | **When** : A request sends to create a user using SCIM2 API           |             |
-|            |                                                      | **Then** : The user should be provisioned in IS                       |             |
-| 1.1.1.2    | Provision user with malformed request using SCIM2    | **Given**: A malformed requests payload exists                        | Not Started |
-|            |                                                      | **When** : A malformed request sends to create a user using SCIM2 API |             |
-|            |                                                      | **Then** : The user shouldn't be created & valid error message appear |             |
-|            |                                                      |                                                                       |             |
-
+| TestCaseID | TestCase                                                      | Test Behaviour                                                                                                                                                                                            | Status      |
+|------------|---------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| 1.1.1.1    | Provision a single user in IS using the SCIM2 API             | **Given**: Test environment is set properly</br> **When** : A request sends to create a user using SCIM2 API</br> **Then** : The user should be provisioned in IS                                     | Automated   |
+| 1.1.1.2    | Provision a user with malformed request using SCIM2           | **Given**: Test environment is set properly</br> **When** : A malformed request (missing mandatory attribute) sends to create a user</br> **Then** : Proper client side error message should appear   | Automated   |
+| 1.1.1.3    | Provision user with a validation failure  request using SCIM2 | **Given**: Test environment is set properly</br> **When** : An invalid request (password policy violation) sends to create a user</br> **Then** : Proper server side error message should appear      | Automated   |
+| 1.1.1.4    | Provision an already existing user using SCIM2                | **Given**: A user exists in the server</br> **When** : Send a request to create a user with an existing username</br> **Then** : User should not be created                                           | Automated   |
+| 1.1.1.5    | Provision a user without authorization headers using SCIM2    | **Given**: Test environment is set properly</br> **When** : Send a request to create user without the authentication header</br> **Then** : Client should get unauthorized response                   | Automated   |
+| 1.1.1.6    | Provision a user without content type header using SCIM2      | **Given**: Test environment is set properly</br> **When** : Send a request to create user without the content-type header</br> **Then** : Request should be failed with proper error message          | Automated   |
+| 1.1.1.7    | Provision a user with all possible attributes using SCIM2     | **Given**: Test environment is set properly</br> **When** : Send a request to create a user including all the default supported attributes</br> **Then** : User should be created with all attributes | Automated   |

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionExistingUserTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionExistingUserTestCase.java
@@ -36,21 +36,53 @@ import org.wso2.identity.scenarios.test.scim2.ScenarioTestBase;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
-public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
+public class ProvisionExistingUserTestCase extends ScenarioTestBase {
 
     private String userId;
     private CloseableHttpClient client;
+    private String USERNAME = "scim2user";
+    private String PASSWORD = "scim2pwd";
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
 
         setKeyStoreProperties();
         client = HttpClients.createDefault();
+
+        HttpResponse response = testCreateSCSIM2User(USERNAME, PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), 201, "User has not been created successfully");
+
+        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+
+        String usernameFromResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(usernameFromResponse, SCIMConstants.USERNAME);
+
+        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
+        assertNotNull(userId);
     }
 
-    @Test(description = "1.1.1.1")
-    public void testSCIM2CreateUser() throws Exception {
+    @Test(description = "1.1.1.4")
+    public void testSCIM2CreateExistingUser() throws Exception {
+
+        HttpResponse response = testCreateSCSIM2User(USERNAME, PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), 409,
+                "User already exists hence server should not accept user creation");
+
+        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+        JSONArray schemasArray = (JSONArray) ((JSONObject) responseObj).get("schemas");
+        assertNotNull(schemasArray);
+        assertEquals(schemasArray.get(0).toString(), SCIMConstants.ERROR_SCHEMA);
+        assertTrue(
+                responseObj.toString().contains("User with the name: " + USERNAME + " already exists in the system"));
+
+        testDeleteUser();
+    }
+
+    private HttpResponse testCreateSCSIM2User(String scim_username, String scim_password) throws Exception {
 
         String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
         HttpPost request = new HttpPost(scimEndpoint);
@@ -63,25 +95,13 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         JSONObject names = new JSONObject();
         names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
         rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
-        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
-        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, scim_username);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, scim_password);
 
         StringEntity entity = new StringEntity(rootObject.toString());
         request.setEntity(entity);
 
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 201, "User has not been created successfully");
-
-        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
-        EntityUtils.consume(response.getEntity());
-
-        String usernameFromResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
-        assertEquals(usernameFromResponse, SCIMConstants.USERNAME);
-
-        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
-        assertNotNull(userId);
-
-        testDeleteUser();
+        return client.execute(request);
     }
 
     private void testDeleteUser() throws Exception {

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionExistingUserTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionExistingUserTestCase.java
@@ -82,7 +82,7 @@ public class ProvisionExistingUserTestCase extends ScenarioTestBase {
         testDeleteUser();
     }
 
-    private HttpResponse testCreateSCSIM2User(String scim_username, String scim_password) throws Exception {
+    private HttpResponse testCreateSCSIM2User(String scimUsername, String scimPassword) throws Exception {
 
         String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
         HttpPost request = new HttpPost(scimEndpoint);
@@ -95,8 +95,8 @@ public class ProvisionExistingUserTestCase extends ScenarioTestBase {
         JSONObject names = new JSONObject();
         names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
         rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
-        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, scim_username);
-        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, scim_password);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, scimUsername);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, scimPassword);
 
         StringEntity entity = new StringEntity(rootObject.toString());
         request.setEntity(entity);

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithAllAttributesTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithAllAttributesTestCase.java
@@ -102,6 +102,7 @@ public class ProvisionUserWithAllAttributesTestCase extends ScenarioTestBase {
     }
 
     private void testGetSCIMUser() throws Exception {
+
         String userResourcePath =
                 getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
         HttpGet request = new HttpGet(userResourcePath);

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithMalformedRequestTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithMalformedRequestTestCase.java
@@ -20,8 +20,6 @@ package org.wso2.identity.scenarios.test.scim2;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -36,11 +34,12 @@ import org.wso2.identity.scenarios.test.scim2.ScenarioTestBase;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
-public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
+public class ProvisionUserWithMalformedRequestTestCase extends ScenarioTestBase {
 
-    private String userId;
     private CloseableHttpClient client;
+    private String USER_NAME_ATTRIBUTE = "Name";
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -49,8 +48,8 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         client = HttpClients.createDefault();
     }
 
-    @Test(description = "1.1.1.1")
-    public void testSCIM2CreateUser() throws Exception {
+    @Test(description = "1.1.1.2")
+    public void testMalformedSCIMUserCreate() throws Exception {
 
         String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
         HttpPost request = new HttpPost(scimEndpoint);
@@ -63,47 +62,23 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         JSONObject names = new JSONObject();
         names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
         rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
-        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
         rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
 
         StringEntity entity = new StringEntity(rootObject.toString());
         request.setEntity(entity);
 
         HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 201, "User has not been created successfully");
+        assertEquals(response.getStatusLine().getStatusCode(), 400,
+                "User creation request is malformed hence server should have returned a bad request");
 
         Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
         EntityUtils.consume(response.getEntity());
+        JSONArray schemasArray = (JSONArray) ((JSONObject) responseObj).get("schemas");
+        assertNotNull(schemasArray);
+        assertEquals(schemasArray.get(0).toString(), SCIMConstants.ERROR_SCHEMA);
+        assertTrue(responseObj.toString().contains("Required attribute userName is missing"));
 
-        String usernameFromResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
-        assertEquals(usernameFromResponse, SCIMConstants.USERNAME);
-
-        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
-        assertNotNull(userId);
-
-        testDeleteUser();
-    }
-
-    private void testDeleteUser() throws Exception {
-
-        String userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpDelete request = new HttpDelete(userResourcePath);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 204, "User has not been retrieved successfully");
-        EntityUtils.consume(response.getEntity());
-        userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpGet getRequest = new HttpGet(userResourcePath);
-        getRequest.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        getRequest.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 404, "User has not been deleted successfully");
-        EntityUtils.consume(response.getEntity());
     }
 
 }

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithMalformedRequestTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithMalformedRequestTestCase.java
@@ -78,7 +78,6 @@ public class ProvisionUserWithMalformedRequestTestCase extends ScenarioTestBase 
         assertNotNull(schemasArray);
         assertEquals(schemasArray.get(0).toString(), SCIMConstants.ERROR_SCHEMA);
         assertTrue(responseObj.toString().contains("Required attribute userName is missing"));
-
     }
 
 }

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithValidationFailuresTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithValidationFailuresTestCase.java
@@ -20,8 +20,6 @@ package org.wso2.identity.scenarios.test.scim2;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -36,11 +34,12 @@ import org.wso2.identity.scenarios.test.scim2.ScenarioTestBase;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
-public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
+public class ProvisionUserWithValidationFailuresTestCase extends ScenarioTestBase {
 
-    private String userId;
     private CloseableHttpClient client;
+    private String PASSWORD = "ab";
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -49,8 +48,8 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         client = HttpClients.createDefault();
     }
 
-    @Test(description = "1.1.1.1")
-    public void testSCIM2CreateUser() throws Exception {
+    @Test(description = "1.1.1.3")
+    public void testInvalidSCIMUserCreate() throws Exception {
 
         String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
         HttpPost request = new HttpPost(scimEndpoint);
@@ -64,46 +63,22 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
         rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
         rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
-        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, PASSWORD);
 
         StringEntity entity = new StringEntity(rootObject.toString());
         request.setEntity(entity);
 
         HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 201, "User has not been created successfully");
+        assertEquals(response.getStatusLine().getStatusCode(), 500,
+                "Password validation failed at user creation hence server should have returned a bad request");
 
         Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
         EntityUtils.consume(response.getEntity());
+        JSONArray schemasArray = (JSONArray) ((JSONObject) responseObj).get("schemas");
+        assertNotNull(schemasArray);
+        assertEquals(schemasArray.get(0).toString(), SCIMConstants.ERROR_SCHEMA);
+        assertTrue(responseObj.toString().contains("Credential is not valid"));
 
-        String usernameFromResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
-        assertEquals(usernameFromResponse, SCIMConstants.USERNAME);
-
-        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
-        assertNotNull(userId);
-
-        testDeleteUser();
-    }
-
-    private void testDeleteUser() throws Exception {
-
-        String userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpDelete request = new HttpDelete(userResourcePath);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 204, "User has not been retrieved successfully");
-        EntityUtils.consume(response.getEntity());
-        userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpGet getRequest = new HttpGet(userResourcePath);
-        getRequest.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        getRequest.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 404, "User has not been deleted successfully");
-        EntityUtils.consume(response.getEntity());
     }
 
 }

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithValidationFailuresTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithValidationFailuresTestCase.java
@@ -78,7 +78,6 @@ public class ProvisionUserWithValidationFailuresTestCase extends ScenarioTestBas
         assertNotNull(schemasArray);
         assertEquals(schemasArray.get(0).toString(), SCIMConstants.ERROR_SCHEMA);
         assertTrue(responseObj.toString().contains("Credential is not valid"));
-
     }
 
 }

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutAuthHeaderTestCase.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutAuthHeaderTestCase.java
@@ -20,26 +20,20 @@ package org.wso2.identity.scenarios.test.scim2;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.scenarios.test.scim2.ScenarioTestBase;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
-public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
+public class ProvisionUserWithoutAuthHeaderTestCase extends ScenarioTestBase {
 
-    private String userId;
     private CloseableHttpClient client;
 
     @BeforeClass(alwaysRun = true)
@@ -49,12 +43,11 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         client = HttpClients.createDefault();
     }
 
-    @Test(description = "1.1.1.1")
-    public void testSCIM2CreateUser() throws Exception {
+    @Test(description = "1.1.1.5")
+    public void testSCIMUserWithoutAuthHeader() throws Exception {
 
         String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
         HttpPost request = new HttpPost(scimEndpoint);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
         request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
 
         JSONObject rootObject = new JSONObject();
@@ -70,40 +63,8 @@ public class ProvisionUserSCIM2TestCase extends ScenarioTestBase {
         request.setEntity(entity);
 
         HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 201, "User has not been created successfully");
-
-        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
-        EntityUtils.consume(response.getEntity());
-
-        String usernameFromResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
-        assertEquals(usernameFromResponse, SCIMConstants.USERNAME);
-
-        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
-        assertNotNull(userId);
-
-        testDeleteUser();
-    }
-
-    private void testDeleteUser() throws Exception {
-
-        String userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpDelete request = new HttpDelete(userResourcePath);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 204, "User has not been retrieved successfully");
-        EntityUtils.consume(response.getEntity());
-        userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpGet getRequest = new HttpGet(userResourcePath);
-        getRequest.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        getRequest.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 404, "User has not been deleted successfully");
-        EntityUtils.consume(response.getEntity());
+        assertEquals(response.getStatusLine().getStatusCode(), 401,
+                "User creation should fail without auth header hence server should have returned an unauthorized message");
     }
 
 }

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
@@ -1,0 +1,25 @@
+package org.wso2.identity.scenarios.test.scim2;
+
+public class SCIMConstants {
+
+    public static final String SCIM2_USERS_ENDPOINT = "/scim2/Users";
+    public static final String SCHEMAS_ATTRIBUTE = "schemas";
+    public static final String GIVEN_NAME_ATTRIBUTE = "givenName";
+    public static final String FAMILY_NAME_ATTRIBUTE = "familyName";
+    public static final String EMAILS_ATTRIBUTE = "emails";
+    public static final String EMAIL_TYPE_WORK_ATTRIBUTE = "work";
+    public static final String EMAIL_TYPE_HOME_ATTRIBUTE = "home";
+    public static final String TYPE_PARAM = "type";
+    public static final String VALUE_PARAM = "value";
+    public static final String PRIMARY_PARAM = "primary";
+    public static final String NAME_ATTRIBUTE = "name";
+    public static final String USER_NAME_ATTRIBUTE = "userName";
+    public static final String PASSWORD_ATTRIBUTE = "password";
+    public static final String ID_ATTRIBUTE = "id";
+    public static final String GIVEN_NAME_CLAIM_VALUE = "user2";
+    public static final String FAMILY_NAME_CLAIM_VALUE = "scim2";
+    public static final String USERNAME = "scim2user";
+    public static final String PASSWORD = "scim2pwd";
+    public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+    public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+}

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/resources/log4j.properties
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2009 WSO2, Inc. (http://wso2.com)
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/resources/testng.xml
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.1-provision-user-using-SCIM2/src/test/resources/testng.xml
@@ -3,9 +3,15 @@
 <suite name="Identity-Scenario-Results">
     <parameter name="useDefaultListeners" value="false"/>
 
-    <test name="is-tests-usr-mgt" preserve-order="true" parallel="false">
+    <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
         </classes>
     </test>
 </suite>

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.2-provision-user-using-SCIM1.1/src/test/resources/testng.xml
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.2-provision-user-using-SCIM1.1/src/test/resources/testng.xml
@@ -1,9 +1,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="Identity-Scenario-Results">
-    <parameter name="useDefaultListeners" value="false"/>
+    <parameter name="useDefauhttps://github.com/sashikamw/product-isltListeners" value="false"/>
 
-    <test name="is-tests-usr-mgt" preserve-order="true" parallel="false">
+    <test name="is-usr-mgt-scim1" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMTestCase"/>
         </classes>

--- a/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.2-provision-user-using-SCIM1.1/src/test/resources/testng.xml
+++ b/product-scenarios/1-user-self-registration-to-an-application/1.1-user-registration-with-web-application-itself/1.1.2-provision-user-using-SCIM1.1/src/test/resources/testng.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="Identity-Scenario-Results">
-    <parameter name="useDefauhttps://github.com/sashikamw/product-isltListeners" value="false"/>
+    <parameter name="useDefaultListeners" value="false"/>
 
     <test name="is-usr-mgt-scim1" preserve-order="true" parallel="false">
         <classes>


### PR DESCRIPTION
## Purpose
> Purpose of this PR is to add SCIM2 scenario tests

## Approach
> The following test scenarios were added 
1. Provision a user with the malformed request using SCIM2 API
2. Provision user with validation failure request using SCIM2 API
3. Provision an already existing user using SCIM2 API
4. Provision a user without authorization headers using SCIM2 API
5. Provision a user without content type header using SCIM2 API
6. Provision a user with all possible attributes using SCIM2 API

## Test environment
> This is tested locally in the following environment.
- JDK - 1.8
- OS - Ubuntu
- Identity Server 5.8.0 M6
