### PR TITLE
SCIM2 Testcases

### DIFF
--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/AnonymousProvisioningWithoutHeaderTestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/AnonymousProvisioningWithoutHeaderTestCase.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.entity.StringEntity;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.json.simple.JSONArray;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+
+public class AnonymousProvisioningWithoutHeaderTestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String scimUsersEndpoint;
+    private String userNameResponse;
+    private String userId;
+    private String SEPERATOR = "/";
+    private String WORKEMAIL = "scimwrk@test.com";
+    private String HOMEEMAIL = "scimhome@test.com";
+    private String PRIMARYSTATE = "true";
+
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+    }
+
+    @Test(description = "1.1.2.1.2.16")
+    private  void selfRegister() throws  Exception {
+
+        scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ANONYMOUS_USER;
+
+        HttpPost request = new HttpPost(scimUsersEndpoint);
+        request.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.FAMILY_NAME_ATTRIBUTE, SCIMConstants.FAMILY_NAME_CLAIM_VALUE);
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        JSONObject emailWork = new JSONObject();
+        emailWork.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_WORK_ATTRIBUTE);
+        emailWork.put(SCIMConstants.VALUE_PARAM, WORKEMAIL);
+
+        JSONObject emailHome = new JSONObject();
+        emailHome.put(SCIMConstants.PRIMARY_PARAM, PRIMARYSTATE);
+        emailHome.put(SCIMConstants.TYPE_PARAM, SCIMConstants.EMAIL_TYPE_HOME_ATTRIBUTE);
+        emailHome.put(SCIMConstants.VALUE_PARAM, HOMEEMAIL);
+
+        JSONArray emails = new JSONArray();
+        emails.add(emailWork);
+        emails.add(emailHome);
+        rootObject.put(SCIMConstants.EMAILS_ATTRIBUTE, emails);
+
+        StringEntity entity = new StringEntity(rootObject.toString());
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created" +
+                " successfully");
+
+        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+
+        userNameResponse = ((JSONObject) responseObj).get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME);
+
+        userId = ((JSONObject) responseObj).get(SCIMConstants.ID_ATTRIBUTE).toString();
+        assertNotNull(userId);
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void cleanUp() throws Exception {
+
+        String scimUsersEndpoint = backendURL + SEPERATOR + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER + SEPERATOR + userId;
+
+        HttpDelete delete = new HttpDelete(scimUsersEndpoint);
+        delete.addHeader(HttpHeaders.CONTENT_TYPE, SCIMConstants.CONTENT_TYPE_APPLICATION_JSON);
+        delete.addHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD));
+
+        HttpResponse response = client.execute(delete);
+        assertEquals(response.getStatusLine().getStatusCode(), org.apache.commons.httpclient.HttpStatus.SC_NO_CONTENT,
+                "User has not been deleted successfully");
+
+        EntityUtils.consume(response.getEntity());
+    }
+
+}
+

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/FilterOutEmailUserProvisioningSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/FilterOutEmailUserProvisioningSCIM2TestCase.java
@@ -54,7 +54,7 @@ public class FilterOutEmailUserProvisioningSCIM2TestCase extends ScenarioTestBas
         super.init();
     }
 
-    @Test(description = "1.1.2.1.2.16")
+    @Test(description = "1.1.2.1.2.13")
     public void testSCIM2CreateUser() throws Exception {
 
         JSONObject rootObject = new JSONObject();

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/FilterOutEmailUserProvisioningSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/FilterOutEmailUserProvisioningSCIM2TestCase.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.apache.http.util.EntityUtils;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+
+import org.wso2.identity.scenarios.commons.util.Constants;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+import static org.testng.Assert.assertEquals;
+
+
+public class FilterOutEmailUserProvisioningSCIM2TestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String userNameResponse;
+    private final String EMAIL_ID="scim2user@wso2.com";
+    private String userId;
+
+    HttpResponse response;
+
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+    }
+
+    @Test(description = "1.1.2.1.2.16")
+    public void testSCIM2CreateUser() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, EMAIL_ID);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM2_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Username " +
+                "format is not valid ");
+
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, EMAIL_ID, "username not found");
+
+        Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+        JSONArray schemasArray = new JSONArray();
+        schemasArray.add(responseObj);
+
+        assertEquals(((JSONObject) responseObj).get("schemas"), SCIMConstants.ERROR_SCHEMA,"The expected" +
+                " ERROR_SCHEMA is not returned");
+    }
+}
+

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionTenantUserSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionTenantUserSCIM2TestCase.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.apache.http.client.methods.HttpDelete;
+
+import org.wso2.identity.scenarios.commons.util.Constants;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.sendPostRequestWithJSON;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+
+
+public class ProvisionTenantUserSCIM2TestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String userNameResponse;
+    private String userId;;
+    private static String TENANT_USER = "scim2user";
+    private static String TENANT_PASSWORD = "scim2user";
+    private String provisionURL;
+    private String SEPERATOR = "/";
+    private String USERS_ATTRIBUTE = "Users";
+
+    HttpResponse response;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+    }
+
+    @Test(description = "1.1.2.1.2.20")
+    public void testSCIM2CreateTenantUser() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, TENANT_USER);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, TENANT_PASSWORD);
+
+        provisionURL =
+                backendURL + SEPERATOR + SCIMConstants.TENANT_DOMAIN + SEPERATOR + SCIMConstants.SCIM2_USERS_ENDPOINT + SEPERATOR +
+                        USERS_ATTRIBUTE + SEPERATOR;
+        response = sendPostRequestWithJSON(client, provisionURL, rootObject, getCommonHeaders());
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created successfully");
+
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, TENANT_USER, "username not found");
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void cleanUp() throws Exception {
+
+        JSONObject responseObj = getJSONFromResponse(this.response);
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        provisionURL =
+                backendURL + SEPERATOR  +  SCIMConstants.TENANT_DOMAIN + SEPERATOR +Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR
+                        + USERS_ATTRIBUTE + SEPERATOR + userId;
+        deleteUserRequest(client,provisionURL,getCommonHeaders());
+    }
+
+    public static HttpResponse deleteUserRequest(HttpClient client, String url, Header[] headers) throws Exception {
+
+        HttpDelete request = new HttpDelete(url);
+        if (headers != null) {
+            request.setHeaders(headers);
+        }
+
+        return client.execute(request);
+    }
+
+    private static Header[] getCommonHeaders() {
+
+        Header[] headers = {
+                new BasicHeader(HttpHeaders.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON),
+                new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(SCIMConstants.TENANT_ADMIN_UN,
+                        SCIMConstants.TENANT_ADMIN_PW))
+        };
+        return headers;
+    }
+
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionedUserDeleteSelfSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionedUserDeleteSelfSCIM2TestCase.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.message.BasicHeader;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.*;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+
+public class ProvisionedUserDeleteSelfSCIM2TestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String scimUsersEndpoint;
+    private final String SEPERATOR = "/";
+    private String userId;
+    private String userEndPoint;
+
+    HttpResponse response,userResponse;
+    JSONObject rootObject,responseObj,groupObject;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+        scimUsersEndpoint = backendURL + SEPERATOR +  Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER;
+        createUser();
+    }
+
+    private void createUser() throws Exception {
+
+        rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        userResponse = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject,
+                Constants.SCIMEndpoints.SCIM2_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER , ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(userResponse.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created" +
+                " successfully");
+    }
+
+    @Test(description = "1.1.2.1.2.21")
+    public void testDeleteSelf() throws Exception {
+
+        JSONObject responseObj = getJSONFromResponse(this.userResponse);
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        userEndPoint = backendURL + SEPERATOR  + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER + SEPERATOR + userId;
+
+        response= deleteUserRequest(client,userEndPoint,getUnauthorizeHeaders());
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_FORBIDDEN, "User has not been " +
+                "deleted successfully");
+    }
+
+    
+    @AfterClass(alwaysRun = true)
+    public void cleanUp() throws Exception {
+
+        SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+    }
+
+    public static HttpResponse deleteUserRequest(HttpClient client, String url, Header[] headers) throws Exception {
+
+        HttpDelete request = new HttpDelete(url);
+        if (headers != null) {
+            request.setHeaders(headers);
+        }
+
+        return client.execute(request);
+    }
+
+    private static Header[] getUnauthorizeHeaders() {
+
+        Header[] headers = {
+                new BasicHeader(HttpHeaders.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON),
+                new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(SCIMConstants.USERNAME,
+                        SCIMConstants.PASSWORD))
+        };
+        return headers;
+    }
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionedUserDeleteSelfSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/ProvisionedUserDeleteSelfSCIM2TestCase.java
@@ -89,11 +89,11 @@ public class ProvisionedUserDeleteSelfSCIM2TestCase extends ScenarioTestBase {
                 Constants.SCIMEndpoints.SCIM_ENDPOINT_USER + SEPERATOR + userId;
 
         response= deleteUserRequest(client,userEndPoint,getUnauthorizeHeaders());
-        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_FORBIDDEN, "User has not been " +
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_FORBIDDEN, "User has been " +
                 "deleted successfully");
     }
 
-    
+
     @AfterClass(alwaysRun = true)
     public void cleanUp() throws Exception {
 

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
@@ -107,7 +107,7 @@ public class SCIMConstants {
    public static final String USER_TYPE_ACTIVE_ATTRIBUTE_VALUE = "true";
    public static final String USER_TYPE_PASSWORD_ATTRIBUTE  = "password";
 
-   public static final String GROUP_ATTRIBUTE = "groups";
+   public static final String GROUP_ATTRIBUTE = "Groups";
    public static final String GROUP_VALUE_ATTRIBUTE = "value";
    public static final String GROUP_VALUE = "e9e30dba-f08f-4109-8486-d5c6a331660a";
    public static final String GROUP_REF_ATTRIBUTE = "$ref";
@@ -151,6 +151,7 @@ public class SCIMConstants {
    public static final String TENANT_DOMAIN = "/t/engineering.com";
    public static final String TENANT_ADMIN_UN = "admin@engineering.com";
    public static final String TENANT_ADMIN_PW = "admin";
+   public static final String GROUP_ENDPOINT = "Groups";
 
    public static final String USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
    public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/SCIMConstants.java
@@ -59,7 +59,7 @@ public class SCIMConstants {
    public static final String DISPLAY = "display";
    public static final String MEMBERS = "members";
    public static final String VALUE = "value";
-   public static final String ROLE_NAME = "TestRole";
+   public static final String ROLE_NAME = "Engineering";
    public static final String ROLE_NAME_ATTRIBUTE = "roles";
    public static final String FORMATTED_NAME_ATTRIBUTE ="formatted";
    public static final String FORMATTED_NAME = "Ms. Barbara J Jensen III";
@@ -137,7 +137,6 @@ public class SCIMConstants {
    public static final String X509_CERTIFICAT_ATTRIBUTE = "x509Certificates";
    public static final String URN_ATTRIBUTE = "urn";
 
-
    public static final String META_ATTRIBUTE = "meta";
    public static final String META_CREATED_ATTRIBUTE = "created";
    public static final String META_CREATED_ATTRIBUTE_VALUE = "2010-01-23T04:56:22Z";
@@ -149,6 +148,9 @@ public class SCIMConstants {
    public static final String META_VERTSION_ATTRIBUTE_VALUE = "W\\//\"3694e05e9dff591\"";
    public static final String META_LOCATION_ATTRIBUTE = "location";
    public static final String META_LOCATION_ATTRIBUTE_VALUE = "https://example.com/v1/Users/2819c223-7f76-453a-919d-413861904646";
+   public static final String TENANT_DOMAIN = "/t/engineering.com";
+   public static final String TENANT_ADMIN_UN = "admin@engineering.com";
+   public static final String TENANT_ADMIN_PW = "admin";
 
    public static final String USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
    public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/UpdateProvisionedUserRoleSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/UpdateProvisionedUserRoleSCIM2TestCase.java
@@ -114,7 +114,7 @@ public class UpdateProvisionedUserRoleSCIM2TestCase extends ScenarioTestBase {
         assertEquals(roleNameFromResponse,SCIMConstants.ROLE_NAME,"Expected Role name does not exist");
     }
 
-    @Test(description = "1.1.2.1.2.18")
+    @Test(description = "1.1.2.1.2.19")
     public void testAddMemberToRole() throws Exception {
 
         responseObj = getJSONFromResponse(this.response);

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/UpdateProvisionedUserRoleSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/UpdateProvisionedUserRoleSCIM2TestCase.java
@@ -94,9 +94,10 @@ public class UpdateProvisionedUserRoleSCIM2TestCase extends ScenarioTestBase {
         firstName = rootObject.get(SCIMConstants.NAME_ATTRIBUTE).toString();
         assertEquals(firstName.substring(14,19),SCIMConstants.GIVEN_NAME_CLAIM_VALUE,"The given first name " +
                 "does not exist");
+        createRole();
     }
 
-    @Test
+
     public void createRole() throws Exception {
 
         groupObject = new JSONObject();
@@ -113,7 +114,7 @@ public class UpdateProvisionedUserRoleSCIM2TestCase extends ScenarioTestBase {
         assertEquals(roleNameFromResponse,SCIMConstants.ROLE_NAME,"Expected Role name does not exist");
     }
 
-    @Test(description = "1.1.2.1.2.18", dependsOnMethods = "createRole")
+    @Test(description = "1.1.2.1.2.18")
     public void testAddMemberToRole() throws Exception {
 
         responseObj = getJSONFromResponse(this.response);

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/UpdateProvisionedUserRoleSCIM2TestCase.java
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/java/org/wso2/identity/scenarios/test/scim2/UpdateProvisionedUserRoleSCIM2TestCase.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.scenarios.test.scim2;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.identity.scenarios.commons.ScenarioTestBase;
+import org.wso2.identity.scenarios.commons.util.Constants;
+import org.wso2.identity.scenarios.commons.util.SCIMProvisioningUtil;
+import org.apache.http.client.methods.HttpPut;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.getJSONFromResponse;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.constructBasicAuthzHeader;
+import static org.wso2.identity.scenarios.commons.util.IdentityScenarioUtil.sendPostRequestWithJSON;
+
+
+public class UpdateProvisionedUserRoleSCIM2TestCase extends ScenarioTestBase {
+
+    private CloseableHttpClient client;
+    private String userNameResponse;
+    private String roleNameFromResponse;
+    private String userId;
+    private String groupId;
+    private String groupURL;
+    private String firstName;
+    private String SEPERATOR = "/";
+    private String ROLE_DISPLAY_NAME_ATTRIBUTE = "displayName";
+    private String GROUP_NAME_ATTRIBUTE = "Groups";
+
+    JSONObject responseObj;
+    JSONObject groupObject;
+
+    HttpResponse response,roleResponse;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        setKeyStoreProperties();
+        client = HttpClients.createDefault();
+        super.init();
+        createUser();
+    }
+
+    public void createUser() throws Exception {
+
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemas = new JSONArray();
+        rootObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+
+        JSONObject names = new JSONObject();
+        names.put(SCIMConstants.GIVEN_NAME_ATTRIBUTE, SCIMConstants.GIVEN_NAME_CLAIM_VALUE);
+        rootObject.put(SCIMConstants.NAME_ATTRIBUTE, names);
+        rootObject.put(SCIMConstants.USER_NAME_ATTRIBUTE, SCIMConstants.USERNAME);
+        rootObject.put(SCIMConstants.PASSWORD_ATTRIBUTE, SCIMConstants.PASSWORD);
+
+        response = SCIMProvisioningUtil.provisionUserSCIM(backendURL, rootObject, Constants.SCIMEndpoints.SCIM2_ENDPOINT,
+                Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_CREATED, "User has not been created " +
+                "successfully");
+
+        userNameResponse = rootObject.get(SCIMConstants.USER_NAME_ATTRIBUTE).toString();
+        assertEquals(userNameResponse, SCIMConstants.USERNAME, "username not found");
+
+        firstName = rootObject.get(SCIMConstants.NAME_ATTRIBUTE).toString();
+        assertEquals(firstName.substring(14,19),SCIMConstants.GIVEN_NAME_CLAIM_VALUE,"The given first name " +
+                "does not exist");
+    }
+
+    @Test
+    public void createRole() throws Exception {
+
+        groupObject = new JSONObject();
+
+        JSONArray schemas = new JSONArray();
+        groupObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        groupObject.put(ROLE_DISPLAY_NAME_ATTRIBUTE, SCIMConstants.ROLE_NAME);
+
+        groupURL = backendURL + SEPERATOR  + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                GROUP_NAME_ATTRIBUTE + SEPERATOR;
+
+        roleResponse = sendPostRequestWithJSON(client,groupURL,groupObject,getCommonHeaders());
+        roleNameFromResponse = groupObject.get(ROLE_DISPLAY_NAME_ATTRIBUTE).toString();
+        assertEquals(roleNameFromResponse,SCIMConstants.ROLE_NAME,"Expected Role name does not exist");
+    }
+
+    @Test(description = "1.1.2.1.2.18", dependsOnMethods = "createRole")
+    public void testAddMemberToRole() throws Exception {
+
+        responseObj = getJSONFromResponse(this.response);
+        userId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        responseObj = getJSONFromResponse(this.roleResponse);
+        groupId = responseObj.get(SCIMConstants.ID_ATTRIBUTE).toString();
+
+        JSONArray schemas = new JSONArray();
+        groupObject.put(SCIMConstants.SCHEMAS_ATTRIBUTE, schemas);
+        groupObject.put(ROLE_DISPLAY_NAME_ATTRIBUTE, SCIMConstants.ROLE_NAME);
+
+        JSONArray members = new JSONArray();
+        for (int i = 0; i < SCIMConstants.USER_NAME_ATTRIBUTE.length(); i++) {
+            JSONObject member = new JSONObject();
+            member.put(SCIMConstants.DISPLAY, SCIMConstants.USERNAME);
+            member.put(SCIMConstants.VALUE_PARAM, userId);
+            members.add(member);
+        }
+
+        groupObject.put(SCIMConstants.MEMBERS, members);
+
+        groupURL = backendURL + SEPERATOR  + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                GROUP_NAME_ATTRIBUTE + SEPERATOR + groupId;
+
+        updateRoleRequest(client,groupURL,groupObject,getCommonHeaders());
+        roleNameFromResponse = groupObject.get(ROLE_DISPLAY_NAME_ATTRIBUTE).toString();
+        assertEquals(roleNameFromResponse,SCIMConstants.ROLE_NAME);
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void cleanUp() throws Exception {
+
+        response = SCIMProvisioningUtil.deleteUser(backendURL, userId, Constants.SCIMEndpoints.SCIM2_ENDPOINT, Constants.SCIMEndpoints.SCIM_ENDPOINT_USER, ADMIN_USERNAME, ADMIN_PASSWORD);
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_NO_CONTENT, "User has not been deleted successfully");
+
+        groupURL = backendURL + SEPERATOR  + Constants.SCIMEndpoints.SCIM2_ENDPOINT + SEPERATOR +
+                GROUP_NAME_ATTRIBUTE + SEPERATOR + groupId;
+        deleteRoleRequest(client,groupURL,getCommonHeaders());
+    }
+
+
+    public static HttpResponse updateRoleRequest(HttpClient client, String url, JSONObject jsonObject,
+                                               Header[] headers) throws Exception {
+
+        HttpPut request = new HttpPut(url);
+        if (headers != null) {
+            request.setHeaders(headers);
+        }
+
+        request.setEntity(new StringEntity(jsonObject.toString()));
+        return client.execute(request);
+    }
+
+    public static HttpResponse deleteRoleRequest(HttpClient client, String url, Header[] headers) throws Exception {
+
+        HttpDelete request = new HttpDelete(url);
+        if (headers != null) {
+            request.setHeaders(headers);
+        }
+
+        return client.execute(request);
+    }
+
+    private static Header[] getCommonHeaders() {
+
+        Header[] headers = {
+                new BasicHeader(HttpHeaders.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON),
+                new BasicHeader(HttpHeaders.AUTHORIZATION, constructBasicAuthzHeader(ADMIN_USERNAME, ADMIN_PASSWORD))
+        };
+        return headers;
+    }
+
+}

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
@@ -5,16 +5,16 @@
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
-            
+
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2FullRequestTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
-           
+
             <!--The ProvisionEmailUserSCIM2TestCase works only with jdbc user store and fails with embedded ldap due to regex -->
-	        
+
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningTestCase"/>
@@ -22,6 +22,7 @@
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UserProvisionWithInsufficientPrivilegesSCIM2TestCase"/>
+
             <!--run this test case only if         <Resource context="(.*)/scim2/Me" secured="true" http-method="POST">
             is set to false -->
 	    <!--class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningWithoutHeaderTestCase"/-->  
@@ -29,6 +30,9 @@
             to block @ sign ex:[a-zA-Z0-9._\-|//]{3,30}$ -->
             <!--class name="org.wso2.identity.scenarios.test.scim2.FilterOutEmailUserProvisioningSCIM2TestCase"/-->
             <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserRoleSCIM2TestCase"/>
+            <!--Please uncomment this test case when a tenant is created in the identity server ex:admin@engineering
+            .com-->
+            <!--class name="org.wso2.identity.scenarios.test.scim2.ProvisionTenantUserSCIM2TestCase"/-->
         </classes>
     </test>
 </suite>

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
@@ -14,7 +14,6 @@
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
 
             <!--The ProvisionEmailUserSCIM2TestCase works only with jdbc user store and fails with embedded ldap due to regex -->
-
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningTestCase"/>
@@ -25,11 +24,17 @@
 
             <!--run this test case only if         <Resource context="(.*)/scim2/Me" secured="true" http-method="POST">
             is set to false -->
-	    <!--class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningWithoutHeaderTestCase"/-->  
+	    <!--class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningWithoutHeaderTestCase"/-->
+
+
 	    <!-- Run this test case only when the default value of UsernameJavaRegEx in JDBC user store has been changed
             to block @ sign ex:[a-zA-Z0-9._\-|//]{3,30}$ -->
             <!--class name="org.wso2.identity.scenarios.test.scim2.FilterOutEmailUserProvisioningSCIM2TestCase"/-->
-            <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserRoleSCIM2TestCase"/>
+
+            <!--class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserRoleSCIM2TestCase"/-->
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionedUserDeleteSelfSCIM2TestCase"/>
+
+
             <!--Please uncomment this test case when a tenant is created in the identity server ex:admin@engineering
             .com-->
             <!--class name="org.wso2.identity.scenarios.test.scim2.ProvisionTenantUserSCIM2TestCase"/-->

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
@@ -5,20 +5,30 @@
 
     <test name="is-usr-mgt-scim2" preserve-order="true" parallel="false">
         <classes>
+            
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UserProvisionSCIMWithDifferentContentTypeTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithoutContentHeaderTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithMalformedRequestTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2FullRequestTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithAllAttributesTestCase"/>
+           
             <!--The ProvisionEmailUserSCIM2TestCase works only with jdbc user store and fails with embedded ldap due to regex -->
-	    <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
+	        
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionEmailUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningTestCase"/>
-            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2EnterpriseUserRequestTestCase" />
+            <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserSCIM2EnterpriseUserRequestTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionExistingUserTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionUserWithValidationFailuresTestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.UserProvisionWithInsufficientPrivilegesSCIM2TestCase"/>
+            <!--run this test case only if         <Resource context="(.*)/scim2/Me" secured="true" http-method="POST">
+            is set to false -->
+	    <!--class name="org.wso2.identity.scenarios.test.scim2.AnonymousProvisioningWithoutHeaderTestCase"/-->  
+	    <!-- Run this test case only when the default value of UsernameJavaRegEx in JDBC user store has been changed
+            to block @ sign ex:[a-zA-Z0-9._\-|//]{3,30}$ -->
+            <!--class name="org.wso2.identity.scenarios.test.scim2.FilterOutEmailUserProvisioningSCIM2TestCase"/-->
+            <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserRoleSCIM2TestCase"/>
         </classes>
     </test>
 </suite>

--- a/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
+++ b/product-scenarios/1-manage-users-roles/1.1-user-registration/1.1.2-user-registration-by-admin/1.1.2.1-user-registration-through-apis/1.1.2.1.2-scim-2.0/src/test/resources/testng.xml
@@ -31,7 +31,7 @@
             to block @ sign ex:[a-zA-Z0-9._\-|//]{3,30}$ -->
             <!--class name="org.wso2.identity.scenarios.test.scim2.FilterOutEmailUserProvisioningSCIM2TestCase"/-->
 
-            <!--class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserRoleSCIM2TestCase"/-->
+            <class name="org.wso2.identity.scenarios.test.scim2.UpdateProvisionedUserRoleSCIM2TestCase"/>
             <class name="org.wso2.identity.scenarios.test.scim2.ProvisionedUserDeleteSelfSCIM2TestCase"/>
 
 


### PR DESCRIPTION
Purpose
This PR contains multiple SCIM2,0 Test cases two of the test cases are to be run on a different combination.

Known Issues
N/A

Tested environments
1.Ubuntu18.04
2.Java: 1.8.0_161
3.Identity Server fresh pack with embedded ldap

Test cases
1.AnonymousProvisioningWithoutHeaderTestCase : run this test case only if    Resource context="(.*)/scim2/Me" secured="true" http-method="POST" is set to false

2.FilterOutEmailUserProvisioningSCIM2TestCase.java :  Run this test case only when the default value of UsernameJavaRegEx in JDBC user store has been changed  to block @ sign ex:[a-zA-Z0-9._\-|//]{3,30}$ . This test case asserts that the error schema is returned

3.UpdateProvisionedUserRoleSCIM2TestCase.java : This test case will create a new user and a user role and assign the new role "Engineering" to the scim2user. This test case then asserts that the new role name exist.