### PR TITLE
Fix Failing Integration Test With Email Template REST APIs

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/email/template/v1/get-all-email-template-types-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/email/template/v1/get-all-email-template-types-response.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "QWNjb3VudExvY2tBZG1pbg",
+    "displayName": "AccountLockAdmin",
+    "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudExvY2tBZG1pbg"
+  },
+  {
     "id": "QWNjb3VudEVuYWJsZQ",
     "displayName": "AccountEnable",
     "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudEVuYWJsZQ"
@@ -13,6 +18,11 @@
     "id": "QWNjb3VudElkUmVjb3Zlcnk",
     "displayName": "AccountIdRecovery",
     "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudElkUmVjb3Zlcnk"
+  },
+  {
+    "id": "QWNjb3VudExvY2tGYWlsZWRBdHRlbXB0",
+    "displayName": "AccountLockFailedAttempt",
+    "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudExvY2tGYWlsZWRBdHRlbXB0"
   },
   {
     "id": "cmVzZW5kQWRtaW5Gb3JjZWRQYXNzd29yZFJlc2V0",
@@ -55,14 +65,9 @@
     "self": "/t/carbon.super/api/server/v1/email/template-types/T25lVGltZVBhc3N3b3Jk"
   },
   {
-    "id": "QWNjb3VudExvY2s",
-    "displayName": "AccountLock",
-    "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudExvY2s"
-  },
-  {
-    "id": "QWNjb3VudFVuTG9jaw",
-    "displayName": "AccountUnLock",
-    "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudFVuTG9jaw"
+    "id": "QWNjb3VudFVubG9ja1RpbWVCYXNlZA",
+    "displayName": "AccountUnlockTimeBased",
+    "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudFVubG9ja1RpbWVCYXNlZA"
   },
   {
     "id": "aWRsZUFjY291bnRSZW1pbmRlcg",
@@ -78,6 +83,11 @@
     "id": "VW5zZWVuRGV2aWNlTG9naW4",
     "displayName": "UnseenDeviceLogin",
     "self": "/t/carbon.super/api/server/v1/email/template-types/VW5zZWVuRGV2aWNlTG9naW4"
+  },
+  {
+    "id": "QWNjb3VudFVubG9ja0FkbWlu",
+    "displayName": "AccountUnlockAdmin",
+    "self": "/t/carbon.super/api/server/v1/email/template-types/QWNjb3VudFVubG9ja0FkbWlu"
   },
   {
     "id": "QWNjb3VudENvbmZpcm1hdGlvbg",


### PR DESCRIPTION
The fix for the issue, https://github.com/wso2/product-is/issues/6778 have made modifications to the default email templates. 

This PR fixes the `get-all-email-template-types-response.json` file to be compatible with the above modifications.