### PR TITLE
Change code coverage reports copying directory

### DIFF
--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -100,5 +100,4 @@ find ./* -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR}/scenari
 
 echo "Generating Scenario Code Coverage Reports"
 source ${HOME}/code-coverage/code-coverage.sh
-generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}
-
+generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}/scenarios


### PR DESCRIPTION
Previously all the reports have been copying to the ${OUTPUT_DIR}.
But now all the reports have been copying to a sub-directory `scenarios` in  ${OUTPUT_DIR}.
So the code-coverage reports and coverage artifacts should be copied to `${OUTPUT_DIR}/scenarios`