### PR TITLE
Reset loop check flag for every new loop

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/approval/common/UserApprovalTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/approval/common/UserApprovalTestBase.java
@@ -195,10 +195,11 @@ public class UserApprovalTestBase extends RESTAPIUserTestBase {
         HttpClient client = new HttpClientFactory().getHttpClient();
         HttpGet request = new HttpGet(url);
 
-        boolean runLoop = false;
+        boolean runLoop;
         int count = 0;
 
         do {
+            runLoop = false;
             HttpResponse httpResponse = client.execute(request);
 
             // If the server response is 500 or it contains "service not available" text or "Operation not found" text,


### PR DESCRIPTION
The `runLoop` variable is used to initiate a new loop upon a failure to call the endpoint.

During the first loop, if the endpoint is not available, the `runLoop` variable is set to true. But it is never set to `false` if any of the consequence loops are able to discover the endpoint.

This PR will reset the `runLoop` variable for each new loop, in order to fix the above issue.