### PR TITLE
Set proper content type and redirect to the proper error page upon error

### DIFF
--- a/modules/jaggery-apps/portal/gadgets/user_profile/controllers/my-profile/download-userinfo.jag
+++ b/modules/jaggery-apps/portal/gadgets/user_profile/controllers/my-profile/download-userinfo.jag
@@ -17,11 +17,13 @@ try {
     var header = {"cookie" : cookie};
     var userInfoJSON = get(url, {}, header ,"json");
     validateResponse(userInfoJSON);
+
+    response.contentType = 'application/json';
     print(userInfoJSON.data);
 
     } catch(e) {
-        print(e);
         log.error(e.message);
+        response.sendRedirect("/portal/error_pages/error.jag");
     }
 
 %>


### PR DESCRIPTION
Here, the content written to the output stream is of json type. Thus, proper content type is set.
Directly writing the error response to the output stream is avoided and upon error user is redirected to an error page
