### PR TITLE
Add introspection endpoint in legacy tenant URL mode to OIDC Metadata Test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OIDCMetadataTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OIDCMetadataTest.java
@@ -45,7 +45,8 @@ public class OIDCMetadataTest extends ISIntegrationTest {
             "https://localhost:9853/t/wso2.com/oauth2/oidcdiscovery/.well-known/openid-configuration";
     private static final String OIDCDISCOVERY_ENDPOINT_WITH_SUPER_TENANT_AS_PATH_PARAM =
             "https://localhost:9853/t/carbon.super/oauth2/oidcdiscovery/.well-known/openid-configuration";
-    private static final String INTROSPECTION_ENDPOINT = "https://localhost:9853/oauth2/introspect";
+    private static final String INTROSPECTION_ENDPOINT_SUPER_TENANT = "https://localhost:9853/oauth2/introspect";
+    private static final String INTROSPECTION_ENDPOINT_TENANT = "https://localhost:9853/t/wso2.com/oauth2/introspect";
     private static final String CHECK_SESSION_IFRAME = "https://localhost:9853/oidc/checksession";
     private static final String ISSUER = "https://localhost:9853/oauth2/token";
     private static final String AUTHORIZATION_ENDPOINT = "https://localhost:9853/oauth2/authorize";
@@ -79,8 +80,6 @@ public class OIDCMetadataTest extends ISIntegrationTest {
         Assert.assertNotNull(content, "Response content is not received");
 
         JSONObject oidcMetadataEndpoints = new JSONObject(content);
-        Assert.assertEquals(oidcMetadataEndpoints.getString("introspection_endpoint"),
-                INTROSPECTION_ENDPOINT, "Incorrect introspection endpoint");
         Assert.assertEquals(oidcMetadataEndpoints.getString("check_session_iframe"),
                 CHECK_SESSION_IFRAME, "Incorrect session iframe");
         Assert.assertEquals(oidcMetadataEndpoints.getString("issuer"),
@@ -104,6 +103,8 @@ public class OIDCMetadataTest extends ISIntegrationTest {
                     JKWS_URI_SUPER_TENANT, "Incorrect jwks uri");
             Assert.assertEquals(oidcMetadataEndpoints.getString("registration_endpoint"),
                     REGISTRATION_ENDPOINT_SUPER_TENANT, "Incorrect registration endpoint");
+            Assert.assertEquals(oidcMetadataEndpoints.getString("introspection_endpoint"),
+                    INTROSPECTION_ENDPOINT_SUPER_TENANT, "Incorrect introspection endpoint");
         }
 
         if (oidcMetadataEndpoint.equals(TOKEN_ENDPOINT_TENANT) ||
@@ -112,6 +113,8 @@ public class OIDCMetadataTest extends ISIntegrationTest {
                     JKWS_URI_TENANT, "Incorrect jwks uri");
             Assert.assertEquals(oidcMetadataEndpoints.getString("registration_endpoint"),
                     REGISTRATION_ENDPOINT_TENANT, "Incorrect registration endpoint");
+            Assert.assertEquals(oidcMetadataEndpoints.getString("introspection_endpoint"),
+                    INTROSPECTION_ENDPOINT_TENANT, "Incorrect introspection endpoint");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2017,7 +2017,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.10</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.4.30</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.4.31</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.5.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.5.4</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.0</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolves: https://github.com/wso2/product-is/issues/8521
- Add Introspection endpoint URL for both super tenant and tenant to OIDC Metadata Test

### When should this PR be merged
This PR should be merged after https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1399

### Follow up actions
After merging https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1399 the released identity-inbound-auth-oauth version should be updated before merging this.
 
