### PR TITLE
Fix user account recovery test fail

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz-response.json
@@ -106,7 +106,7 @@
         {
           "name": "Recovery.ExpiryTime",
           "value": "1440",
-          "displayName": "Notification Expiry Time",
+          "displayName": "Recovery Link Expiry Time",
           "description": ""
         },
         {


### PR DESCRIPTION
## Purpose
In PR https://github.com/wso2-extensions/identity-governance/pull/345 a connector configuration has been changed. 
Due to the change `IdentityGovernanceSuccessTest` was failed. This PR fixes the test failure.

## Approach
Change the property value of the connector config in the test case to suit the name in the https://github.com/wso2-extensions/identity-governance/pull/345 PR.