### PR TITLE
SCIM1.1 This test case attempts to provision a user using unauthorize credentials

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
@@ -20,6 +20,7 @@ package org.wso2.identity.scenarios.test.scim;
 
 public class SCIMConstants {
 
+    
     static final String SCIM_ENDPOINT = "/wso2/scim";
     static final String SCHEMAS_ATTRIBUTE = "schemas";
     static final String GIVEN_NAME_ATTRIBUTE = "givenName";

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionWithInsufficientPrivilegesSCIMTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionWithInsufficientPrivilegesSCIMTestCase.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.*;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+
+public class UserProvisionWithInsufficientPrivilegesSCIMTestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String scimUsersEndpoint;
+    private final String SEPERATOR = "/";
+    private String newUser = "newusername";
+    private String newPass = "newpassword";
+    private String userId;
+    HttpResponse response;
+    JSONObject rootObject;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+        scimUsersEndpoint = backendURL + SEPERATOR +  Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+        testSCIMCreateFirstUser();
+    }
+
+    private void testSCIMCreateFirstUser() throws Exception {
+
+        rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM1_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER , ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created successfully");
+    }
+
+    @Test(description = "1.1.2.1.1.11")
+    public void testSCIMCreateSecondUser() throws Exception {
+
+
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, newUser);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, newPass);
+
+        HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
+                new Header[]{getFaultyAuthzHeader(), getContentTypeApplicationJSONHeader()});
+
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_UNAUTHORIZED, "User is not authorized to perform provisioning");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanUp() throws Exception {
+
+        JSONObject responseObj = getJSONFromResponse(this.response);
+        userId=responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM1_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK, "User has not been deleted successfully");
+    }
+
+    private Header getFaultyAuthzHeader() {
+
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(SCIMConstants.USERNAME, SCIMConstants.PASSWORD));
+    }
+
+    private Header getContentTypeApplicationJSONHeader() {
+
+        return new BasicHeader(HttpHeaders.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON);
+    }
+}
+

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionWithInsufficientPrivilegesSCIMTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UserProvisionWithInsufficientPrivilegesSCIMTestCase.java
@@ -54,7 +54,8 @@ public class UserProvisionWithInsufficientPrivilegesSCIMTestCase extends Scenari
         setKeyStoreProperties();
         client = HttpClients.createDefault();
         super.init();
-        scimUsersEndpoint = backendURL + SEPERATOR +  Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR + Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+        scimUsersEndpoint = backendURL + SEPERATOR +  Constants.SCIMEndpoints.SCIM1_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
         testSCIMCreateFirstUser();
     }
 
@@ -69,8 +70,10 @@ public class UserProvisionWithInsufficientPrivilegesSCIMTestCase extends Scenari
         rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
         rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
 
-        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM1_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER , ADMIN_USERNAME, ADMIN_PASSWORD);
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created successfully");
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM1_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER , ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created" +
+                " successfully");
     }
 
     @Test(description = "1.1.2.1.1.11")
@@ -83,7 +86,8 @@ public class UserProvisionWithInsufficientPrivilegesSCIMTestCase extends Scenari
         HttpResponse response = sendPostRequestWithJSON(client, scimUsersEndpoint, rootObject,
                 new Header[]{getFaultyAuthzHeader(), getContentTypeApplicationJSONHeader()});
 
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_UNAUTHORIZED, "User is not authorized to perform provisioning");
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_UNAUTHORIZED, "User is not authorized" +
+                " to perform provisioning");
     }
 
     @AfterClass(alwaysRun = true)
@@ -92,13 +96,17 @@ public class UserProvisionWithInsufficientPrivilegesSCIMTestCase extends Scenari
         JSONObject responseObj = getJSONFromResponse(this.response);
         userId=responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
 
-        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM1_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK, "User has not been deleted successfully");
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM1_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER,
+                ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK, "User has not been " +
+                "deleted successfully");
     }
 
     private Header getFaultyAuthzHeader() {
 
-        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(SCIMConstants.USERNAME, SCIMConstants.PASSWORD));
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(SCIMConstants.USERNAME,
+                SCIMConstants.PASSWORD));
     }
 
     private Header getContentTypeApplicationJSONHeader() {
@@ -106,4 +114,3 @@ public class UserProvisionWithInsufficientPrivilegesSCIMTestCase extends Scenari
         return new BasicHeader(HttpHeaders.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON);
     }
 }
-

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/resources/testng.xml
@@ -5,7 +5,8 @@
 
     <test name="is-usr-mgt-scim1" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMTestCase"/>
+            <!-- please enable this test once https://github.com/wso2/product-is/issues/4022 is fixed -->
+            <!--class name="org.wso2.identity.scenarios.test.scim.UserProvisionWithInsufficientPrivilegesSCIMTestCase"/-->
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Purpose
This test case has the following scenario
1.The admin adds a user ex:(scim1user) using the scim1.1 API
2.We attempt to create a second user ex: (scim2user) using the credentials of scim1user
3.Since scim1user does not have adequate permission we assert for [401] User is not authorized to perform provisioning expected.

Known Issues
#4022

Tested environments
1.Ubuntu18.04
2.Java: 1.8.0_161
3.Identity Server fresh pack with embedded ldap