### PR TITLE
Add tests to verify the OAuth2 error redirection

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
@@ -129,8 +129,24 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
                 .replace("services/", "oauth2/authorize");
         HttpResponse response = sendPostRequestWithParameters(client, urlParameters, authorizeEndpoint);
         Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
-        Assert.assertTrue(locationHeader.getValue().contains("redirect_uri"),
-                "Error response does not contain redirect_uri");
+        Assert.assertTrue(locationHeader.getValue().startsWith(OAuth2Constant.CALLBACK_URL),
+                "Error response is not redirected to the redirect_uri given in the request");
+        EntityUtils.consume(response.getEntity());
+    }
+
+    @Test(groups = "wso2.is", description = "Send authorize user request without redirect_uri param", dependsOnMethods
+            = "testRegisterApplication")
+    public void testInvalidRedirectUri() throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
+        AutomationContext automationContext = new AutomationContext("IDENTITY", TestUserMode.SUPER_TENANT_ADMIN);
+        String authorizeEndpoint = automationContext.getContextUrls().getBackEndUrl()
+                .replace("services/", "oauth2/authorize");
+        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, authorizeEndpoint);
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertTrue(locationHeader.getValue().startsWith(OAuth2Constant.OAUTH2_DEFAULT_ERROR_URL),
+                "Error response is not redirected to default OAuth error URI");
         EntityUtils.consume(response.getEntity());
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
@@ -41,6 +41,8 @@ public final class OAuth2Constant {
     public final static String REDIRECT_LOCATIONS = "http.protocol.redirect-locations";
     public final static String ACCESS_TOKEN_ENDPOINT = "https://localhost:9853/oauth2/token";
     public final static String TOKEN_REVOKE_ENDPOINT = "https://localhost:9853/oauth2/revoke";
+    public final static String OAUTH2_DEFAULT_ERROR_URL = "https://localhost:9853/authenticationendpoint/" +
+            "oauth2_error.do";
     public final static String USER_INFO_ENDPOINT = "https://localhost:9853/oauth2/userinfo?schema=openid";
     public final static String AUTHTOKEN_VALIDATE_SERVICE = CommonConstants.DEFAULT_SERVICE_URL + "OAuth2TokenValidationService";
     public final static String COMMON_AUTH_URL = "https://localhost:9853/commonauth";


### PR DESCRIPTION
Add integration tests to validate the behavior of OAuth response redirection when an exception occurs with the default configurations.

- Tests the functionality implemented through https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1118
- Related to the issue https://github.com/wso2/product-is/issues/5277