### PR TITLE
The SCIM2.0 test cases cover validation in the use of proper content type

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutContentHeaderTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutContentHeaderTestCase.java
@@ -70,7 +70,7 @@ public class ProvisionUserWithoutContentHeaderTestCase extends ScenarioTestBase 
 
         HttpResponse response = client.execute(request);
         assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE,
-                "User creation should failed without the Content Type header");
+                "The expected response code 406 has not been received");
 
         EntityUtils.consume(response.getEntity());
         schemasArray = (JSONArray) (rootObject).get("schemas");

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutContentHeaderTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutContentHeaderTestCase.java
@@ -20,6 +20,7 @@ package org.wso2.identity.scenarios.test.scim2;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -27,10 +28,10 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -38,6 +39,8 @@ import static org.testng.Assert.assertNotNull;
 public class ProvisionUserWithoutContentHeaderTestCase extends ScenarioTestBase {
 
     private CloseableHttpClient client;
+    private static String SEPERATOR ="/";
+    JSONArray schemasArray;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -49,7 +52,7 @@ public class ProvisionUserWithoutContentHeaderTestCase extends ScenarioTestBase 
     @Test(description = "1.1.1.1.6")
     public void testSCIMUserWithoutContentHeader() throws Exception {
 
-        String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
+        String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
         HttpPost request = new HttpPost(scimEndpoint);
         request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
 
@@ -66,14 +69,12 @@ public class ProvisionUserWithoutContentHeaderTestCase extends ScenarioTestBase 
         request.setEntity(entity);
 
         HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 406,
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE,
                 "User creation should failed without the Content Type header");
 
-        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
         EntityUtils.consume(response.getEntity());
-        JSONArray schemasArray = (JSONArray) ((JSONObject) responseObj).get("schemas");
+        schemasArray = (JSONArray) (rootObject).get("schemas");
         assertNotNull(schemasArray);
-        assertEquals(schemasArray.get(0).toString(), SCIMConstants.ERROR_SCHEMA);
     }
 
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutContentHeaderTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithoutContentHeaderTestCase.java
@@ -49,7 +49,7 @@ public class ProvisionUserWithoutContentHeaderTestCase extends ScenarioTestBase 
         client = HttpClients.createDefault();
     }
 
-    @Test(description = "1.1.1.1.6")
+    @Test(description = "1.1.2.1.2.6")
     public void testSCIMUserWithoutContentHeader() throws Exception {
 
         String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -74,9 +74,9 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
 
         assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
 
-        schemasArray = (JSONArray) (rootObject).get("schemas");
-        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable");
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The Content-Type is not applicable for user provisioning");
 
+        schemasArray = (JSONArray) (rootObject).get("schemas");
         assertNotNull(schemasArray);
     }
 

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -72,9 +72,9 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
                 new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
 
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected response code 406 has not been received");
 
-        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The Content-Type is not applicable for user provisioning");
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The expected Content-Type has been received");
 
         schemasArray = (JSONArray) (rootObject).get("schemas");
         assertNotNull(schemasArray);

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.sendPostRequestWithJSON;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String scimUsersEndpoint;
+    private final String SEPERATOR = "/";
+    private JSONArray schemasArray;
+
+    HttpResponse response;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+    }
+
+    @Test(description = "1.1.2.1.2.10")
+    public void testWrongContentType() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE,SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
+                new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
+
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
+
+        JSONObject responseObj = getJSONFromResponse(response);
+        schemasArray = (JSONArray) (rootObject).get("schemas");
+        assertNotNull(schemasArray);
+    }
+
+    private Header getBasicAuthzHeader() {
+
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    private Header getContentTypeApplicationXMLHeader() {
+
+        return new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/xml");
+    }
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -44,6 +44,7 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
     private String scimUsersEndpoint;
     private final String SEPERATOR = "/";
     private JSONArray schemasArray;
+    private final String CONTENT_TYPE ="application/xml";
 
     HttpResponse response;
 
@@ -73,8 +74,9 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
 
         assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
 
-        JSONObject responseObj = getJSONFromResponse(response);
         schemasArray = (JSONArray) (rootObject).get("schemas");
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable");
+
         assertNotNull(schemasArray);
     }
 
@@ -85,6 +87,6 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
 
     private Header getContentTypeApplicationXMLHeader() {
 
-        return new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/xml");
+        return new BasicHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE );
     }
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
@@ -5,13 +5,7 @@
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Purpose
the test cases validate if the system will provide the required response codes if we skip sending the content type or pass a wrong content type

Approach
1.This test case sends a wrong content type when provisioning a user

Tested environment 
1.ubuntu 18.04
2.java version "1.8.0_161"
