### PR TITLE
 Improve dependency management for tests-common/extensions

### DIFF
--- a/modules/integration/tests-common/extensions/pom.xml
+++ b/modules/integration/tests-common/extensions/pom.xml
@@ -33,9 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement</artifactId>
-            <version>5.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -876,6 +876,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.entitlement</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>


### PR DESCRIPTION
$subject.

This will avoid maintaining its own entitlement dependency at the
modules/integration/tests-common/extensions/pom.xml
level.

This avoids the need for changes such as https://github.com/wso2/product-is/pull/5021.