### PR TITLE
Integration tests for required attribute support in email -templates

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v1/EmailTemplatesNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v1/EmailTemplatesNegativeTest.java
@@ -32,6 +32,8 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Test class for Email Templates REST API negative paths.
@@ -158,4 +160,15 @@ public class EmailTemplatesNegativeTest extends EmailTemplatesTestBase {
         Response response = getResponseOfPut(path, body);
         validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "ETM-50003");
     }
+
+    @Test
+    public void testGetAllEmailTemplateTypesWithIncorrectRequiredAttribute() throws Exception {
+
+        Map<String, Object> requiredAttributeParam = new HashMap<>();
+        requiredAttributeParam.put("requiredAttributes", "template");
+        Response response = getResponseOfGetWithQueryParams(EMAIL_TEMPLATES_API_BASE_PATH + EMAIL_TEMPLATE_TYPES_PATH,
+                requiredAttributeParam);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "ETM-50006");
+    }
+
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v1/model/EmailTemplateTypeWithoutTemplates.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v1/model/EmailTemplateTypeWithoutTemplates.java
@@ -19,6 +19,8 @@ package org.wso2.identity.integration.test.rest.api.server.email.template.v1.mod
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -28,6 +30,7 @@ public class EmailTemplateTypeWithoutTemplates {
     private String id;
     private String displayName;
     private String self;
+    private List<EmailTemplateWithID> templates = null;
 
     /**
     * Unique id of the email template type.
@@ -72,6 +75,37 @@ public class EmailTemplateTypeWithoutTemplates {
     }
 
     /**
+     * Email templates for the template type.
+     **/
+    public EmailTemplateTypeWithoutTemplates templates(List<EmailTemplateWithID> templates) {
+
+        this.templates = templates;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Email templates for the template type.")
+    @JsonProperty("templates")
+    @Valid
+    public List<EmailTemplateWithID> getTemplates() {
+
+        return templates;
+    }
+
+    public void setTemplates(List<EmailTemplateWithID> templates) {
+
+        this.templates = templates;
+    }
+
+    public EmailTemplateTypeWithoutTemplates addTemplatesItem(EmailTemplateWithID templatesItem) {
+
+        if (this.templates == null) {
+            this.templates = new ArrayList<>();
+        }
+        this.templates.add(templatesItem);
+        return this;
+    }
+
+    /**
     * Location of the created/updated resource.
     **/
     public EmailTemplateTypeWithoutTemplates self(String self) {
@@ -105,12 +139,15 @@ public class EmailTemplateTypeWithoutTemplates {
         }
         EmailTemplateTypeWithoutTemplates emailTemplateTypeWithoutTemplates = (EmailTemplateTypeWithoutTemplates) o;
         return Objects.equals(this.id, emailTemplateTypeWithoutTemplates.id) &&
-            Objects.equals(this.displayName, emailTemplateTypeWithoutTemplates.displayName);
+                Objects.equals(this.displayName, emailTemplateTypeWithoutTemplates.displayName) &&
+                Objects.equals(this.templates, emailTemplateTypeWithoutTemplates.templates) &&
+                Objects.equals(this.self, emailTemplateTypeWithoutTemplates.self);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, displayName, self);
+
+        return Objects.hash(id, displayName, templates, self);
     }
 
     @Override
@@ -121,6 +158,7 @@ public class EmailTemplateTypeWithoutTemplates {
 
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    templates: ").append(toIndentedString(templates)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/all-inbound-protocols-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/all-inbound-protocols-response.json
@@ -8,10 +8,6 @@
     "displayName": "OAuth/OpenID Connect Configuration"
   },
   {
-    "name": "ws-federation",
-    "displayName": "WS-Federation (Passive) Configuration"
-  },
-  {
     "name": "ws-trust",
     "displayName": "WS-Trust Security Token Service Configuration"
   }

--- a/pom.xml
+++ b/pom.xml
@@ -2045,7 +2045,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.4.0</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.3.2</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.3.3</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->
@@ -2100,7 +2100,7 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
 
         <!-- Identity REST API feature -->
-        <identity.api.dispatcher.version>1.0.96</identity.api.dispatcher.version>
+        <identity.api.dispatcher.version>1.0.97</identity.api.dispatcher.version>
 
         <identity.agent.sso.version>5.4.0</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.4.0</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
- Add integration tests for https://github.com/wso2/identity-api-server/pull/151 feature
- Fix test failure due to https://github.com/wso2/identity-api-server/pull/148 change by editing response in `all-inbound-protocols-response.json`
- Update `testGetAllEmailTemplateTypes` testcase to keep robust even new templates are added 
