### PR TITLE
The SCIM1.1 test case validates for incorrect content types

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -72,11 +72,11 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
                 new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
 
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected status code has not been received");
         JSONObject responseObj = getJSONFromResponse(response);
         responseMessage = responseObj.toJSONString();
 
-        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The Content-Type is not applicable for user provisioning");
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The expected Content-Type has been received");
     }
 
     private Header getBasicAuthzHeader() {

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.sendPostRequestWithJSON;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioTestBase {
+
+
+
+    private CloseableHttpClient client;
+    private String responseMessage;
+    private String scimUsersEndpoint;
+    private final String SEPERATOR = "/";
+    private final String CONTENT_TYPE = "application/xml";
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+    }
+
+    @Test(description = "1.1.2.1.1.10")
+    public void testWrongContentType() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
+                new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
+
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "User has not been created successfully");
+        JSONObject responseObj = getJSONFromResponse(response);
+        responseMessage = responseObj.toJSONString();
+
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable");
+    }
+
+    private Header getBasicAuthzHeader() {
+
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    private Header getContentTypeApplicationXMLHeader() {
+
+        return new BasicHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
+    }
+}
+

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -72,7 +72,7 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
                 new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
 
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected status code has not been received");
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected status code 406  has not been received");
         JSONObject responseObj = getJSONFromResponse(response);
         responseMessage = responseObj.toJSONString();
 
@@ -89,4 +89,3 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         return new BasicHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
     }
 }
-

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -76,7 +76,7 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         JSONObject responseObj = getJSONFromResponse(response);
         responseMessage = responseObj.toJSONString();
 
-        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable");
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The Content-Type is not applicable for user provisioning");
     }
 
     private Header getBasicAuthzHeader() {

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.1-provision-user-using-SCIM1.1/src/test/resources/testng.xml
@@ -6,6 +6,16 @@
     <test name="is-usr-mgt-scim1" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.ProvisionUserWithAllAttributesTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.ProvisionUserWithMalformedRequestTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.SCIM1ProvisionUserWithValidationFailuresTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.ProvisionExistingUserTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.ProvisionUserWithAllAttributesTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.ProvisionUserWithoutAuthHeaderTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.ProvisionUserWithoutContentHeaderTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.AnonymousProvisioningTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
+            <!--class name="org.wso2.identity.scenarios.test.scim.UserProvisionWithInsufficientPrivilegesSCIMTestCase"/-->
         </classes>
     </test>
 </suite>

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
@@ -4,14 +4,8 @@
     <parameter name="useDefaultListeners" value="false"/>
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
-        <classes>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
+    <classes>
+            <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Purpose
this test case validates that the content type should be application/json if incorrect is asserted for a 406

Tested environment 
1.ubuntu 18.04
2.java version "1.8.0_161"
3.Identity Server fresh pack with embedded ldap