### PR TITLE
Add integration tests for Application Template API

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementBaseTest.java
@@ -17,6 +17,7 @@ package org.wso2.identity.integration.test.rest.api.server.application.managemen
 
 import io.restassured.RestAssured;
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -38,6 +39,8 @@ public class ApplicationManagementBaseTest extends RESTAPIServerTestBase {
 
     static final String APPLICATION_MANAGEMENT_API_BASE_PATH = "/applications";
     static final String METADATA_API_BASE_PATH = APPLICATION_MANAGEMENT_API_BASE_PATH + "/meta";
+    static final String APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH = APPLICATION_MANAGEMENT_API_BASE_PATH +
+            "/templates";
     static final String PATH_SEPARATOR = "/";
 
     protected static String swaggerDefinition;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationTemplateManagementFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationTemplateManagementFailureTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1;
+
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.io.IOException;
+
+import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils
+        .extractApplicationIdFromLocationHeader;
+
+public class ApplicationTemplateManagementFailureTest extends ApplicationManagementBaseTest {
+
+    private JSONObject applicationObject;
+    private String invalidTemplateId = "some-wrong-id";
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public ApplicationTemplateManagementFailureTest(TestUserMode userMode) throws Exception {
+
+        super(userMode);
+    }
+
+    @BeforeTest(alwaysRun = true)
+    public void initTestClass() throws IOException, JSONException {
+
+        applicationObject = createSampleApplicationObject();
+
+        super.init();
+    }
+
+    @AfterTest(alwaysRun = true)
+    public void testFinish() {
+
+        super.testFinish();
+    }
+
+    @Test
+    public void testGetApplicationTemplateByInvalidId() {
+
+        Response responseOfGet = getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" +
+                invalidTemplateId);
+
+        validateHttpStatusCode(responseOfGet, HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void testDeleteApplicationTemplateByInvalidId() {
+
+        Response responseOfDelete = getResponseOfDelete(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" +
+                invalidTemplateId);
+        validateHttpStatusCode(responseOfDelete, HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void testUpdateApplicationTemplateByInvalidId() throws Exception {
+
+        JSONObject createRequest = new JSONObject();
+        createRequest.put("name", "Sample Template");
+        createRequest.put("description", "This is a sample Template");
+        createRequest.put("application", applicationObject);
+        String payload = createRequest.toString();
+        Response responseOfDelete = getResponseOfPut(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" +
+                invalidTemplateId, payload);
+        validateHttpStatusCode(responseOfDelete, HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void testCreateDuplicateTemplate() throws Exception {
+
+        String body = readResource("create-application-template.json");
+        String firstTemplateId = getTemplateId(createApplicationTemplate(body));
+        Response responseOfRePost = createApplicationTemplate(body);
+        validateErrorResponse(responseOfRePost, HttpStatus.SC_CONFLICT, "TMM_00014");
+        removeCreatedApplicationTemplates(firstTemplateId);
+    }
+
+    @Test
+    public void testUpdateApplicationTemplateWithDuplicateName() throws Exception {
+
+        JSONObject firstTemplate = new JSONObject();
+        firstTemplate.put("name", "First Template");
+        firstTemplate.put("description", "Description of first template");
+        firstTemplate.put("application", applicationObject);
+        String payload1 = firstTemplate.toString();
+
+        String firstTemplateId = getTemplateId(createApplicationTemplate(payload1));
+
+        JSONObject secondTemplate = new JSONObject();
+        secondTemplate.put("name", "Second Template");
+        secondTemplate.put("description", "Description of second template");
+        secondTemplate.put("application", applicationObject);
+        String payload2 = secondTemplate.toString();
+
+        String secondTemplateId = getTemplateId(createApplicationTemplate(payload2));
+
+        JSONObject updateRequest = new JSONObject();
+        updateRequest.put("name", "First Template");
+        updateRequest.put("description", "Updated description of second template");
+        updateRequest.put("application", applicationObject);
+        String updatePayload = updateRequest.toString();
+
+        Response responsePut = getResponseOfPut(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + secondTemplateId,
+                updatePayload);
+        validateErrorResponse(responsePut, HttpStatus.SC_CONFLICT, "TMM_00014");
+
+        removeCreatedApplicationTemplates(firstTemplateId);
+        removeCreatedApplicationTemplates(secondTemplateId);
+    }
+
+    @Test
+    public void testNotImplementedLimit() {
+
+        Response response = getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "?limit=30");
+        validateErrorResponse(response, HttpStatus.SC_NOT_IMPLEMENTED, "APP-65004");
+    }
+
+    @Test
+    public void testNotImplementedOffset() {
+
+        Response response = getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "?offset=1");
+        validateErrorResponse(response, HttpStatus.SC_NOT_IMPLEMENTED, "APP-65004");
+    }
+
+    private JSONObject createSampleApplicationObject() throws JSONException {
+
+        JSONObject application = new JSONObject();
+        application.put("name", "sample application");
+        application.put("description", "This is the sample application.");
+        application.put("imageUrl", "https://example.com/logo/my-logo.png");
+
+        return application;
+    }
+
+    private void removeCreatedApplicationTemplates(String templateId) {
+
+        getResponseOfDelete(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + templateId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    private Response createApplicationTemplate(String requestBody) {
+
+        return getResponseOfPost(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH, requestBody);
+    }
+
+    private String getTemplateId(Response responseOfPost) {
+
+        String location = responseOfPost.getHeader(HttpHeaders.LOCATION);
+        return extractApplicationIdFromLocationHeader(location);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationTemplateManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationTemplateManagementSuccessTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1;
+
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.assertNotBlank;
+import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils
+        .extractApplicationIdFromLocationHeader;
+
+public class ApplicationTemplateManagementSuccessTest extends ApplicationManagementBaseTest {
+
+    private static final String CREATED_TEMPLATE_NAME = "Sample Application Template";
+    private static final String UPDATED_TEMPLATE_NAME = "Updated Sample Application Template";
+    private static final String TEMPLATE_IMAGE_URL = "https://example.com/logo/my-logo.png";
+    private static final String UPDATED_TEMPLATE_IMAGE_URL = "https://example.com/logo/update-logo.png";
+    private String createdTemplateId;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public ApplicationTemplateManagementSuccessTest(TestUserMode userMode) throws Exception {
+
+        super(userMode);
+    }
+
+    @Test
+    public void testCreateTemplate() throws Exception {
+
+        String body = readResource("create-application-template.json");
+        Response responseOfPost = getResponseOfPost(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+
+        String location = responseOfPost.getHeader(HttpHeaders.LOCATION);
+        createdTemplateId = extractApplicationIdFromLocationHeader(location);
+        assertNotBlank(createdTemplateId);
+    }
+
+    @Test(dependsOnMethods = {"testCreateTemplate"})
+    public void testGetAllApplicationTemplates() throws Exception {
+
+        String baseIdentifier = "templates.find{ it.id == '" + createdTemplateId + "' }.";
+        Response response = getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("templates.size()", is(1))
+                .body(baseIdentifier + "name", equalTo(CREATED_TEMPLATE_NAME))
+                .body(baseIdentifier + "self", equalTo("/t/" + context.getContextTenant().getDomain() +
+                        "/api/server/" + API_VERSION + APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" +
+                        createdTemplateId));
+    }
+
+    @Test(dependsOnMethods = {"testGetAllApplicationTemplates"})
+    public void testGetApplicationTemplateById() throws Exception {
+
+        getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + createdTemplateId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("name", equalTo(CREATED_TEMPLATE_NAME))
+                .body("image", equalTo(TEMPLATE_IMAGE_URL))
+                .body("application", notNullValue())
+                .body("application.claimConfiguration.requestedClaims", notNullValue());
+    }
+
+    @Test(dependsOnMethods = {"testGetApplicationTemplateById"})
+    public void testUpdateApplicationTemplateById() throws Exception {
+
+        String body = readResource("update-application-template.json");
+        getResponseOfPut(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + createdTemplateId, body)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+
+        getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + createdTemplateId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("name", equalTo(UPDATED_TEMPLATE_NAME))
+                .body("image", equalTo(UPDATED_TEMPLATE_IMAGE_URL))
+                .body("application", notNullValue())
+                .body("application.claimConfiguration.requestedClaims", nullValue());
+    }
+
+    @Test(dependsOnMethods = {"testUpdateApplicationTemplateById"})
+    public void testDeleteApplicationById() throws Exception {
+
+        getResponseOfDelete(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + createdTemplateId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Verify that the application template is not available.
+        getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH + "/" + createdTemplateId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test(dependsOnMethods = {"testDeleteApplicationById"})
+    public void testGetEmptyList() throws Exception {
+
+        getResponseOfGet(APPLICATION_TEMPLATE_MANAGEMENT_API_BASE_PATH)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("templates.size()", is(0));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/create-application-template.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/create-application-template.json
@@ -1,0 +1,57 @@
+{
+  "name": "Sample Application Template",
+  "description": "This is a sample application template",
+  "image": "https://example.com/logo/my-logo.png",
+  "authenticationProtocol": "oidc",
+  "types": [
+    "react",
+    "angular"
+  ],
+  "category": "Server Template",
+  "displayOrder": 2,
+  "application": {
+    "name": "pickup",
+    "description": "This is the configuration for Pickup application.",
+    "imageUrl": "https://example.com/logo/my-logo.png",
+    "accessUrl": "https://example.com/login",
+    "claimConfiguration": {
+      "dialect": "LOCAL",
+      "claimMappings": [
+        {
+          "applicationClaim": "firstname",
+          "localClaim": {
+            "uri": "http://wso2.org/claims/username"
+          }
+        }
+      ],
+      "requestedClaims": [
+        {
+          "claim": {
+            "uri": "http://wso2.org/claims/username"
+          },
+          "mandatory": false
+        }
+      ],
+      "subject": {
+        "claim": {
+          "uri": "http://wso2.org/claims/username"
+        },
+        "includeUserDomain": false,
+        "includeTenantDomain": false,
+        "useMappedLocalSubject": false
+      },
+      "role": {
+        "mappings": [
+          {
+            "localRole": "admin",
+            "applicationRole": "Administrator"
+          }
+        ],
+        "includeUserDomain": true,
+        "claim": {
+          "uri": "http://wso2.org/claims/username"
+        }
+      }
+    }
+  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/update-application-template.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/update-application-template.json
@@ -1,0 +1,49 @@
+{
+  "name": "Updated Sample Application Template",
+  "description": "This is a sample application template",
+  "image": "https://example.com/logo/update-logo.png",
+  "authenticationProtocol": "oidc",
+  "types": [
+    "react",
+    "angular"
+  ],
+  "category": "Server Template",
+  "displayOrder": 2,
+  "application": {
+    "name": "pickup",
+    "description": "This is the configuration for Pickup application.",
+    "imageUrl": "https://example.com/logo/my-logo.png",
+    "accessUrl": "https://example.com/login",
+    "claimConfiguration": {
+      "dialect": "LOCAL",
+      "claimMappings": [
+        {
+          "applicationClaim": "firstname",
+          "localClaim": {
+            "uri": "http://wso2.org/claims/username"
+          }
+        }
+      ],
+      "subject": {
+        "claim": {
+          "uri": "http://wso2.org/claims/username"
+        },
+        "includeUserDomain": false,
+        "includeTenantDomain": false,
+        "useMappedLocalSubject": false
+      },
+      "role": {
+        "mappings": [
+          {
+            "localRole": "admin",
+            "applicationRole": "Administrator"
+          }
+        ],
+        "includeUserDomain": true,
+        "claim": {
+          "uri": "http://wso2.org/claims/username"
+        }
+      }
+    }
+  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -149,6 +149,8 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>
         </classes>


### PR DESCRIPTION
This PR adds the test cases for Application Template API

**Related PRs**
https://github.com/wso2/identity-api-server/pull/125

** Merge this PR after bundling the config-store feature to the pack **