### PR TITLE
Fix non-matching parent artifactId in SSO pom file

### DIFF
--- a/product-scenarios/2-single-sign-on/2.1-sso-with-central-idp/pom.xml
+++ b/product-scenarios/2-single-sign-on/2.1-sso-with-central-idp/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.is</groupId>
-        <artifactId>2.1-sso-for-web-app</artifactId>
+        <artifactId>single-sign-on-tests</artifactId>
         <version>5.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
== Purpose ==

This is to fix Non-resolvable parent POM for org.wso2.is:2.1.1-sso-with-central-idp which cause to fail the build.

== Environment ==

OS - Mac High Sierra
JDK - Oracle JDK 1.8.0_181