### PR TITLE
Removing File.separator from TomcatInitiazierTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/TomcatInitializerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/TomcatInitializerTestCase.java
@@ -75,8 +75,7 @@ public class TomcatInitializerTestCase extends ISIntegrationTest {
 
         tomcat = Utils.getTomcat(getClass());
         for (String application : APPLICATIONS) {
-            URL resourceUrl = getClass()
-                    .getResource(File.separator + "samples" + File.separator + application + ".war");
+            URL resourceUrl = getClass().getResource("/samples/" + application + ".war");
             tomcat.addWebapp(tomcat.getHost(), "/" + application, resourceUrl.getPath());
             LOG.info("Deployed tomcat application " + application);
         }


### PR DESCRIPTION
Fixing the issue [5007](https://github.com/wso2/product-is/issues/5007)

Here I have used forward slash character ("/") instead of File.separator.