### PR TITLE
Fix SAML RegistryMount Testcase failure against different DBS

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
@@ -129,7 +129,6 @@ public class RegistryMountTestCase extends ISIntegrationTest {
 
         ssoConfigServiceClient
                 .addServiceProvider(createSsoServiceProviderDTO());
-        serverConfigurationManager.restartGracefully();
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -192,6 +192,7 @@
     </test>
     <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
+            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
             <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase" />
@@ -201,7 +202,6 @@
             <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
             <!--<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>-->
             <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>
             <!-- TODO this test has a restart-->


### PR DESCRIPTION
Fix SAML Registry Mount Test case failure against other DB types. Restart is removed as the registry is mounted by default in .toml model from IS-5.9.0 onwards