### PR TITLE
SCIM1.1 Test case for provisioning a user and updating user profile

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/SCIMConstants.java
@@ -20,14 +20,30 @@ package org.wso2.identity.scenarios.test.scim;
 
 public class SCIMConstants {
 
-    static final String SCIM_ENDPOINT = "/wso2/scim";
-    static final String SCHEMAS_ATTRIBUTE = "schemas";
-    static final String GIVEN_NAME_ATTRIBUTE = "givenName";
-    static final String NAME_ATTRIBUTE = "name";
-    static final String USER_NAME_ATTRIBUTE = "userName";
-    static final String PASSWORD_ATTRIBUTE = "password";
-    static final String ID_ATTRIBUTE = "id";
-    static final String GIVEN_NAME_CLAIM_VALUE = "user1";
-    static final String USERNAME = "scim1user";
-    static final String PASSWORD = "scim1pwd";
+    public static final String SCIM_ENDPOINT = "/wso2/scim";
+    public static final String SCHEMAS_ATTRIBUTE = "schemas";
+    public static final String GIVEN_NAME_ATTRIBUTE = "givenName";
+    public static final String NAME_ATTRIBUTE = "name";
+    public static final String USER_NAME_ATTRIBUTE = "userName";
+    public static final String PASSWORD_ATTRIBUTE = "password";
+    public static final String ID_ATTRIBUTE = "id";
+    public static final String GIVEN_NAME_CLAIM_VALUE = "user1";
+    public static final String USERNAME = "scim1user";
+    public static final String PASSWORD = "scim1pwd";
+    public static final String SCIM2USER = "scim2user";
+    public static final String SCIM2PASSWORD = "scim2pwd";
+    public static final String DISPLAY_NAME = "displayName";
+    public static final String DISPLAY = "display";
+    public static final String MEMBERS = "members";
+    public static final String VALUE = "value";
+    public static final String ROLE_NAME = "TestRole";
+    public static final String FAMILY_NAME_ATTRIBUTE = "familyName";
+    public static final String FAMILY_NAME_CLAIM_VALUE = "scim2";
+    public static final String TYPE_PARAM = "type";
+    public static final String EMAIL_TYPE_WORK_ATTRIBUTE = "work";
+    public static final String EMAIL_TYPE_HOME_ATTRIBUTE = "home";
+    public static final String VALUE_PARAM = "value";
+    public static final String PRIMARY_PARAM = "primary";
+    public static final String EMAILS_ATTRIBUTE = "emails";
+    public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
 }

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UpdateProvisionedUserSCIM1TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UpdateProvisionedUserSCIM1TestCase.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+import org.apache.http.client.methods.HttpPut;
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+
+public class UpdateProvisionedUserSCIM1TestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String userNameResponse;
+    private String userId;
+    private String updateURL;
+    private String firstName;
+    private String SEPERATOR = "/";
+    private String NEWNAME = "testuser";
+
+    JSONObject responseObj;
+
+    HttpResponse response;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+        createUser();
+    }
+
+
+    public void createUser() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject,
+                Constants.SCIMEndpoints.SCIM1_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created " +
+                "successfully");
+
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME, "username not found");
+
+        firstName = rootObject.get(SCIMConstants.NAME_ATTRIBUTE).toString();
+        assertEquals(firstName.substring(14,19),SCIMConstants.GIVEN_NAME_CLAIM_VALUE,"The given first name " +
+                "does not exist");
+    }
+
+    @Test(description = "1.1.2.1.1.15")
+    public void testUpdateUser() throws Exception {
+
+        responseObj = getJSONFromResponse(this.response);
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        updateURL = backendURL + SEPERATOR  + SCIMConstants.SCIM_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER + SEPERATOR + userId;
+
+        JSONObject updateUserObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        updateUserObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, NEWNAME);
+        updateUserObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        updateUserObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        updateUserObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        updateUserRequest(client, updateURL, updateUserObject, getCommonHeaders());
+        userNameResponse = updateUserObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME, "username not found");
+
+        firstName = updateUserObject.get(SCIMConstants.NAME_ATTRIBUTE).toString();
+        assertEquals(firstName.substring(14,22),NEWNAME,"The given first name " +
+                "does not exist");
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void cleanUp() throws Exception {
+
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM1_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK, "User has not been deleted successfully");
+    }
+
+
+    public static HttpResponse updateUserRequest(HttpClient client, String url, JSONObject jsonObject, Header[] headers) throws IOException {
+
+        HttpPut request = new HttpPut(url);
+        if (headers != null) {
+            request.setHeaders(headers);
+        }
+
+        request.setEntity(new StringEntity(jsonObject.toString()));
+        return client.execute(request);
+    }
+
+    private static Header[] getCommonHeaders() {
+
+        Header[] headers = {
+                new BasicHeader(HttpHeaders.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON),
+                new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD))
+        };
+        return headers;
+    }
+
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UpdateProvisionedUserSCIM1TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/java/org/wso2/identity/scenarios/test/scim/UpdateProvisionedUserSCIM1TestCase.java
@@ -52,6 +52,7 @@ public class UpdateProvisionedUserSCIM1TestCase extends ScenarioTestBase {
     private String firstName;
     private String SEPERATOR = "/";
     private String NEWNAME = "testuser";
+    private String NEW_LAST_NAME = "lastname";
 
     JSONObject responseObj;
 
@@ -75,6 +76,7 @@ public class UpdateProvisionedUserSCIM1TestCase extends ScenarioTestBase {
 
         JSONObject names = new JSONObject();
         names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        names.put(SCIMConstants.FAMILY_NAME_ATTRIBUTE,SCIMConstants.FAMILY_NAME_CLAIM_VALUE);
         rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
         rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
         rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
@@ -108,6 +110,7 @@ public class UpdateProvisionedUserSCIM1TestCase extends ScenarioTestBase {
 
         JSONObject names = new JSONObject();
         names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, NEWNAME);
+        names.put(SCIMConstants.FAMILY_NAME_ATTRIBUTE,NEW_LAST_NAME);
         updateUserObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
         updateUserObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
         updateUserObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.1-scim-1.1/src/test/resources/testng.xml
@@ -5,7 +5,7 @@
 
     <test name="is-usr-mgt-scim1" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.scenarios.test.scim.UserProvisionSCIMTestCase"/>
+            <class name="org.wso2.identity.scenarios.test.scim.UpdateProvisionedUserSCIM1TestCase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Purpose
This test case updates a provisioned users profile attribute "first name" and last name and assert if the first name is what we updated

Tested environment
1.ubuntu 18.04
2.java version "1.8.0_161"
3.Identity server wum updated pack wso2is-5.7.0+1543336788716.full with jdbc user store with the UsernameJavaRegEx changes to [a-zA-Z0-9._-|//]{3,30}$

Automation tests
The test attempts to update a provisioned users profile. First a user is provisioned and then the first name attribute is added with a value. Next with the updated users method we update the provisioned users profile firstName