### PR TITLE
The SCIM2 test case validates for availability of authorization header

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutAuthHeaderTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutAuthHeaderTestCase.java
@@ -20,6 +20,7 @@ package org.wso2.identity.scenarios.test.scim2;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -29,12 +30,15 @@ import org.json.simple.JSONObject;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.scenarios.commons.ScenarioTestBase;
-
+import org.wso2.identity.scenarios.commons.util.Constants;
 import static org.testng.Assert.assertEquals;
 
 public class ProvisionUserWithoutAuthHeaderTestCase extends ScenarioTestBase {
 
     private CloseableHttpClient client;
+    private static String SEPERATOR ="/";
+
+    HttpResponse response;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -43,10 +47,10 @@ public class ProvisionUserWithoutAuthHeaderTestCase extends ScenarioTestBase {
         client = HttpClients.createDefault();
     }
 
-    @Test(description = "1.1.1.1.5")
+    @Test(description = "1.1.2.1.2.5")
     public void testSCIMUserWithoutAuthHeader() throws Exception {
 
-        String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
+        String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
         HttpPost request = new HttpPost(scimEndpoint);
         request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
 
@@ -62,9 +66,8 @@ public class ProvisionUserWithoutAuthHeaderTestCase extends ScenarioTestBase {
         StringEntity entity = new StringEntity(rootObject.toString());
         request.setEntity(entity);
 
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 401,
+        response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_UNAUTHORIZED,
                 "User creation should fail without auth header hence server should have returned an unauthorized message");
     }
-
 }


### PR DESCRIPTION
Purpose
This test case validates that the user provisioning scenario for scim 2 endpoint needs to have the authorization header passed. The test case assets for SC_UNAUTHORIZED 401 response code

Approach
1.This test case sends a request for provisioning a user without the authorization header

Tested environments
1. ubuntu 18.04
2.java version "1.8.0_161"
3.Identity Server fresh pack with embedded ldap