### PR TITLE
Add initial test class for SAML SSO with Centreal IDP.

### DIFF
--- a/product-scenarios/2-single-sign-on/2.1-sso-with-central-idp/2.1.1-sso-with-saml/README.md
+++ b/product-scenarios/2-single-sign-on/2.1-sso-with-central-idp/2.1.1-sso-with-saml/README.md
@@ -10,6 +10,11 @@ End User
 ## Sub-Scenarios
 - [2.1.1.1.1 Create Service Provider]()
 - [2.1.1.1.2 Testing SAML SSO Passive login]()
-- [2.1.1.1.3 Testing SAML SSO login]()
-- [2.1.1.1.4 Remove Service provider]()
+- [2.1.1.1.3 Remove Service provider]()
+- [2.1.1.1.4 Testing SAML SSO login]()
+- [2.1.1.1.5 Testing Claims]()
+- [2.1.1.1.6 Testing SAML SSO logout]()
+- [2.1.1.1.7 Testing SAML RelayState Decode]()
+- [2.1.1.1.8 Testing SAML SSO IDP logout]()
+
 

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/util/Constants.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/util/Constants.java
@@ -60,6 +60,7 @@ public class Constants {
     public static final String SCIM_ENDPOINT_USER = "Users";
     public static final String SAML_REQUEST_PARAM = "SAMLRequest";
     public static final String SAML_RESPONSE_PARAM = "SAMLResponse";
+    public static final String RELAY_STATE_PARAM = "RelayState";
     public static final String TOCOMMONAUTH = "tocommonauth";
     public static final String COOKIE = "Cookie";
     public static final String HEADER_SET_COOKIE = "Set-Cookie";


### PR DESCRIPTION
This PR contains initial test cases for SAML SSO with Centreal IDP.
Scenario: 2 Single sign-on across multiple applications
2.1 SSO for  web applications with the centralized Identity Provider.
2.1.1 Single sign-on for  web applications using SAML