### PR TITLE
Update the badges and improve build info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ Welcome to WSO2 Identity Server
 
 ---
 
-
 |  Branch | Build Status | Test Results |
 | :------------ |:------------- |:-------------
 | master      | [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fjob%2Fproducts%2Fjob%2Fproduct-is%2F&style=flat)](https://wso2.org/jenkins/job/products/job/product-is/) | [![Test Results](https://img.shields.io/jenkins/tests?compact_message&failed_label=failed&jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fjob%2Fproducts%2Fjob%2Fproduct-is%2F&passed_label=passed&skipped_label=skipped)](https://wso2.org/jenkins/job/products/job/product-is/lastBuild/testReport/) |
 
 
-
+[![Stackoverflow](https://img.shields.io/badge/Ask%20for%20help%20on-Stackoverflow-orange)](https://stackoverflow.com/questions/tagged/wso2is)
 [![Join the chat at https://join.slack.com/t/wso2is/shared_invite/enQtNzk0MTI1OTg5NjM1LTllODZiMTYzMmY0YzljYjdhZGExZWVkZDUxOWVjZDJkZGIzNTE1NDllYWFhM2MyOGFjMDlkYzJjODJhOWQ4YjE](https://img.shields.io/badge/Join%20us%20on-Slack-%23e01563.svg)](https://join.slack.com/t/wso2is/shared_invite/enQtNzk0MTI1OTg5NjM1LTllODZiMTYzMmY0YzljYjdhZGExZWVkZDUxOWVjZDJkZGIzNTE1NDllYWFhM2MyOGFjMDlkYzJjODJhOWQ4YjE)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/wso2/product-is/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/wso2.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=wso2)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Welcome to WSO2 Identity Server
 
 ---
 
-|  Branch | Build Status |
-| :------------ |:-------------
-| master      | [![Build Status](https://wso2.org/jenkins/job/products/job/product-is/badge/icon)](https://wso2.org/jenkins/job/products/job/product-is) |
+
+|  Branch | Build Status | Test Results |
+| :------------ |:------------- |:-------------
+| master      | [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fjob%2Fproducts%2Fjob%2Fproduct-is%2F&style=flat)](https://wso2.org/jenkins/job/products/job/product-is/) | [![Test Results](https://img.shields.io/jenkins/tests?compact_message&failed_label=failed&jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fjob%2Fproducts%2Fjob%2Fproduct-is%2F&passed_label=passed&skipped_label=skipped)](https://wso2.org/jenkins/job/products/job/product-is/lastBuild/testReport/) |
 
 
 


### PR DESCRIPTION
Update the README.md file with improved build info and added the stackoverflow badge to it.

- Added the build status image which is currently not shown.
- Added a new column to represent the test results.
- Added the stackoverflow badge link the tag _**wso2is**_

**The current README.md file is seen as:**
![Screenshot from 2020-06-23 06-32-33](https://user-images.githubusercontent.com/33062368/85349161-59967b00-b51b-11ea-8a98-8ae5e8785abf.png)

**with this fix it will be seen as:**
![Screenshot from 2020-06-23 06-34-55](https://user-images.githubusercontent.com/33062368/85349272-aed28c80-b51b-11ea-8b2c-5740deeeda43.png)
