### PR TITLE
Exclude redundent dependencies from cxf3 runtime

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -502,28 +502,22 @@
 
         <!-- copying runtimes -->
         <fileSet>
-            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/lib/runtimes</directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/lib/runtimes/</outputDirectory>
+            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/lib/runtimes/cxf3</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/lib/runtimes/cxf3</outputDirectory>
             <excludes>
-                <exclude>*/httpclient*</exclude>
-                <exclude>*/httpcore*</exclude>
-                <exclude>*/commons-logging*</exclude>
+                <exclude>jackson-annotations*</exclude>
+                <exclude>jackson-core*</exclude>
+                <exclude>jackson-databind*</exclude>
+                <exclude>javax.annotation*</exclude>
             </excludes>
         </fileSet>
+
         <fileSet>
-            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/lib/runtimes</directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/lib/runtimes/</outputDirectory>
+            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/lib/</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/lib/</outputDirectory>
             <includes>
-                <include>*/httpcore-nio*</include>
+                <include>*.jar</include>
             </includes>
-        </fileSet>
-        <fileSet>
-            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/lib/</directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/lib/</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/lib/</directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/lib/</outputDirectory>
         </fileSet>
 
         <fileSet>


### PR DESCRIPTION
Below jars were excluded from cxf3 runtime since it will be added to the classpath to be used for the new config feature.

- jackson-annotations-2.9.9.jar
- jackson-core-2.9.9.jar
- jackson-databind-2.9.9.3.jar
- javax.annotation-api-1.3.2.jar