### PR TITLE
This test case provisions a user using the scim2/Me endpoint withouth auth headers

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/AnonymousProvisioningWithoutHeaderTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/java/org/wso2/identity/scenarios/test/scim2/AnonymousProvisioningWithoutHeaderTestCase.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.entity.StringEntity;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.json.simple.JSONArray;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+
+public class AnonymousProvisioningWithoutHeaderTestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String scimUsersEndpoint;
+    private String userNameResponse;
+    private String userId;
+    private String SEPERATOR = "/";
+    private String WORKEMAIL = "scimwrk@test.com";
+    private String HOMEEMAIL = "scimhome@test.com";
+    private String PRIMARYSTATE = "true";
+
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+    }
+
+    @Test(description = "1.1.2.1.2.16")
+    private  void selfRegister() throws  Exception {
+
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ANONYMOUS_USER;
+
+        HttpPost request = new HttpPost(scimUsersEndpoint);
+        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.FAMILY_NAME_ATTRIBUTE, SCIMConstants.FAMILY_NAME_CLAIM_VALUE);
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        JSONObject emailWork = new JSONObject();
+        emailWork.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_WORK_ATTRIBUTE);
+        emailWork.put(SCIMConstants.VALUE_PARAM, WORKEMAIL);
+
+        JSONObject emailHome = new JSONObject();
+        emailHome.put(SCIMConstants.PRIMARY_PARAM, PRIMARYSTATE);
+        emailHome.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_HOME_ATTRIBUTE);
+        emailHome.put(SCIMConstants.VALUE_PARAM, HOMEEMAIL);
+
+        JSONArray emails = new JSONArray();
+        emails.add(emailWork);
+        emails.add(emailHome);
+        rootObject.put(SCIMConstants.EMAILS_ATTRIBUTE, emails);
+
+        StringEntity entity = new StringEntity(rootObject.toString());
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created successfully");
+
+        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+
+        userNameResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME);
+
+        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
+        assertNotNull(userId);
+    }
+
+    @Test(dependsOnMethods = "selfRegister")
+    private void cleanUp() throws Exception {
+
+        String scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER + SEPERATOR + userId;
+
+        HttpDelete delete = new HttpDelete(scimUsersEndpoint);
+        delete.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
+        delete.addHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD));
+
+        HttpResponse response = client.execute(delete);
+        assertEquals(response.getStatusLine().getStatusCode(), org.apache.commons.httpclient.HttpStatus.SC_NO_CONTENT, "User has not been deleted successfully");
+
+        EntityUtils.consume(response.getEntity());
+    }
+
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
@@ -5,17 +5,6 @@
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2FullRequestTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
-
             <!--class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningWithoutHeaderTestCase" /-->
         </classes>
     </test>

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration-to-an-application/1.1.1-user-registration-with-web-application-itself/1.1.1.2-provision-user-using-SCIM2/src/test/resources/testng.xml
@@ -6,12 +6,17 @@
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2FullRequestTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
+
+            <!--class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningWithoutHeaderTestCase" /-->
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Purpose
This test case provisions a user using the scim2/Me endpoint 

Approach
1.The test case requires that below properties are set to false in the identity.xml

```
 <Resource context="(.*)/scim2/Me" secured="false" http-method="DELETE">
            <Permissions>/permission/admin/manage/identity/usermgt/delete</Permissions>
        </Resource>

        <Resource context="(.*)/scim2/Me" secured="false" http-method="POST">
            <Permissions>/permission/admin/manage/identity/usermgt/create</Permissions>
        </Resource>
```
3.Tested Environment
1.Ubuntu 18.04
2.java version "1.8.0_161"
3.Identity Server 5.7.0 with jdbc user store