### PR TITLE
Integration tests for SAML Metadata endpoint

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -25,10 +25,8 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.tenant.mgt.stub.TenantMgtAdminServiceExceptionException;
-import org.wso2.identity.integration.common.clients.TenantManagementServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.json.JSONObject;
@@ -41,6 +39,8 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
     private static final String SAML_METADATA_ENDPOINT_SUPER_TENANT = "https://localhost:9853/identity/metadata/saml2";
     private static final String SAML_METADATA_ENDPOINT_TENANT =
             "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
+    private static final String SAML_METADATA_ENDPOINT_WITH_SUPER_TENANT_AS_PATH_PARAM =
+            "https://localhost:9853//t/carbon.super/identity/metadata/saml2";
     private static final String SAML_SSO_ENDPOINT_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
     private static final String SAML_SSO_ENDPOINT_SUPER_TENANT = "https://localhost:9853/samlsso";
     private static final String SAMLARTRESOLVE_ENDPOINT = "https://localhost:9853/samlartresolve";
@@ -49,6 +49,7 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
     public void getSAMLMetadata() throws IOException, TenantMgtAdminServiceExceptionException, JSONException {
 
         testResponseContent(SAML_METADATA_ENDPOINT_SUPER_TENANT, SAML_SSO_ENDPOINT_SUPER_TENANT);
+        testResponseContent(SAML_METADATA_ENDPOINT_WITH_SUPER_TENANT_AS_PATH_PARAM, SAML_SSO_ENDPOINT_SUPER_TENANT);
         testResponseContent(SAML_METADATA_ENDPOINT_TENANT, SAML_SSO_ENDPOINT_TENANT);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -39,26 +39,16 @@ import java.io.IOException;
 public class SAMLMetadataTestCase extends ISIntegrationTest {
 
     private static final String SAML_METADATA_ENDPOINT_SUPER_TENANT = "https://localhost:9853/identity/metadata/saml2";
-    private static final String SAML_METADATA_ENDPOINT_TENANT = "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
+    private static final String SAML_METADATA_ENDPOINT_TENANT =
+            "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
     private static final String SAML_SSO_ENDPOINT_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
     private static final String SAML_SSO_ENDPOINT_SUPER_TENANT = "https://localhost:9853/samlsso";
     private static final String SAMLARTRESOLVE_ENDPOINT = "https://localhost:9853/samlartresolve";
-    private TenantManagementServiceClient tenantServiceClient;
-
-    @BeforeClass(alwaysRun = true)
-    public void testInit() throws Exception {
-
-        super.init();
-        tenantServiceClient = new TenantManagementServiceClient(isServer.getContextUrls().getBackEndUrl(),
-                sessionCookie);
-    }
 
     @Test(groups = "wso2.is", description = "This test method will test SAML Metadata endpoints.")
     public void getSAMLMetadata() throws IOException, TenantMgtAdminServiceExceptionException, JSONException {
 
         testResponseContent(SAML_METADATA_ENDPOINT_SUPER_TENANT, SAML_SSO_ENDPOINT_SUPER_TENANT);
-        tenantServiceClient.addTenant("wso2.com", "John", "password",
-                "john@friends.com", "John", "Smith");
         testResponseContent(SAML_METADATA_ENDPOINT_TENANT, SAML_SSO_ENDPOINT_TENANT);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.saml;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.tenant.mgt.stub.TenantMgtAdminServiceExceptionException;
+import org.wso2.identity.integration.common.clients.TenantManagementServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+import org.json.JSONObject;
+import org.json.XML;
+import java.io.IOException;
+
+public class SAMLMetadataTestCase extends ISIntegrationTest {
+
+    private static final String SAML_METADATA_ENDPOINT_SUPER_TENANT = "https://localhost:9853/identity/metadata/saml2";
+    private static final String SAML_METADATA_ENDPOINT_TENANT =
+            "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
+    private static final String TENANT_URL = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
+    private static final String SUPER_TENANT_URL = "https://localhost:9853/samlsso";
+    private TenantManagementServiceClient tenantServiceClient;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init();
+        tenantServiceClient = new TenantManagementServiceClient(isServer.getContextUrls().getBackEndUrl(),
+                sessionCookie);
+    }
+
+    @Test(groups = "wso2.is", description = "This test method will test, invoking SAML Metadata endpoint.")
+    public void getSAMLMetadata() throws IOException, TenantMgtAdminServiceExceptionException, JSONException {
+
+        testResponseContent(SAML_METADATA_ENDPOINT_SUPER_TENANT, SUPER_TENANT_URL);
+        tenantServiceClient.addTenant("wso2.com", "John", "password",
+                "john@friends.com", "John", "Smith");
+        testResponseContent(SAML_METADATA_ENDPOINT_TENANT, TENANT_URL);
+    }
+
+    private void testResponseContent(String samlMetadataEndPoint, String locationUrl)
+            throws IOException, JSONException {
+
+        HttpClient client = HttpClientBuilder.create().build();
+        HttpResponse httpResponse = sendGetRequest(client, samlMetadataEndPoint);
+        String content = DataExtractUtil.getContentData(httpResponse);
+        Assert.assertNotNull(content);
+        JSONArray singleLogoutServices = XML.toJSONObject(content).getJSONObject("EntityDescriptor").getJSONObject(
+                "IDPSSODescriptor").getJSONArray("SingleLogoutService");
+
+        for (int i = 0; i < singleLogoutServices.length(); i++) {
+
+            JSONObject singleLogoutService = singleLogoutServices.getJSONObject(i);
+            Assert.assertEquals(singleLogoutService.getString("Location"),
+                    locationUrl, String.format("Expected location was not received for single logout service in " +
+                            "super tenant mode for the binding %S.", singleLogoutService.getString("Binding")));
+            Assert.assertEquals(singleLogoutService.getString("ResponseLocation"),
+                    locationUrl, String.format("Expected response location was not received for single logout service" +
+                            " in super tenant mode for the binding %S.", singleLogoutService.getString("Binding")));
+        }
+
+        JSONArray singleSignOnServices = XML.toJSONObject(content).getJSONObject("EntityDescriptor").getJSONObject(
+                "IDPSSODescriptor").getJSONArray("SingleSignOnService");
+
+        for (int i = 0; i < singleSignOnServices.length(); i++) {
+            JSONObject singleSignOnService = singleSignOnServices.getJSONObject(i);
+            Assert.assertEquals(singleSignOnService.getString("Location"),
+                    locationUrl, String.format("Expected location was not received for single sign-on service in " +
+                            "super tenant mode for the binding %S.", singleSignOnService.getString("Binding")));
+        }
+    }
+
+    private HttpResponse sendGetRequest(HttpClient client, String locationURL) throws IOException {
+
+        HttpGet getRequest = new HttpGet(locationURL);
+        HttpResponse response = client.execute(getRequest);
+        return response;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -40,13 +40,13 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
     private static final String SAML_METADATA_ENDPOINT_TENANT =
             "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
     private static final String SAML_METADATA_ENDPOINT_WITH_SUPER_TENANT_AS_PATH_PARAM =
-            "https://localhost:9853//t/carbon.super/identity/metadata/saml2";
+            "https://localhost:9853/t/carbon.super/identity/metadata/saml2";
     private static final String SAML_SSO_ENDPOINT_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
     private static final String SAML_SSO_ENDPOINT_SUPER_TENANT = "https://localhost:9853/samlsso";
     private static final String SAMLARTRESOLVE_ENDPOINT = "https://localhost:9853/samlartresolve";
 
     @Test(groups = "wso2.is", description = "This test method will test SAML Metadata endpoints.")
-    public void getSAMLMetadata() throws IOException, TenantMgtAdminServiceExceptionException, JSONException {
+    public void getSAMLMetadata() throws IOException, JSONException {
 
         testResponseContent(SAML_METADATA_ENDPOINT_SUPER_TENANT, SAML_SSO_ENDPOINT_SUPER_TENANT);
         testResponseContent(SAML_METADATA_ENDPOINT_WITH_SUPER_TENANT_AS_PATH_PARAM, SAML_SSO_ENDPOINT_SUPER_TENANT);
@@ -59,7 +59,7 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
         HttpClient client = HttpClientBuilder.create().build();
         HttpResponse httpResponse = sendGetRequest(client, samlMetadataEndpoint);
         String content = DataExtractUtil.getContentData(httpResponse);
-        Assert.assertNotNull(content);
+        Assert.assertNotNull(content, "Response content is not received");
 
         JSONArray singleLogoutServices = XML.toJSONObject(content).getJSONObject("EntityDescriptor").getJSONObject(
                 "IDPSSODescriptor").getJSONArray("SingleLogoutService");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -69,11 +69,10 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
         HttpResponse httpResponse = sendGetRequest(client, locationURL);
         String content = DataExtractUtil.getContentData(httpResponse);
         Assert.assertNotNull(content);
+
         JSONArray singleLogoutServices = XML.toJSONObject(content).getJSONObject("EntityDescriptor").getJSONObject(
                 "IDPSSODescriptor").getJSONArray("SingleLogoutService");
-
         for (int i = 0; i < singleLogoutServices.length(); i++) {
-
             JSONObject singleLogoutService = singleLogoutServices.getJSONObject(i);
             Assert.assertEquals(singleLogoutService.getString("Location"),
                     samlMetadataEndpoint, String.format("Expected location was not received for single logout" +
@@ -85,7 +84,6 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
 
         JSONArray singleSignOnServices = XML.toJSONObject(content).getJSONObject("EntityDescriptor").getJSONObject(
                 "IDPSSODescriptor").getJSONArray("SingleSignOnService");
-
         for (int i = 0; i < singleSignOnServices.length(); i++) {
             JSONObject singleSignOnService = singleSignOnServices.getJSONObject(i);
             Assert.assertEquals(singleSignOnService.getString("Location"),

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -53,7 +53,7 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
                 sessionCookie);
     }
 
-    @Test(groups = "wso2.is", description = "This test method will test, invoking SAML Metadata endpoint.")
+    @Test(groups = "wso2.is", description = "This test method will test SAML Metadata endpoints.")
     public void getSAMLMetadata() throws IOException, TenantMgtAdminServiceExceptionException, JSONException {
 
         testResponseContent(SUPER_TENANT_URL, SAML_METADATA_ENDPOINT_SUPER_TENANT);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLMetadataTestCase.java
@@ -38,10 +38,10 @@ import java.io.IOException;
 
 public class SAMLMetadataTestCase extends ISIntegrationTest {
 
-    private static final String SUPER_TENANT_URL = "https://localhost:9853/identity/metadata/saml2";
-    private static final String TENANT_URL = "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
-    private static final String SAML_METADATA_ENDPOINT_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
-    private static final String SAML_METADATA_ENDPOINT_SUPER_TENANT = "https://localhost:9853/samlsso";
+    private static final String SAML_METADATA_ENDPOINT_SUPER_TENANT = "https://localhost:9853/identity/metadata/saml2";
+    private static final String SAML_METADATA_ENDPOINT_TENANT = "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
+    private static final String SAML_SSO_ENDPOINT_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
+    private static final String SAML_SSO_ENDPOINT_SUPER_TENANT = "https://localhost:9853/samlsso";
     private static final String SAMLARTRESOLVE_ENDPOINT = "https://localhost:9853/samlartresolve";
     private TenantManagementServiceClient tenantServiceClient;
 
@@ -56,17 +56,17 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
     @Test(groups = "wso2.is", description = "This test method will test SAML Metadata endpoints.")
     public void getSAMLMetadata() throws IOException, TenantMgtAdminServiceExceptionException, JSONException {
 
-        testResponseContent(SUPER_TENANT_URL, SAML_METADATA_ENDPOINT_SUPER_TENANT);
+        testResponseContent(SAML_METADATA_ENDPOINT_SUPER_TENANT, SAML_SSO_ENDPOINT_SUPER_TENANT);
         tenantServiceClient.addTenant("wso2.com", "John", "password",
                 "john@friends.com", "John", "Smith");
-        testResponseContent(TENANT_URL, SAML_METADATA_ENDPOINT_TENANT);
+        testResponseContent(SAML_METADATA_ENDPOINT_TENANT, SAML_SSO_ENDPOINT_TENANT);
     }
 
-    private void testResponseContent(String locationURL, String samlMetadataEndpoint)
+    private void testResponseContent(String samlMetadataEndpoint, String samlEndpoint)
             throws IOException, JSONException {
 
         HttpClient client = HttpClientBuilder.create().build();
-        HttpResponse httpResponse = sendGetRequest(client, locationURL);
+        HttpResponse httpResponse = sendGetRequest(client, samlMetadataEndpoint);
         String content = DataExtractUtil.getContentData(httpResponse);
         Assert.assertNotNull(content);
 
@@ -75,10 +75,10 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
         for (int i = 0; i < singleLogoutServices.length(); i++) {
             JSONObject singleLogoutService = singleLogoutServices.getJSONObject(i);
             Assert.assertEquals(singleLogoutService.getString("Location"),
-                    samlMetadataEndpoint, String.format("Expected location was not received for single logout" +
+                    samlEndpoint, String.format("Expected location was not received for single logout" +
                             " service for the binding %S.", singleLogoutService.getString("Binding")));
             Assert.assertEquals(singleLogoutService.getString("ResponseLocation"),
-                    samlMetadataEndpoint, String.format("Expected response location was not received for single " +
+                    samlEndpoint, String.format("Expected response location was not received for single " +
                             "logout service for the binding %S.", singleLogoutService.getString("Binding")));
         }
 
@@ -87,7 +87,7 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
         for (int i = 0; i < singleSignOnServices.length(); i++) {
             JSONObject singleSignOnService = singleSignOnServices.getJSONObject(i);
             Assert.assertEquals(singleSignOnService.getString("Location"),
-                    samlMetadataEndpoint, String.format("Expected location was not received for single sign-on " +
+                    samlEndpoint, String.format("Expected location was not received for single sign-on " +
                             "service for the binding %S.", singleSignOnService.getString("Binding")));
         }
 
@@ -99,9 +99,9 @@ public class SAMLMetadataTestCase extends ISIntegrationTest {
                         "service for the binding %S.", artifactResolutionService.getString("Binding")));
     }
 
-    private HttpResponse sendGetRequest(HttpClient client, String locationURL) throws IOException {
+    private HttpResponse sendGetRequest(HttpClient client, String samlMetadataEndpoint) throws IOException {
 
-        HttpGet getRequest = new HttpGet(locationURL);
+        HttpGet getRequest = new HttpGet(samlMetadataEndpoint);
         HttpResponse response = client.execute(getRequest);
         return response;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -74,6 +74,7 @@
             <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
             <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
             <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>
             <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
             <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
             <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>


### PR DESCRIPTION
**Description**

Add integration tests for SAML Metadata endpoint. Tests for the following expected behaviors.
- **For Super Tenant Legacy Mode**: No endpoint in the metadata document should have the tenant domain as a path param nor a query param
- **For Tenant Legacy Mode**: All the endpoints in the metadata document except for the /samlartresove should append the tenant domain as a query param. /samlartresolve endpoint should not have the tenant domain as a path param nor a query param.
