### PR TITLE
Pack shindig-extensions in product build

### DIFF
--- a/modules/distribution/conf/shindig/web.xml
+++ b/modules/distribution/conf/shindig/web.xml
@@ -41,6 +41,7 @@
             org.apache.shindig.sample.container.SampleContainerGuiceModule:
             org.apache.shindig.extras.ShindigExtrasGuiceModule:
             org.apache.shindig.gadgets.admin.GadgetAdminModule:
+            org.apache.shindig.wso2.ext.OverridingModule:
             org.wso2.carbon.dashboard.shindig.features.WSO2ShindigFeaturesModule
         </param-value>
     </context-param>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -62,6 +62,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.org.apache.shindig</groupId>
+            <artifactId>wso2-extensions</artifactId>
+        </dependency>
         <!--
               dependency> <groupId>org.wso2.carbon</groupId>
               <artifactId>com.wso2.carbon.multitenancy.tenant.mgt</artifactId>
@@ -277,6 +281,11 @@
                                     <fileset dir="conf/shindig">
                                         <include name="web.xml" />
                                     </fileset>
+                                </copy>
+
+                                <dependencyfilesets prefix="shindigDeps."/>
+                                <copy todir="${tempdir}/shindig/WEB-INF/lib">
+                                    <fileset refid="shindigDeps.org.wso2.org.apache.shindig:wso2-extensions:jar"/>
                                 </copy>
 
                                 <zip destfile="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/shindig.war" basedir="${tempdir}/shindig" />

--- a/pom.xml
+++ b/pom.xml
@@ -1729,6 +1729,13 @@
                 <artifactId>org.wso2.carbon.logging.admin.stub</artifactId>
                 <version>${carbon.logging.admin.stub.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.wso2.org.apache.shindig</groupId>
+                <artifactId>wso2-extensions</artifactId>
+                <version>${wso2.shindig.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -2002,6 +2009,7 @@
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <carbon.healthcheck.version>1.0.3</carbon.healthcheck.version>
         <carbon.logging.admin.stub.version>4.6.60</carbon.logging.admin.stub.version>
+        <wso2.shindig.version>2.5.2-wso2v11</wso2.shindig.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
- Earlier, we packed the wso2-extensions JAR with shindig which caused some test failures. Now we only push the JAR to nexus from shindig and repack it in product-is.
- Note: Please wait for https://github.com/wso2/wso2-shindig/pull/16 to be merged and released.