### PR TITLE
test case for validating incorrect content type

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/ProvisionUserWithAllAttributesTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/ProvisionUserWithAllAttributesTestCase.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+
+public class ProvisionUserWithAllAttributesTestCase extends ScenarioTestBase {
+
+    HttpResponse response;
+    private CloseableHttpClient client;
+    private String HOMEEMAIL = "scimhome@test.com";
+    private String PRIMARYSTATE = "true";
+    private String userNameResponse;
+    private String userId;
+    private String WORKEMAIL = "scimwrk@test.com";
+
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+    }
+
+    @Test(description = "1.1.1.1.7")
+    public void testSCIMCreateUser() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.FAMILY_NAME_ATTRIBUTE, SCIMConstants.FAMILY_NAME_CLAIM_VALUE);
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+        JSONObject emailWork = new JSONObject();
+        emailWork.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_WORK_ATTRIBUTE);
+        emailWork.put(SCIMConstants.VALUE_PARAM, WORKEMAIL);
+        JSONObject emailHome = new JSONObject();
+        emailHome.put(SCIMConstants.PRIMARY_PARAM, PRIMARYSTATE);
+        emailHome.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_HOME_ATTRIBUTE);
+        emailHome.put(SCIMConstants.VALUE_PARAM, HOMEEMAIL);
+        JSONArray emails = new JSONArray();
+        emails.add(emailWork);
+        emails.add(emailHome);
+        rootObject.put(SCIMConstants.EMAILS_ATTRIBUTE, emails);
+
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIM1_USERS_ENDPOINT, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created successfully");
+
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME, "username not found");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup() throws Exception {
+
+        JSONObject responseObj = getJSONFromResponse(this.response);
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIM1_USERS_ENDPOINT, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK, "User has not been deleted successfully");
+    }
+
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/ProvisionUserWithAllAttributesTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/ProvisionUserWithAllAttributesTestCase.java
@@ -50,6 +50,7 @@ public class ProvisionUserWithAllAttributesTestCase extends ScenarioTestBase {
 
         setKeyStoreProperties();
         client = HttpClients.createDefault();
+
         super.init();
     }
 

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -53,10 +53,10 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         client = HttpClients.createDefault();
         super.init();
 
-        scimUsersEndpoint = backendURL + SCIMConstants.SCIM_ENDPOINT + SEPERATOR + Constants.SCIM_ENDPOINT_USER;
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
     }
 
-    @Test(description = "1.1.1.1.10")
+    @Test(description = "1.1.2.1.1.10")
     public void testWrongContentType() throws Exception {
 
         JSONObject rootObject = new JSONObject();

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.sendPostRequestWithJSON;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioTestBase {
+
+
+
+    private CloseableHttpClient client;
+    private String responseMessage;
+    private String scimUsersEndpoint;
+    private final String SEPERATOR = "/";
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+
+        scimUsersEndpoint = backendURL + SCIMConstants.SCIM_ENDPOINT + SEPERATOR + Constants.SCIM_ENDPOINT_USER;
+    }
+
+    @Test(description = "1.1.1.1.10")
+    public void testWrongContentType() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
+                new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
+
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
+        JSONObject responseObj = getJSONFromResponse(response);
+        responseMessage = responseObj.toJSONString();
+
+        assertEquals(responseMessage,"{\"Errors\":[{\"code\":\"406\",\"description\":\"Requested format is not supported.\"}]}");
+    }
+
+    private Header getBasicAuthzHeader() {
+
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    private Header getContentTypeApplicationXMLHeader() {
+
+        return new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/xml");
+    }
+}


### PR DESCRIPTION
this test case validates if the content type is different to application/json. We are passing application/xml and then assert for error code 406 on the response 

tested environment
1.ubuntu 18.04
2.java 1.8.0_161