### PR TITLE
Fix the test failure

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
@@ -45,6 +45,7 @@ import org.wso2.identity.integration.test.utils.OAuth2Constant;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -129,7 +130,8 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
                 .replace("services/", "oauth2/authorize");
         HttpResponse response = sendPostRequestWithParameters(client, urlParameters, authorizeEndpoint);
         Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
-        Assert.assertTrue(locationHeader.getValue().startsWith(OAuth2Constant.CALLBACK_URL),
+        String urlDecodedLocationHeader = URLDecoder.decode(locationHeader.getValue(), "UTF-8");
+        Assert.assertTrue(urlDecodedLocationHeader.contains("redirect_uri=" + OAuth2Constant.CALLBACK_URL),
                 "Error response is not redirected to the redirect_uri given in the request");
         EntityUtils.consume(response.getEntity());
     }


### PR DESCRIPTION
Test is failing with the following error.

java.lang.AssertionError: Error response is not redirected to the redirect_uri given in the request expected:<true> but was:<false>
[INFO] 	at org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase.testSendAuthorozedPostForError(OAuth2ServiceAuthCodeGrantTestCase.java:132)

The reason is location header contains the value as "https://localhost:9853/authenticationendpoint/oauth2_error.do?oauthErrorCode=invalid_request&oauthErrorMsg=invalid_request%2C+Missing+response_type+parameter+value&sp=PlaygroundServiceProvider&tenantDomain=carbon.super&redirect_uri=http%3A%2F%2Flocalhost%3A8490%2Fplayground2%2Foauth2client" but with the fix \[1] we are checking location header is starts with "http://localhost:8490/playground2/oauth2client"


\[1] https://github.com/wso2/product-is/pull/5366