### PR TITLE
Add workflows for GitHub actions

### DIFF
--- a/.github/workflows/Ubuntu+jdk1.8.yml
+++ b/.github/workflows/Ubuntu+jdk1.8.yml
@@ -1,0 +1,20 @@
+name: Ubuntu+jdk1.8
+
+on: 
+  schedule:
+    # Runs at 12AM LK time.
+    - cron:  '30 18 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn clean install

--- a/.github/workflows/Ubuntu+jdk1.8.yml
+++ b/.github/workflows/Ubuntu+jdk1.8.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/Ubuntu+jdk11.yml
+++ b/.github/workflows/Ubuntu+jdk11.yml
@@ -1,0 +1,20 @@
+name: Ubuntu+jdk11
+
+on:
+  schedule:
+    # Runs at 12AM LK time.
+    - cron:  '30 18 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build with Maven
+      run: mvn clean install

--- a/.github/workflows/Ubuntu+jdk11.yml
+++ b/.github/workflows/Ubuntu+jdk11.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/Ubuntu+jdk11.yml
+++ b/.github/workflows/Ubuntu+jdk11.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/Windows+jdk1.8.yml
+++ b/.github/workflows/Windows+jdk1.8.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Allow longpaths
       run: git config --system core.longpaths true
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/Windows+jdk1.8.yml
+++ b/.github/workflows/Windows+jdk1.8.yml
@@ -1,0 +1,22 @@
+name: Windows+jdk1.8
+
+on:
+  schedule:
+    # Runs at 12AM LK time.
+    - cron:  '30 18 * * *'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Allow longpaths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@master
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn clean install

--- a/.github/workflows/Windows+jdk11.yml
+++ b/.github/workflows/Windows+jdk11.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Allow longpaths
       run: git config --system core.longpaths true
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/Windows+jdk11.yml
+++ b/.github/workflows/Windows+jdk11.yml
@@ -1,0 +1,22 @@
+name: Windows+jdk11
+
+on:
+  schedule:
+    # Runs at 12AM LK time.
+    - cron:  '30 18 * * *'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Allow longpaths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@master
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build with Maven
+      run: mvn clean install


### PR DESCRIPTION
Adds the following workflows to be triggered through GitHub actions

- Build on Ubunutu(latest) with JDK 1.8
- Build on Ubunutu(latest) with JDK 11
- Build on Windows(latest) with JDK 1.8
- Build on Windows(latest) with JDK 11

Builds will be triggered daily at 12AM LK time

Ref: https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions