### PR TITLE
The test case validates for different content type in scim 1.1 api

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
@@ -20,14 +20,30 @@ package org.wso2.identity.scenarios.test.scim;
 
 public class SCIMConstants {
 
-    static final String SCIM_ENDPOINT = "/wso2/scim";
-    static final String SCHEMAS_ATTRIBUTE = "schemas";
-    static final String GIVEN_NAME_ATTRIBUTE = "givenName";
-    static final String NAME_ATTRIBUTE = "name";
-    static final String USER_NAME_ATTRIBUTE = "userName";
-    static final String PASSWORD_ATTRIBUTE = "password";
-    static final String ID_ATTRIBUTE = "id";
-    static final String GIVEN_NAME_CLAIM_VALUE = "user1";
-    static final String USERNAME = "scim1user";
-    static final String PASSWORD = "scim1pwd";
+    public static final String SCIM_ENDPOINT = "/wso2/scim";
+    public static final String SCHEMAS_ATTRIBUTE = "schemas";
+    public static final String GIVEN_NAME_ATTRIBUTE = "givenName";
+    public static final String NAME_ATTRIBUTE = "name";
+    public static final String USER_NAME_ATTRIBUTE = "userName";
+    public static final String PASSWORD_ATTRIBUTE = "password";
+    public static final String ID_ATTRIBUTE = "id";
+    public static final String GIVEN_NAME_CLAIM_VALUE = "user1";
+    public static final String USERNAME = "scim1user";
+    public static final String PASSWORD = "scim1pwd";
+    public static final String SCIM2USER = "scim2user";
+    public static final String SCIM2PASSWORD = "scim2pwd";
+    public static final String DISPLAY_NAME = "displayName";
+    public static final String DISPLAY = "display";
+    public static final String MEMBERS = "members";
+    public static final String VALUE = "value";
+    public static final String ROLE_NAME = "TestRole";
+    public static final String FAMILY_NAME_ATTRIBUTE = "familyName";
+    public static final String FAMILY_NAME_CLAIM_VALUE = "scim2";
+    public static final String TYPE_PARAM = "type";
+    public static final String EMAIL_TYPE_WORK_ATTRIBUTE = "work";
+    public static final String EMAIL_TYPE_HOME_ATTRIBUTE = "home";
+    public static final String VALUE_PARAM = "value";
+    public static final String PRIMARY_PARAM = "primary";
+    public static final String EMAILS_ATTRIBUTE = "emails";
+    public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
@@ -20,7 +20,7 @@ package org.wso2.identity.scenarios.test.scim;
 
 public class SCIMConstants {
 
-    	static final String SCIM_ENDPOINT = "/wso2/scim";
+    static final String SCIM_ENDPOINT = "/wso2/scim";
     static final String SCHEMAS_ATTRIBUTE = "schemas";
     static final String GIVEN_NAME_ATTRIBUTE = "givenName";
     static final String NAME_ATTRIBUTE = "name";

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
@@ -20,7 +20,7 @@ package org.wso2.identity.scenarios.test.scim;
 
 public class SCIMConstants {
 
-    static final String SCIM_ENDPOINT = "/wso2/scim";
+    	static final String SCIM_ENDPOINT = "/wso2/scim";
     static final String SCHEMAS_ATTRIBUTE = "schemas";
     static final String GIVEN_NAME_ATTRIBUTE = "givenName";
     static final String NAME_ATTRIBUTE = "name";

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.sendPostRequestWithJSON;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioTestBase {
+
+
+
+    private CloseableHttpClient client;
+    private String responseMessage;
+    private String scimUsersEndpoint;
+    private final String SEPERATOR = "/";
+    private final String CONTENT_TYPE = "application/xml";
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+    }
+
+    @Test(description = "1.1.2.1.1.10")
+    public void testWrongContentType() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
+                new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
+
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected status code 406  has not been received");
+        JSONObject responseObj = getJSONFromResponse(response);
+        responseMessage = responseObj.toJSONString();
+
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The expected Content-Type has been received");
+    }
+
+    private Header getBasicAuthzHeader() {
+
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD));
+    }
+
+    private Header getContentTypeApplicationXMLHeader() {
+
+        return new BasicHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
+    }
+}
+

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionSCIMWithDifferentContentTypeTestCase.java
@@ -54,7 +54,8 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         client = HttpClients.createDefault();
         super.init();
 
-        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
     }
 
     @Test(description = "1.1.2.1.1.10")
@@ -72,11 +73,13 @@ public class UserProvisionSCIMWithDifferentContentTypeTestCase extends ScenarioT
         HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
                 new Header[]{getBasicAuthzHeader(), getContentTypeApplicationXMLHeader()});
 
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected status code 406  has not been received");
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NOT_ACCEPTABLE, "The expected status" +
+                " code 406  has not been received");
         JSONObject responseObj = getJSONFromResponse(response);
         responseMessage = responseObj.toJSONString();
 
-        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The expected Content-Type has been received");
+        assertEquals(response.getStatusLine().getReasonPhrase(), "Not Acceptable","The expected " +
+                "Content-Type has been received");
     }
 
     private Header getBasicAuthzHeader() {

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/resources/testng.xml
@@ -5,7 +5,7 @@
 
     <test name="is-usr-mgt-scim1" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Purpose
This test case sends checks if wrong content types are validated

Tested environment
1.ubuntu 18.04
2.java version "1.8.0_161"
3.Identity server wum updated pack wso2is-5.7.0+1543336788716.full with jdbc user store

Automation tests
The test attempts to provision a user with application/xml as the content type for scim 1.1 api and asserts the response code