### PR TITLE
Adding sms notification templates to the registry

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -843,6 +843,13 @@
         </file>
         <file>
             <source>
+                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/sms/sms-templates-admin-config.xml
+            </source>
+            <outputDirectory>wso2is-${pom.version}/repository/conf/sms</outputDirectory>
+            <fileMode>644</fileMode>
+        </file>
+        <file>
+            <source>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/security/identity_log_tokens.properties
             </source>
             <outputDirectory>wso2is-${pom.version}/repository/conf/security</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1977,7 +1977,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.3.9</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.2.19</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.2.20</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
## Proposed changes

Adding permission to add SMS notification template config files to the product.
Related to PRs: 
 - https://github.com/wso2-extensions/identity-event-handler-notification/pull/114
 - https://github.com/wso2-extensions/identity-governance/pull/350

Related to the issue: wso2/product-is#7006

## When should this PR be merged
- The PR should be merged after merging https://github.com/wso2-extensions/identity-event-handler-notification/pull/114. 
- After merging above two PRs the respective versions need to be updated in the `pom.xml`