### PR TITLE
Fix the error in code coverage reports copying directory

### DIFF
--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -100,4 +100,4 @@ find ./* -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR}/scenari
 
 echo "Generating Scenario Code Coverage Reports"
 source ${HOME}/code-coverage/code-coverage.sh
-generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}/scenarios
+generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}


### PR DESCRIPTION
Copying scenario-test-results and code-coverage reports to the same directory leads to a unstable build. In order to distinguish scenario-test-results from other outputs (ex: aggregate coverage reports, etc.), a sub-directory `scenarios` is added to ${OUTPUT_DIR}. And all the other outputs are added to the ${OUTPUT_DIR} itself.