### PR TITLE
Bump the version of notification event handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2009,7 +2009,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.3.9</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.2.22</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.2.23</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
The integrations tests were updated from this https://github.com/wso2/product-is/pull/7560 based on the changes introduced the` identity-event-handler-notification` in PR https://github.com/wso2-extensions/identity-event-handler-notification/pull/117.

Therefore the `identity-event-handler-notification` version needs to be updated.