### PR TITLE
Fix test failures for the rest auth update

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/ConsentMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/ConsentMgtTestCase.java
@@ -18,10 +18,9 @@
 
 package org.wso2.identity.integration.test.consent;
 
-import org.apache.wink.client.ClientConfig;
+import org.apache.http.HttpHeaders;
 import org.apache.wink.client.Resource;
 import org.apache.wink.client.RestClient;
-import org.apache.wink.client.handlers.BasicAuthSecurityHandler;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.testng.Assert;
@@ -32,9 +31,11 @@ import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 
 import javax.ws.rs.core.MediaType;
 
+import static org.wso2.identity.integration.test.util.Utils.getBasicAuthHeader;
+
 public class ConsentMgtTestCase extends ISIntegrationTest {
 
-    public static final String CONSNT_ENDPOINT_SUFFIX = "/api/identity/consent-mgt/v1.0/consents";
+    public static final String CONSENT_ENDPOINT_SUFFIX = "/api/identity/consent-mgt/v1.0/consents";
     private String isServerBackendUrl;
     private String consentEndpoint;
 
@@ -43,7 +44,7 @@ public class ConsentMgtTestCase extends ISIntegrationTest {
 
         super.init();
         isServerBackendUrl = isServer.getContextUrls().getWebAppURLHttps();
-        consentEndpoint = isServerBackendUrl + CONSNT_ENDPOINT_SUFFIX;
+        consentEndpoint = isServerBackendUrl + CONSENT_ENDPOINT_SUFFIX;
     }
 
     @AfterClass(alwaysRun = true)
@@ -112,53 +113,43 @@ public class ConsentMgtTestCase extends ISIntegrationTest {
 
     private JSONObject addPIICategory(String name, String description) {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(userInfo.getUserName());
-        basicAuth.setPassword(userInfo.getPassword());
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint + "/" + "pii-categories");
 
-        String addPIICatString = "{\"piiCategory\": " + "\"" + name + "\"" + ", \"description\": " + "\"" +
-                description + "\" , \"sensitive\": \"" + true + "\"}";
+        String addPIICatString =
+                "{\"piiCategory\": " + "\"" + name + "\"" + ", \"description\": " + "\"" + description + "\" , " +
+                        "\"sensitive\": \"" + true + "\"}";
 
-        String response = piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addPIICatString);
+        String response = piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(userInfo)).
+                post(String.class,
+                addPIICatString);
 
         return (JSONObject) JSONValue.parse(response);
     }
 
     private JSONObject addPurposeCategory(String name, String description) {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(userInfo.getUserName());
-        basicAuth.setPassword(userInfo.getPassword());
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint + "/" + "purpose-categories");
 
         String addPurposeCatString = "{\"purposeCategory\": " + "\"" + name + "\"" + ", \"description\": " + "\"" +
                 description + "\"}";
 
-        String response = piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addPurposeCatString);
+        String response = piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(userInfo)).
+                post(String.class, addPurposeCatString);
 
         return (JSONObject) JSONValue.parse(response);
     }
 
     private JSONObject addPurpose(String name, String description, String group, String groupType) {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(userInfo.getUserName());
-        basicAuth.setPassword(userInfo.getPassword());
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint + "/" + "purposes");
 
         String addPurposeString = "{" +
@@ -174,8 +165,11 @@ public class ConsentMgtTestCase extends ISIntegrationTest {
                                   "  ]" +
                                   "}";
 
-        String response = piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addPurposeString);
+        String response = piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(userInfo)).
+                post(String.class, addPurposeString);
 
         return (JSONObject) JSONValue.parse(response);
     }
@@ -184,13 +178,7 @@ public class ConsentMgtTestCase extends ISIntegrationTest {
             serviceDescription, String consentType, String collectionMethod, String jurisdiction, String language,
                                   String policyURL) {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(userInfo.getUserName());
-        basicAuth.setPassword(userInfo.getPassword());
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint);
 
         String addReceiptString = "{" +
@@ -226,8 +214,11 @@ public class ConsentMgtTestCase extends ISIntegrationTest {
                 "  \"policyURL\": \"" + policyURL + "\"" +
                 "}";
 
-        String response = piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addReceiptString);
+        String response = piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(userInfo)).
+                post(String.class, addReceiptString);
 
         return (JSONObject) JSONValue.parse(response);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/SelfSignUpConsentTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/SelfSignUpConsentTest.java
@@ -21,14 +21,13 @@ package org.wso2.identity.integration.test.consent;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.wink.client.ClientConfig;
 import org.apache.wink.client.Resource;
 import org.apache.wink.client.RestClient;
-import org.apache.wink.client.handlers.BasicAuthSecurityHandler;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,6 +36,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProviderProperty;
@@ -52,6 +52,8 @@ import org.wso2.identity.integration.test.utils.OAuth2Constant;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import javax.ws.rs.core.MediaType;
+
+import static org.wso2.identity.integration.test.util.Utils.getBasicAuthHeader;
 
 /**
  * Self sign up tests - with consents.
@@ -308,38 +310,40 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
 
     private void addPIICategory(String name, String description) {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(tenantAdminUserName);
-        basicAuth.setPassword(ADMIN);
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint + "/" + "pii-categories");
 
         String addPIICatString = "{\"piiCategory\": " + "\"" + name + "\"" + ", \"description\": " + "\"" +
                 description + "\" , \"sensitive\": \"" + true + "\"}";
 
-        piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addPIICatString);
+        User user = new User();
+        user.setUserName(tenantAdminUserName);
+        user.setPassword(ADMIN);
+
+        piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(user)).
+                post(String.class, addPIICatString);
     }
 
     private String addPurposeCategory(String name, String description) throws JSONException {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(tenantAdminUserName);
-        basicAuth.setPassword(ADMIN);
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint + "/" + "purpose-categories");
 
         String addPurposeCatString = "{\"purposeCategory\": " + "\"" + name + "\"" + ", \"description\": " + "\"" +
                 description + "\"}";
 
-        String content = piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addPurposeCatString);
+        User user = new User();
+        user.setUserName(tenantAdminUserName);
+        user.setPassword(ADMIN);
+
+        String content = piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(user)).
+                post(String.class, addPurposeCatString);
         JSONObject purpose = new JSONObject(content);
         return purpose.getString("purposeCategoryId");
     }
@@ -357,13 +361,7 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
     private String addPurpose(String name, String description, String group, String groupType)
             throws JSONException {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(tenantAdminUserName);
-        basicAuth.setPassword(ADMIN);
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource piiCatResource = restClient.resource(consentEndpoint + "/" + "purposes");
 
         String addPurposeString = "{" +
@@ -379,8 +377,15 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
                                   "  ]" +
                                   "}";
 
-        String response = piiCatResource.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, addPurposeString);
+        User user = new User();
+        user.setUserName(tenantAdminUserName);
+        user.setPassword(ADMIN);
+
+        String response = piiCatResource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(user)).
+                post(String.class, addPurposeString);
         JSONObject purpose = new JSONObject(response);
         return purpose.getString("purposeId");
     }
@@ -407,18 +412,17 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
                 "{\"uri\": \"http://wso2.org/claims/mobile\",\"value\": \"" + mobile + "\"} ] }," +
                 "\"properties\": [{\"key\": \"consent\", \"value\": \"" + consent + "\"}]}";
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(tenantAdminUserName);
-        basicAuth.setPassword(ADMIN);
-        clientConfig.handlers(basicAuth);
+        RestClient restClient = new RestClient();
+        Resource selfRegistrationResource = restClient.resource(selfRegistrationMeEndpoint);
 
-        RestClient restClient = new RestClient(clientConfig);
-        Resource user = restClient.resource(selfRegistrationMeEndpoint);
+        User user = new User();
+        user.setUserName(tenantAdminUserName);
+        user.setPassword(ADMIN);
 
-        user.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .post(String.class, selfRegisterReqBody);
-
+        selfRegistrationResource.contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(user)).
+                post(String.class, selfRegisterReqBody);
     }
 
     private String getConsentReqBody(String purposeId, int piiCategoryId, String username) {
@@ -437,36 +441,39 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
 
     private String getConsents(String username, String password) {
 
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(username);
-        basicAuth.setPassword(password);
-        clientConfig.handlers(basicAuth);
-
-        RestClient restClient = new RestClient(clientConfig);
-        Resource user = restClient.resource(consentEndpoint + "?piiPrincipalId=" + MultitenantUtils
+        RestClient restClient = new RestClient();
+        Resource resource = restClient.resource(consentEndpoint + "?piiPrincipalId=" + MultitenantUtils
                 .getTenantAwareUsername(username));
 
-        String response = user.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .get(String.class);
+        User user = new User();
+        user.setUserName(username);
+        user.setPassword(password);
+
+        String response = resource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(user)).
+                get(String.class);
         return response;
     }
 
     private String getConsent(String username, String password, String receiptId) {
 
         log.info("Retrieving consent for username " + username + ". reciptId : " + receiptId);
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(username);
-        basicAuth.setPassword(password);
-        clientConfig.handlers(basicAuth);
 
-        RestClient restClient = new RestClient(clientConfig);
-        Resource user = restClient.resource(consentEndpoint + "/receipts/" + receiptId);
+        RestClient restClient = new RestClient();
+        Resource resource = restClient.resource(consentEndpoint + "/receipts/" + receiptId);
         log.info("Calling to receipt endpoint :" + consentEndpoint + "/receipts/" + receiptId);
 
-        String response = user.contentType(MediaType.APPLICATION_JSON_TYPE).accept(MediaType.APPLICATION_JSON)
-                .get(String.class);
+        User user = new User();
+        user.setUserName(username);
+        user.setPassword(password);
+
+        String response = resource.
+                contentType(MediaType.APPLICATION_JSON_TYPE).
+                accept(MediaType.APPLICATION_JSON).
+                header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(user)).
+                get(String.class);
         return response;
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ScopesTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ScopesTestCase.java
@@ -19,11 +19,10 @@
 package org.wso2.identity.integration.test.oauth2;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.wink.client.ClientConfig;
-import org.apache.wink.client.Resource;
+import org.apache.http.HttpHeaders;
 import org.apache.wink.client.ClientResponse;
+import org.apache.wink.client.Resource;
 import org.apache.wink.client.RestClient;
-import org.apache.wink.client.handlers.BasicAuthSecurityHandler;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -33,9 +32,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 
+import java.io.IOException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
+
+import static org.wso2.identity.integration.test.util.Utils.getBasicAuthHeader;
 
 public class OAuth2ScopesTestCase extends ISIntegrationTest {
 
@@ -210,20 +211,14 @@ public class OAuth2ScopesTestCase extends ISIntegrationTest {
     }
 
     private Resource getUserResource(String scopeEndpointAppender) {
-        ClientConfig clientConfig = new ClientConfig();
-        BasicAuthSecurityHandler basicAuth = new BasicAuthSecurityHandler();
-        basicAuth.setUserName(userInfo.getUserName());
-        basicAuth.setPassword(userInfo.getPassword());
-        clientConfig.handlers(basicAuth);
 
-        RestClient restClient = new RestClient(clientConfig);
+        RestClient restClient = new RestClient();
         Resource userResource;
         if(StringUtils.isNotBlank(scopeEndpointAppender)) {
             userResource = restClient.resource(scopeEndpoint + scopeEndpointAppender);
         } else {
             userResource = restClient.resource(scopeEndpoint);
         }
-        return userResource;
+        return userResource.header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(userInfo));
     }
-
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/util/Utils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/util/Utils.java
@@ -36,12 +36,15 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
 import org.wso2.carbon.h2.osgi.utils.CarbonUtils;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.mgt.stub.types.carbon.FlaggedName;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase;
+import org.wso2.identity.integration.test.utils.BasicAuthHandler;
+import org.wso2.identity.integration.test.utils.BasicAuthInfo;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 
 import java.io.BufferedReader;
@@ -485,5 +488,19 @@ public class Utils {
             }
         }
         return results;
+    }
+
+    /**
+     * Construct and return basic authentication information of the user.
+     */
+    public static String getBasicAuthHeader(User userInfo) {
+
+        BasicAuthInfo basicAuthInfo = new BasicAuthInfo();
+        basicAuthInfo.setUserName(userInfo.getUserName());
+        basicAuthInfo.setPassword(userInfo.getPassword());
+
+        BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
+        BasicAuthInfo encodedBasicAuthInfo = (BasicAuthInfo) basicAuthHandler.getAuthenticationToken(basicAuthInfo);
+        return encodedBasicAuthInfo.getAuthorizationHeader();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1813,7 +1813,7 @@
         <identity.carbon.auth.saml2.version>5.4.4</identity.carbon.auth.saml2.version>
         <identity.carbon.auth.mutual.ssl.version>5.3.3</identity.carbon.auth.mutual.ssl.version>
         <identity.carbon.auth.iwa.version>5.3.4</identity.carbon.auth.iwa.version>
-        <identity.carbon.auth.rest.version>1.3.6</identity.carbon.auth.rest.version>
+        <identity.carbon.auth.rest.version>1.3.7</identity.carbon.auth.rest.version>
 
 
         <!-- Identity Inbound Versions   -->


### PR DESCRIPTION
### Proposed changes
We updated the logic of the carbon rest authenticator with https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/87 but that appeared to break some of the test cases. This PR changes the braking tests to authenticate differently with the new auth rest changes.