### PR TITLE
Provision with all attributes scim2 test case

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithAllAttributesTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionUserWithAllAttributesTestCase.java
@@ -1,67 +1,67 @@
 /*
-*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.identity.scenarios.test.scim2;
 
-import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
+import org.apache.http.HttpStatus;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.scenarios.commons.ScenarioTestBase;
 
+import org.wso2.identity.scenarios.commons.util.Constants;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+
 
 public class ProvisionUserWithAllAttributesTestCase extends ScenarioTestBase {
 
-    private String userId;
     private CloseableHttpClient client;
-    private String WORKEMAIL = "scimwrk@test.com";
-    private String HOMEEMAIL = "scimhome@test.com";
+    private String userNameResponse;
+    private String userId;
+
+    private String HOMEEMAIL = "test@home.com";
     private String PRIMARYSTATE = "true";
+    private String SEPERATOR = "/";
+    private String WORKEMAIL = "test@work.com";
+
+
+    HttpResponse response;
+
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
 
         setKeyStoreProperties();
         client = HttpClients.createDefault();
+        super.init();
     }
 
-    @Test(description = "1.1.1.1.7")
+    @Test(description = "1.1.2.1.2.7")
     public void testSCIM2CreateUserWithAllAttributes() throws Exception {
 
-        String scimEndpoint = getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT;
-        HttpPost request = new HttpPost(scimEndpoint);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        JSONObject rootObject = new JSONObject();
+        JSONObject  rootObject = new JSONObject();
         JSONArray schemas = new JSONArray();
         rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
         JSONObject names = new JSONObject();
@@ -70,70 +70,36 @@ public class ProvisionUserWithAllAttributesTestCase extends ScenarioTestBase {
         rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
         rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
         rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
         JSONObject emailWork = new JSONObject();
         emailWork.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_WORK_ATTRIBUTE);
         emailWork.put(SCIMConstants.VALUE_PARAM, WORKEMAIL);
+
         JSONObject emailHome = new JSONObject();
         emailHome.put(SCIMConstants.PRIMARY_PARAM, PRIMARYSTATE);
         emailHome.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_HOME_ATTRIBUTE);
         emailHome.put(SCIMConstants.VALUE_PARAM, HOMEEMAIL);
+
         JSONArray emails = new JSONArray();
         emails.add(emailWork);
         emails.add(emailHome);
         rootObject.put(SCIMConstants.EMAILS_ATTRIBUTE, emails);
 
-        StringEntity entity = new StringEntity(rootObject.toString());
-        request.setEntity(entity);
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created successfully");
 
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 201, "User has not been created successfully");
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME, "username not found");
+   }
 
-        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
-        EntityUtils.consume(response.getEntity());
+    @Test(dependsOnMethods = "testSCIM2CreateUserWithAllAttributes")
+    private void testDeleteUser() throws Exception {
 
-        String usernameFromResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
-        assertEquals(usernameFromResponse, SCIMConstants.USERNAME);
-
-        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
+        JSONObject responseObj = getJSONFromResponse(this.response);
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
         assertNotNull(userId);
 
-        testGetSCIMUser();
-        testDeleteSCIMUser();
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NO_CONTENT, "User has not been deleted successfully");
     }
-
-    private void testGetSCIMUser() throws Exception {
-
-        String userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpGet request = new HttpGet(userResourcePath);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-
-        HttpResponse response = client.execute(request);
-        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
-        assertTrue(responseObj.toString().contains(SCIMConstants.USERNAME));
-        assertTrue(responseObj.toString().contains(WORKEMAIL));
-    }
-
-    private void testDeleteSCIMUser() throws Exception {
-
-        String userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpDelete request = new HttpDelete(userResourcePath);
-        request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 204, "User has not been retrieved successfully");
-        EntityUtils.consume(response.getEntity());
-        userResourcePath =
-                getDeploymentProperties().getProperty(IS_HTTPS_URL) + SCIMConstants.SCIM2_USERS_ENDPOINT + "/" + userId;
-        HttpGet getRequest = new HttpGet(userResourcePath);
-        getRequest.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
-        getRequest.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
-
-        response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 404, "User has not been deleted successfully");
-        EntityUtils.consume(response.getEntity());
-    }
-
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
@@ -5,12 +5,6 @@
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
         </classes>
     </test>


### PR DESCRIPTION
Purpose
This test case will provision a user with all attributes and assert for a 201 response code

Approach
This test case sends all attributes that can provision a user but not the full request


Tested environments
1.ubuntu 18.04
2.java version "1.8.0_161"
3.Identity Server fresh pack with embedded ldap and Jdbc Userstore