### PR TITLE
Add authorization to scim2/me create test cases

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2BaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2BaseTestCase.java
@@ -1,7 +1,5 @@
 package org.wso2.identity.integration.test.scim2;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
@@ -41,13 +39,11 @@ public class SCIM2BaseTestCase extends ISIntegrationTest {
 
     private ServerConfigurationManager serverConfigurationManager;
 
-    @BeforeTest(alwaysRun = true)
     public void initTest() throws Exception {
         super.init();
         changeISConfiguration();
     }
 
-    @AfterTest(alwaysRun = true)
     public void tearDownTest() throws Exception {
         super.init();
         resetISConfiguration();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2MeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2MeTestCase.java
@@ -20,9 +20,9 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.integration.common.admin.client.UserManagementClient;
 import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
-import org.wso2.identity.integration.common.clients.UserManagementClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 
 import java.io.IOException;
@@ -120,6 +120,7 @@ public class SCIM2MeTestCase extends ISIntegrationTest {
     @Test
     public void testCreateMe() throws Exception {
         HttpPost request = new HttpPost(getPath());
+        request.addHeader(HttpHeaders.AUTHORIZATION, getAdminAuthzHeader());
         request.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         JSONObject rootObject = new JSONObject();
@@ -165,6 +166,7 @@ public class SCIM2MeTestCase extends ISIntegrationTest {
 
         userId = ((JSONObject) responseObj).get(ID_ATTRIBUTE).toString();
         assertNotNull(userId);
+        assignUserToGroup();
     }
 
     @Test(dependsOnMethods = "testCreateMe")
@@ -221,5 +223,22 @@ public class SCIM2MeTestCase extends ISIntegrationTest {
 
     private String getAdminAuthzHeader() {
         return "Basic " + Base64.encodeBase64String((adminUsername + ":" + admiPassword).getBytes()).trim();
+    }
+
+    private void assignUserToGroup() throws Exception {
+
+        AutomationContext automationContext;
+        if (tenant.equals(org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            automationContext = new AutomationContext("IDENTITY", TestUserMode.SUPER_TENANT_ADMIN);
+        } else {
+            automationContext = new AutomationContext("IDENTITY", TestUserMode.TENANT_ADMIN);
+        }
+
+        String backendUrl = automationContext.getContextUrls().getBackEndUrl();
+        String sessionCookie = new LoginLogoutClient(automationContext).login();
+        UserManagementClient userMgtClient = new UserManagementClient(backendUrl, sessionCookie);
+
+        String[] roles = {ADMIN_ROLE};
+        userMgtClient.addRemoveRolesOfUser(USERNAME, roles, null);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -170,7 +170,6 @@
     </test>
     <test name="is-tests-scim2" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>


### PR DESCRIPTION
According to the previous test implementation, there are configuration changes to make the scim2/me create endpoint unsecured.
With this PR, that test case is modified to call the endpoint with authorization header.