### PR TITLE
Add and Improve Integration Tests For Association REST APIs

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/UserProfileMgtServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/UserProfileMgtServiceClient.java
@@ -150,11 +150,6 @@ public class UserProfileMgtServiceClient {
         userProfileMgtServiceStub.removeAssociateID(idpName, idpAssociatedId);
     }
 
-//    public void addFedIdpAccountAssociation(String username, String idpName, String idpAssociatedId) throws Exception {
-//
-//        userProfileMgtServiceStub.associateIDForUser(username, idpName, idpAssociatedId);
-//    }
-
     public AssociatedAccountDTO[] getAssociatedFedUserAccountIds() throws Exception {
 
         return userProfileMgtServiceStub.getAssociatedIDs();

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/UserProfileMgtServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/UserProfileMgtServiceClient.java
@@ -144,6 +144,17 @@ public class UserProfileMgtServiceClient {
         userProfileMgtServiceStub.associateID(idpName, idpAssociatedId);
     }
 
+    public void deleteFedIdpAccountAssociation(String idpName,
+                                            String idpAssociatedId) throws Exception{
+
+        userProfileMgtServiceStub.removeAssociateID(idpName, idpAssociatedId);
+    }
+
+//    public void addFedIdpAccountAssociation(String username, String idpName, String idpAssociatedId) throws Exception {
+//
+//        userProfileMgtServiceStub.associateIDForUser(username, idpName, idpAssociatedId);
+//    }
+
     public AssociatedAccountDTO[] getAssociatedFedUserAccountIds() throws Exception {
 
         return userProfileMgtServiceStub.getAssociatedIDs();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
@@ -32,6 +32,8 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
 import org.hamcrest.Matcher;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
+import org.wso2.identity.integration.common.clients.UserProfileMgtServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
@@ -45,6 +47,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.rmi.RemoteException;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.jar.JarEntry;
@@ -81,6 +84,8 @@ public class RESTTestBase extends ISIntegrationTest {
     protected AutomationContext context;
 
     protected RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
+    protected UserProfileMgtServiceClient userProfileMgtServiceClient;
+    protected IdentityProviderMgtServiceClient identityProviderMgtServiceClient;
     protected String swaggerDefinition;
 
     protected String basePath = StringUtils.EMPTY;
@@ -98,7 +103,7 @@ public class RESTTestBase extends ISIntegrationTest {
      * @throws XPathExpressionException
      */
     protected void init(String swaggerDefinition, String basePathInSwagger, String basePath)
-            throws AxisFault {
+            throws RemoteException {
 
         this.basePath = basePath;
         this.swaggerDefinition = swaggerDefinition;
@@ -110,6 +115,8 @@ public class RESTTestBase extends ISIntegrationTest {
                 .build();
         validationFilter = new OpenApiValidationFilter(openAPIValidator);
         remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
+        userProfileMgtServiceClient = new UserProfileMgtServiceClient(backendURL, sessionCookie);
+        identityProviderMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL);
     }
 
     protected void conclude() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/ClaimManagementNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/ClaimManagementNegativeTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import java.io.IOException;
+import java.rmi.RemoteException;
 
 import static org.hamcrest.core.IsNull.notNullValue;
 
@@ -54,7 +55,7 @@ public class ClaimManagementNegativeTest extends ClaimManagementTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws AxisFault {
+    public void init() throws RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/ClaimManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/ClaimManagementSuccessTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import java.io.IOException;
+import java.rmi.RemoteException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -57,7 +58,7 @@ public class ClaimManagementSuccessTest extends ClaimManagementTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws AxisFault {
+    public void init() throws RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/common/RESTAPIServerTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/common/RESTAPIServerTestBase.java
@@ -19,6 +19,8 @@ package org.wso2.identity.integration.test.rest.api.server.common;
 import org.apache.axis2.AxisFault;
 import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
+import java.rmi.RemoteException;
+
 /**
  * Base Test Class for server based REST API test cases.
  * ex: /t/{tenant-domain}/api/server/{version}
@@ -31,7 +33,7 @@ public class RESTAPIServerTestBase extends RESTTestBase {
             TENANT_CONTEXT_IN_URL + API_SERVER_BASE_PATH;
 
     protected void testInit(String apiVersion, String apiDefinition, String tenantDomain)
-            throws AxisFault {
+            throws RemoteException {
 
         String basePathInSwagger = String.format(API_SERVER_BASE_PATH_IN_SWAGGER, apiVersion);
         String basePath = String.format(API_SERVER_BASE_PATH_WITH_TENANT_CONTEXT,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/permission/management/v1/PermissionManagementTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/permission/management/v1/PermissionManagementTest.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
 
 import java.io.IOException;
+import java.rmi.RemoteException;
 
 /**
  * The main test class for permission management.
@@ -74,7 +75,7 @@ public class PermissionManagementTest extends RESTAPIServerTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws AxisFault {
+    public void init() throws RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserAssociationTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserAssociationTestBase.java
@@ -38,8 +38,10 @@ public class UserAssociationTestBase extends RESTAPIUserTestBase {
     static String API_PACKAGE_NAME = "org.wso2.carbon.identity.rest.api.user.association.v1";
 
     public static final String ASSOCIATION_ENDPOINT_URI = "/%s/associations";
+    public static final String FEDERATED_ASSOCIATION_ENDPOINT_URI = "/%s/federated-associations";
 
     protected String userAssociationEndpointURI;
+    protected String federatedUserAssociationEndpointURI;
 
     protected static String swaggerDefinition;
 
@@ -55,6 +57,7 @@ public class UserAssociationTestBase extends RESTAPIUserTestBase {
     void initUrls(String pathParam) {
 
         this.userAssociationEndpointURI = String.format(ASSOCIATION_ENDPOINT_URI, pathParam);
+        this.federatedUserAssociationEndpointURI = String.format(FEDERATED_ASSOCIATION_ENDPOINT_URI, pathParam);
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeNegativeTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeNegativeTestBase.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import java.io.IOException;
+import java.rmi.RemoteException;
 import javax.xml.xpath.XPathExpressionException;
 
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -58,7 +59,7 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");
@@ -123,16 +124,16 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
     public void testCreateExitingAssociationAgain() throws IOException {
         String body;
         if (TestUserMode.SUPER_TENANT_ADMIN.equals(userMode)) {
-            body = readResource("association-creation.json");
+            body = readResource("association-creation-1.json");
         } else {
-            body = readResource("association-creation-tenant.json").replace("TENANT", tenant);
+            body = readResource("association-creation-tenant-1.json").replace("TENANT", tenant);
         }
         getResponseOfPost(this.userAssociationEndpointURI, body);
 
         if (TestUserMode.SUPER_TENANT_ADMIN.equals(userMode)) {
-            body = readResource("association-creation.json");
+            body = readResource("association-creation-1.json");
         } else {
-            body = readResource("association-creation-tenant.json").replace("TENANT", tenant);
+            body = readResource("association-creation-tenant-1.json").replace("TENANT", tenant);
         }
         getResponseOfPost(this.userAssociationEndpointURI, body)
                 .then()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v1/MeAuthorizedAppsNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v1/MeAuthorizedAppsNegativeTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
+import java.rmi.RemoteException;
 import javax.xml.xpath.XPathExpressionException;
 
 public class MeAuthorizedAppsNegativeTest extends UserAuthorizedAppsBaseTest {
@@ -36,7 +37,7 @@ public class MeAuthorizedAppsNegativeTest extends UserAuthorizedAppsBaseTest {
     private static final String INVALID_APP = "invalid-app";
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v1/MeAuthorizedAppsSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v1/MeAuthorizedAppsSuccessTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
+import java.rmi.RemoteException;
 import javax.xml.xpath.XPathExpressionException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -48,7 +49,7 @@ public class MeAuthorizedAppsSuccessTest extends UserAuthorizedAppsBaseTest {
 
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserMeNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserMeNegativeTest.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.um.ws.api.stub.PermissionDTO;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 
 import java.io.IOException;
+import java.rmi.RemoteException;
 import javax.xml.xpath.XPathExpressionException;
 
 public class UserMeNegativeTest extends UserChallengeTestBase {
@@ -67,7 +68,7 @@ public class UserMeNegativeTest extends UserChallengeTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserMeSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserMeSuccessTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import java.io.IOException;
+import java.rmi.RemoteException;
 import javax.xml.xpath.XPathExpressionException;
 
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -50,7 +51,7 @@ public class UserMeSuccessTest extends UserChallengeTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserNegativeTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
+import java.rmi.RemoteException;
 import java.util.Base64;
 import javax.xml.xpath.XPathExpressionException;
 
@@ -46,7 +47,7 @@ public class UserNegativeTest extends UserMeNegativeTest {
 
     @BeforeClass(alwaysRun = true)
     @Override
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         String user = this.user;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/challenge/v1/UserSuccessTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Factory;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.rmi.RemoteException;
 import java.util.Base64;
 import javax.xml.xpath.XPathExpressionException;
 
@@ -38,7 +39,7 @@ public class UserSuccessTest extends UserMeSuccessTest {
 
     @BeforeClass(alwaysRun = true)
     @Override
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         String user = MultitenantUtils.getTenantAwareUsername(context.getContextTenant().getTenantUserList().get(0)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/RESTAPIUserTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/RESTAPIUserTestBase.java
@@ -19,6 +19,7 @@ package org.wso2.identity.integration.test.rest.api.user.common;
 import org.apache.axis2.AxisFault;
 import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
+import java.rmi.RemoteException;
 import javax.xml.xpath.XPathExpressionException;
 
 /**
@@ -32,7 +33,7 @@ public class RESTAPIUserTestBase extends RESTTestBase {
     protected static final String API_USERS_BASE_PATH_WITH_TENANT_CONTEXT = TENANT_CONTEXT_IN_URL + API_USERS_BASE_PATH;
 
     protected void testInit(String apiVersion, String apiDefinition, String tenantDomain)
-            throws XPathExpressionException, AxisFault {
+            throws XPathExpressionException, RemoteException {
 
         String basePathInSwagger = String.format(API_USERS_BASE_PATH_IN_SWAGGER, apiVersion);
         String basePath = String.format(API_USERS_BASE_PATH_WITH_TENANT_CONTEXT,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/session/v1/UserSessionMeSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/session/v1/UserSessionMeSuccessTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
+import java.rmi.RemoteException;
 import java.util.List;
 import javax.xml.xpath.XPathExpressionException;
 
@@ -63,7 +64,7 @@ public class UserSessionMeSuccessTest extends UserSessionTest {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws XPathExpressionException, AxisFault {
+    public void init() throws XPathExpressionException, RemoteException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2BaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2BaseTest.java
@@ -27,6 +27,7 @@ import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
 import java.io.File;
 import java.io.IOException;
+import java.rmi.RemoteException;
 
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.SCIM2_ENDPOINT;
 
@@ -51,7 +52,7 @@ public class SCIM2BaseTest extends RESTTestBase {
     }
 
     public void testInit(String apiDefinition, String tenantDomain)
-            throws AxisFault {
+            throws RemoteException {
 
         final String basePath;
         if ("carbon.super".equals(tenantDomain)) {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-1.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-1.json
@@ -1,0 +1,10 @@
+{
+  "userId": "TestUser01",
+  "password": "Test123",
+  "properties": [
+    {
+      "key": "key",
+      "value": "value"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-2.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-2.json
@@ -1,5 +1,5 @@
 {
-  "userId": "TestUser",
+  "userId": "TestUser02",
   "password": "Test123",
   "properties": [
     {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-tenant-1.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-tenant-1.json
@@ -1,0 +1,10 @@
+{
+  "userId": "TestUser01@TENANT",
+  "password": "Test123",
+  "properties": [
+    {
+      "key": "key",
+      "value": "value"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-tenant-2.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/association/v1/association-creation-tenant-2.json
@@ -1,5 +1,5 @@
 {
-  "userId": "TestUser@TENANT",
+  "userId": "TestUser02@TENANT",
   "password": "Test123",
   "properties": [
     {


### PR DESCRIPTION
> Fixes https://github.com/wso2/product-is/issues/6916.
- Adds test cases for deleting local association by Id. Existing test cases are altered to support this requirement, by creating two local associations instead of one.
- Adds test cases for federated association GET, DELETE by Id and DELETE all scenarios.
- Calling UserProfileMgtService is required for creating a federated association prior to tests. This service call expects a `rmi.RemoteException`. Therefore several other tests were altered to handle this exception.


