### PR TITLE
Bump Identity Framework Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1917,7 +1917,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.15.11</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2038,9 +2038,9 @@
         <carbon.kernel.version>4.5.2</carbon.kernel.version>
 
         <!-- Carbon Repo Versions -->
-        <carbon.commons.version>4.7.17</carbon.commons.version>
+        <carbon.commons.version>4.7.18</carbon.commons.version>
         <carbon.deployment.version>4.9.11</carbon.deployment.version>
-        <carbon.registry.version>4.7.19</carbon.registry.version>
+        <carbon.registry.version>4.7.20</carbon.registry.version>
         <carbon.multitenancy.version>4.7.11</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.3</carbon.metrics.version>
         <carbon.business-process.version>4.5.20</carbon.business-process.version>


### PR DESCRIPTION
The bumping framework to 5.15.17 requires carbon commons and carbon registry version bumps. This PR handles it accordingly.