### PR TITLE
Update release-guidelines with the component that packs balana

### DIFF
--- a/release-guidelines.md
+++ b/release-guidelines.md
@@ -14,7 +14,7 @@
    
    charon       : [identity-inbound-provisioning-scim2](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/)
    
-   balana       : [identity-application-authz-xacml](https://github.com/wso2-extensions/identity-application-authz-xacml/)
+   balana       : [carbon-identity-framework](https://github.com/wso2/carbon-identity-framework)
    
    rampart      : [identity-inbound-auth-sts](https://github.com/wso2-extensions/identity-inbound-auth-sts/)
    


### PR DESCRIPTION
Change the component that packs balana to product-is, from 'identity-application-authz-xacml' to 'carbon-identity-framework'