### PR TITLE
Change test-results copying directory

### DIFF
--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -91,10 +91,10 @@ mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf
 
 #=============== Copy Surefire Reports ===========================================
 
-echo "Copying surefire-reports to ${OUTPUT_DIR}"
+echo "Copying surefire-reports to ${OUTPUT_DIR}/scenarios"
 
-mkdir -p ${OUTPUT_DIR}
-find ./* -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR} \;
+mkdir -p ${OUTPUT_DIR}/scenarios
+find ./* -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR}/scenarios \;
 
 #=============== Code Coverage Report Generation ===========================================
 


### PR DESCRIPTION
Previously all the results have been copying to the ${OUTPUT_DIR}.
In order to distinguish scenario-test-results from other outputs (ex: aggregate coverage reports, etc.), a sub-directory `scenarios` is added to ${OUTPUT_DIR}.
So the scenario-test-results should be copied to `${OUTPUT_DIR}/scenarios`.