### PR TITLE
fix scenario tests to issue refresh tokens adhering to SP level configs

### DIFF
--- a/product-scenarios/4-single-sign-on/4.1-sso-for-web-app/4.1.4-sso-with-oidc/4.1.4.3-basic-profile/src/test/java/org/wso2/identity/scenarios/sso/test/oidc/OIDCSSOTestCase.java
+++ b/product-scenarios/4-single-sign-on/4.1-sso-for-web-app/4.1.4-sso-with-oidc/4.1.4.3-basic-profile/src/test/java/org/wso2/identity/scenarios/sso/test/oidc/OIDCSSOTestCase.java
@@ -217,7 +217,7 @@ public class OIDCSSOTestCase extends ScenarioTestBase {
         HttpResponse response = oAuth2CommonClient
                 .sendCodeGrantTokenRequest(authorizeCode, redirectUri1, clientId1, clientSecret1, null);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
 
         httpCommonClient.consume(response);
@@ -265,7 +265,7 @@ public class OIDCSSOTestCase extends ScenarioTestBase {
         HttpResponse response = oAuth2CommonClient
                 .sendCodeGrantTokenRequest(authorizeCode, redirectUri2, clientId2, clientSecret2, null);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
 
         httpCommonClient.consume(response);

--- a/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.1-authorization-code-grant-flow/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/code/OAuth2AuthorizationCodeGrantTest.java
+++ b/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.1-authorization-code-grant-flow/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/code/OAuth2AuthorizationCodeGrantTest.java
@@ -189,7 +189,7 @@ public class OAuth2AuthorizationCodeGrantTest extends ScenarioTestBase {
         HttpResponse response = oAuth2CommonClient
                 .sendCodeGrantTokenRequest(authorizeCode, redirectUri, clientId, clientSecret, null);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
 
         httpCommonClient.consume(response);

--- a/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.10-self-contained-access-token-as-authorization-grant/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/selfcontainedtoken/OAuth2SelfContainedTokenCodeGrantTest.java
+++ b/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.10-self-contained-access-token-as-authorization-grant/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/selfcontainedtoken/OAuth2SelfContainedTokenCodeGrantTest.java
@@ -193,7 +193,7 @@ public class OAuth2SelfContainedTokenCodeGrantTest extends ScenarioTestBase {
         HttpResponse response = oAuth2CommonClient
                 .sendCodeGrantTokenRequest(authorizeCode, redirectUri, clientId, clientSecret, null);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
         signedJWT = SignedJWT.parse(accessToken);
         assertNotNull(signedJWT, "JWT token value is null. Invalid self-contained access token.");

--- a/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.10-self-contained-access-token-as-authorization-grant/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/selfcontainedtoken/OAuth2SelfContainedTokenPasswordGrantTest.java
+++ b/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.10-self-contained-access-token-as-authorization-grant/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/selfcontainedtoken/OAuth2SelfContainedTokenPasswordGrantTest.java
@@ -133,7 +133,7 @@ public class OAuth2SelfContainedTokenPasswordGrantTest extends ScenarioTestBase 
         HttpResponse response = oAuth2CommonClient
                 .sendPasswordGrantTokenRequest(username, password, clientId, clientSecret, null);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
         signedJWT = SignedJWT.parse(accessToken);
         assertNotNull(signedJWT, "JWT token value is null. Invalid self-contained access token.");

--- a/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.2-authorization-code-grant-flow-with-pkce/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/code/pkce/OAuth2AuthorizationCodeGrantWithPKCES256Test.java
+++ b/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.2-authorization-code-grant-flow-with-pkce/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/code/pkce/OAuth2AuthorizationCodeGrantWithPKCES256Test.java
@@ -205,7 +205,7 @@ public class OAuth2AuthorizationCodeGrantWithPKCES256Test extends ScenarioTestBa
         HttpResponse response = oAuth2CommonClient
                 .sendCodeGrantTokenRequest(authorizeCode, redirectUri, clientId, clientSecret, pkceVerifier);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
 
         httpCommonClient.consume(response);

--- a/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.6-password-grant-flow/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/password/OAuth2PasswordGrantTest.java
+++ b/product-scenarios/9-access-delegation/9.1-access-delegation-with-end-user-authorization/9.1.6-password-grant-flow/src/test/java/org/wso2/identity/scenarios/access/delegation/oauth2/password/OAuth2PasswordGrantTest.java
@@ -124,7 +124,7 @@ public class OAuth2PasswordGrantTest extends ScenarioTestBase {
         HttpResponse response = oAuth2CommonClient
                 .sendPasswordGrantTokenRequest(username, password, clientId, clientSecret, null);
         JSONObject responseJSON = httpCommonClient.getJSONFromResponse(response);
-        oAuth2CommonClient.validateAccessToken(responseJSON, true);
+        oAuth2CommonClient.validateAccessToken(responseJSON, false);
         accessToken = responseJSON.get(OAuth2Constants.TokenResponseElements.ACCESS_TOKEN).toString();
 
         httpCommonClient.consume(response);


### PR DESCRIPTION
Modify scenario tests to suit with the latest wum fix [1] [2]
[1]. https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1072
[2]. https://github.com/wso2/product-is/issues/4256