### PR TITLE
Test case that submits an email id as the user name for jdbc user store

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
@@ -76,7 +76,6 @@ public class ProvisionEmailUserSCIM2TestCase extends ScenarioTestBase {
         JSONObject responseObj = getJSONFromResponse(this.response);
         userId = (responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
         assertNotNull(userId);
-
     }
 
     @Test(dependsOnMethods = "testSCIM2CreateUser")

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.scenarios.commons.ScenarioTestBase;
@@ -80,7 +81,7 @@ public class ProvisionEmailUserSCIM2TestCase extends ScenarioTestBase {
         assertNotNull(userId);
     }
 
-    @Test(dependsOnMethods = "testSCIM2CreateUser")
+    @AfterClass(alwaysRun = true)
     private void cleanUp() throws Exception {
 
         response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT,

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
@@ -67,8 +67,10 @@ public class ProvisionEmailUserSCIM2TestCase extends ScenarioTestBase {
         rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, EMAIL_ID);
         rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
 
-        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "Username format is not valid ");
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM2_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "Username format is not " +
+                "valid ");
 
         userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
         assertEquals(userNameResponse, EMAIL_ID, "username not found");
@@ -81,8 +83,10 @@ public class ProvisionEmailUserSCIM2TestCase extends ScenarioTestBase {
     @Test(dependsOnMethods = "testSCIM2CreateUser")
     private void cleanUp() throws Exception {
 
-        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NO_CONTENT, "User has not been deleted successfully");
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NO_CONTENT, "User has not been " +
+                "deleted successfully");
     }
 
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionEmailUserSCIM2TestCase.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+
+import org.wso2.identity.scenarios.commons.util.Constants;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+
+
+
+public class ProvisionEmailUserSCIM2TestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String userNameResponse;
+    private final String EMAIL_ID="scim2user@wso2.com";
+    private String userId;
+
+    HttpResponse response;
+
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+    }
+
+    @Test(description = "1.1.2.1.2.14")
+    public void testSCIM2CreateUser() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, EMAIL_ID);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "Username format is not valid ");
+
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, EMAIL_ID, "username not found");
+
+        JSONObject responseObj = getJSONFromResponse(this.response);
+        userId = (responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
+        assertNotNull(userId);
+
+    }
+
+    @Test(dependsOnMethods = "testSCIM2CreateUser")
+    private void cleanUp() throws Exception {
+
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NO_CONTENT, "User has not been deleted successfully");
+    }
+
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
@@ -48,4 +48,5 @@ public class SCIMConstants {
     public static final String VALUE = "value";
     public static final String ROLE_NAME = "TestRole";
     public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+    public static final String ENTERPRISE_SCHEMA = "urn:scim:schemas:extension:enterprise:1.0";
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
@@ -5,13 +5,7 @@
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
-            <!--<class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>-->
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutAuthHeaderTestCase"/>
-            <!--<class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>-->
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
         </classes>
     </test>
 </suite>

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/util/Constants.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/util/Constants.java
@@ -24,7 +24,6 @@ public class Constants {
     private Constants() {
 
     }
-
     public static final String APPROVE_ONCE = "approve";
     public static final String APPROVE_ALWAYS = "approveAlways";
     public static final String BASIC = "Basic";

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/util/Constants.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/util/Constants.java
@@ -72,7 +72,7 @@ public class Constants {
         public static final String SCIM2_ENDPOINT = "scim2";
         public static final String SCIM_ENDPOINT_BULK = "Bulk";
         public static final String SCIM_ENDPOINT_USER = "Users";
-
+        public static final String SCIM_ANONYMOUS_USER = "Me";
     }
 
 }


### PR DESCRIPTION
Purpose
This test case submits a user as an email format when jdbc user store is used with default regex

Approach
This test case can be run when jdbc user store is configured with the default regex. In this situation the user name will get creted as ex: user@mail.com as the below pattern allows.

^[\S]{3,30}$
^[\S]{3,30}$

Tested environments
1.ubuntu 18.04
2.java version "1.8.0_161"
3.Identity Server with JDBC Userstore and mysql database