### PR TITLE
Remove comment from carbon.xml at build

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -195,7 +195,7 @@
 
                                 <replace file="target/wso2carbon-core-${carbon.kernel.version}/repository/conf/carbon.xml" token="&lt;ForceLocalCache&gt;false&lt;/ForceLocalCache&gt;" value="&lt;ForceLocalCache&gt;true&lt;/ForceLocalCache&gt;" />
 
-                                <replace file="target/wso2carbon-core-${carbon.kernel.version}/repository/conf/carbon.xml" token="&lt;!--${line.separator} Uncomment the following configuration to use hardware security module for cryptographic operations.${line.separator} Provide configurations as detailed in each tag.${line.separator} --&gt;" value=" " />
+                                <replaceregexp file="target/wso2carbon-core-${carbon.kernel.version}/repository/conf/carbon.xml" match="^(\s)*&lt;\!--(\s)*Uncomment the following configuration to use hardware security module for cryptographic operations.\n(\s)*Provide configurations as detailed in each tag.\n(\s)*--&gt;" replace=" " flags="m" />
 
                                 <replaceregexp file="target/wso2carbon-core-${carbon.kernel.version}/repository/conf/carbon.xml" match="^(\s)*&lt;\!--(\s)*&lt;HSMBasedCryptoProviderConfig&gt;[\s\S]*?&lt;\/HSMBasedCryptoProviderConfig&gt;(\s)*--&gt;" replace=" " flags="m" />
 


### PR DESCRIPTION
Removes the following comment from carbon.xml at build
```
        <!--
            Uncomment the following configuration to use hardware security module for cryptographic operations.
            Provide configurations as detailed in each tag.
        -->
```