### PR TITLE
Fix template manager test failure

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/template/mgt/TemplateManagementServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/template/mgt/TemplateManagementServiceClient.java
@@ -47,7 +47,7 @@ public class TemplateManagementServiceClient {
         handleLoggedInUserAuthorization(TemplateMgtConstants.PERMISSION_TEMPLATE_MGT_ADD);
         Template template = new Template(templateRequestDTO.getTenantId(), templateRequestDTO.getTemplateName(),
                 templateRequestDTO.getDescription(), templateRequestDTO.getTemplateScript());
-        return getTemplateManager().addTemplate(template);
+        return getTemplateManager().addTemplateUsingTemplateMgtDAO(template);
     }
 
     public Template getTemplateByName(String templateName) throws TemplateManagementException {

--- a/pom.xml
+++ b/pom.xml
@@ -1966,7 +1966,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.17.12</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.14</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
From this PR, https://github.com/wso2/carbon-identity-framework/pull/2827, the template management implementation is changed to use the configuration store. This PR update the Template Management test case to use the previous deprecated `addTemplate` method to preserve the behavior.