### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: ❗️ Issue/Bug report
+about: Report issue or bug related to the project
+title: '[ISSUE]'
+labels: 'Type/Bug'
+assignees: ''
+
+---
+
+**Describe the Issue:**
+<!-- A clear and concise description of what the bug is. If applicable, add screenshots to help explain your problem. -->
+
+**How To Reproduce:**
+<!-- Steps to reproduce the behavior. -->
+
+**Expected behavior:**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Environment Information** (_Please complete the following information; remove  any unnecessary fields_) **:**
+ - Product Version: [e.g. IS 5.10.0, IS 5.9.0]
+ - OS: [e.g. Windows, Linux, Mac]
+ - Database: [e.g. MySQL, H2]
+ - Userstore: [e.g. LDAP, JDBC]
+
+---
+
+### Optional Fields
+
+**Related Issues:**
+<!-- Any related issues from this/other repositories-->
+
+**Suggested Labels:**
+<!-- Only to be used by non-members -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,27 +7,27 @@ assignees: ''
 
 ---
 
-**Describe the Issue:**
+**Describe the issue:**
 <!-- A clear and concise description of what the bug is. If applicable, add screenshots to help explain your problem. -->
 
-**How To Reproduce:**
+**How to reproduce:**
 <!-- Steps to reproduce the behavior. -->
 
 **Expected behavior:**
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Environment Information** (_Please complete the following information; remove  any unnecessary fields_) **:**
- - Product Version: [e.g. IS 5.10.0, IS 5.9.0]
- - OS: [e.g. Windows, Linux, Mac]
- - Database: [e.g. MySQL, H2]
- - Userstore: [e.g. LDAP, JDBC]
+**Environment information** (_Please complete the following information; remove  any unnecessary fields_) **:**
+ - Product Version: [e.g., IS 5.10.0, IS 5.9.0]
+ - OS: [e.g., Windows, Linux, Mac]
+ - Database: [e.g., MySQL, H2]
+ - Userstore: [e.g., LDAP, JDBC]
 
 ---
 
 ### Optional Fields
 
-**Related Issues:**
+**Related issues:**
 <!-- Any related issues from this/other repositories-->
 
-**Suggested Labels:**
+**Suggested labels:**
 <!-- Only to be used by non-members -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: UI issues
-    url: https://github.com/wso2/identity-apps/issues
+    url: https://github.com/wso2/identity-apps/issues/new/choose
     about: Please report UI issues here
   - name: Doc issues
     url: https://github.com/wso2/docs-is/issues

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: UI issues
+    url: https://github.com/wso2/identity-apps/issues
+    about: Please report UI issues here
+  - name: Doc issues
+    url: https://github.com/wso2/docs-is/issues
+    about: Please report documentaion issues here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: ➕ Feature request
+about: Suggest an idea for this project
+title: '[FEATURE]'
+labels: 'Type/New Feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I would like to have[...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-<!-- A clear and concise description of what the problem is. Ex. I would like to have[...] -->
+<!-- A clear and concise description of what the problem is. e.g., I would like to have[...] -->
 
-**Describe the solution you'd like**
-<!-- A clear and concise description of what you want to happen. -->
+**Describe the solution you would prefer**
+<!-- A clear and concise description of the expected behavior. -->
 
 **Additional context**
 <!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: ❓ Question
+about: Ask a question related to the product
+title: '[QUESTION]'
+labels: 'Type/Question'
+assignees: ''
+
+---
+
+**Question**
+<!-- A clear and concise description of the question. Ex. How can I [...] -->
+
+**Environment Information** 
+ - Product Version: [e.g. IS 5.10.0, IS 5.9.0]

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Question**
-<!-- A clear and concise description of the question. Ex. How can I [...] -->
+<!-- A clear and concise description of the question. e.g., How can I [...] -->
 
-**Environment Information** 
- - Product Version: [e.g. IS 5.10.0, IS 5.9.0]
+**Environment information** 
+ - Product version: [e.g., IS 5.10.0, IS 5.9.0]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+> **Warning** : Please do not create GitHub issues for security vulnerabilities.
+
+WSO2 takes security issues very seriously. If you have any concerns regarding 
+our product security or have uncovered a security vulnerability, we strongly 
+encourage you to report that to our private and highly confidential security 
+mailing list: security@wso2.com first, without disclosing them in any forums, 
+sites or other groups - public or private. To protect the end-user security, 
+these issues could be disclosed in other places only after WSO2 completes its 
+[Vulnerability Management Process](https://docs.wso2.com/display/Security/WSO2+Security+Vulnerability+Management+Process).
+
+[WSO2 guidelines for reporting a security vulnerability](https://docs.wso2.com/display/Security/WSO2+Security+Vulnerability+Reporting+Guidelines) page describes how to report a Security Vulnerability and includes a public key if you wish to send secure messages to security@wso2.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ WSO2 takes security issues very seriously. If you have any concerns regarding
 our product security or have uncovered a security vulnerability, we strongly 
 encourage you to report that to our private and highly confidential security 
 mailing list: security@wso2.com first, without disclosing them in any forums, 
-sites or other groups - public or private. To protect the end-user security, 
+sites, or other groups - public or private. To protect the end-user security, 
 these issues could be disclosed in other places only after WSO2 completes its 
 [Vulnerability Management Process](https://docs.wso2.com/display/Security/WSO2+Security+Vulnerability+Management+Process).
 


### PR DESCRIPTION
Issue templates to standardize the information to include when contributors open an issue. These issue templates can try out using [sample repo](https://github.com/GANGANI/Sample-Issue-Template/issues/new/choose).