### PR TITLE
Rename key-mapping.json file

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -180,7 +180,7 @@
                                         <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/key-mappings.json</param>
                                         <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.identity.core.server.feature.key-mappings.json</param>
                                         <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.identity.application.authentication.framework.server.feature.key-mappings.json</param>
-                                        <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.identity.event.server.feature.key-mapping.json</param>
+                                        <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.identity.event.server.feature.key-mappings.json</param>
                                     </include>
                                     <target>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/key-mappings.json</target>
                                 </task>


### PR DESCRIPTION
**Proposed changes in this pull request**
- Rename org.wso2.carbon.identity.event.server.feature.key-mapping.json file to org.wso2.carbon.identity.event.server.feature.key-mappings.json.

Related To: https://github.com/wso2/carbon-identity-framework/pull/2325