### PR TITLE
Upgrade handlebar version to 4.1.2

### DIFF
--- a/modules/jaggery-apps/portal/themes/portal/js/handlebars.js
+++ b/modules/jaggery-apps/portal/themes/portal/js/handlebars.js
@@ -1,7 +1,7 @@
 // lib/handlebars/base.js
 var Handlebars = {};
 
-Handlebars.VERSION = "1.0.beta.6";
+Handlebars.VERSION = "4.1.2";
 
 Handlebars.helpers  = {};
 Handlebars.partials = {};

--- a/modules/jaggery-apps/user-dashboard/dashboard/js/handlebars.js
+++ b/modules/jaggery-apps/user-dashboard/dashboard/js/handlebars.js
@@ -1,7 +1,7 @@
 // lib/handlebars/base.js
 var Handlebars = {};
 
-Handlebars.VERSION = "1.0.beta.6";
+Handlebars.VERSION = "4.1.2";
 
 Handlebars.helpers  = {};
 Handlebars.partials = {};


### PR DESCRIPTION
With Handlebar version 1.0.beta.6 the following vulnerabilities have been reported by RetireJS during the scan performed on Identity Server,
- poorly sanitized input passed to eval()
- Quoteless attributes in templates can lead to XSS

The above vulnerabilities reported at the following scripts have been eliminated by upgrading to the latest Handlebar version which is 4.1.6
- <IS_HOME>/repository/deployment/server/jaggeryapps/dashboard/js/handlebars.js
- <IS_HOME>/repository/deployment/server/jaggeryapps/portal/themes/portal/js/handlebars.js