### PR TITLE
 Add integration tests for samlsso legacy URL mode

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
@@ -284,7 +284,7 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         }
     }
 
-    public void createApplicationForSAMLAartResolve(SAMLConfig config, String appName) throws Exception {
+    public void createApplicationForSAMLArtResolve(SAMLConfig config, String appName) throws Exception {
 
         samlArtResolve = true;
         createApplication(config, appName);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
@@ -32,6 +32,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.application.common.model.xsd.InboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.xsd.InboundAuthenticationRequestConfig;
+import org.wso2.carbon.identity.application.common.model.xsd.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.xsd.Property;
 import org.wso2.carbon.identity.application.common.model.xsd.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
@@ -75,6 +76,7 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
     private static final String emailClaimURI = "http://wso2.org/claims/emailaddress";
 
     private static final String profileName = "default";
+    private static Boolean samlArtResolve = false;
 
     private ApplicationManagementServiceClient applicationManagementServiceClient;
     protected SAMLSSOConfigServiceClient ssoConfigServiceClient;
@@ -171,6 +173,8 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
 
         SUPER_TENANT_APP_WITH_SIGNING("travelocity.com", true),
         TENANT_APP_WITHOUT_SIGNING("travelocity.com-saml-tenantwithoutsigning", false),
+        SUPER_TENANT_APP_WITH_SAMLARTIFACT_CONFIG("travelocity.com-saml-artifactresolving", false),
+        TENANT_APP_WITH_SAMLARTIFACT_CONFIG("travelocity.com-saml-tenant-artifactresolving", false),
         ECP_APP("https://localhost/ecp-sp", false);
 
         private String artifact;
@@ -280,6 +284,12 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         }
     }
 
+    public void createApplicationForSAMLAartResolve(SAMLConfig config, String appName) throws Exception {
+
+        samlArtResolve =true;
+        createApplication(config, appName);
+    }
+
     public void createApplication(SAMLConfig config, String appName) throws Exception {
 
         ServiceProvider serviceProvider = new ServiceProvider();
@@ -309,6 +319,13 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
             requestPathAuthenticatorConfig.setName("BasicAuthRequestPathAuthenticator");
             serviceProvider.setRequestPathAuthenticatorConfigs(
                     new RequestPathAuthenticatorConfig[]{requestPathAuthenticatorConfig});
+        }
+
+        if (samlArtResolve) {
+        LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig =
+                new LocalAndOutboundAuthenticationConfig();
+        localAndOutboundAuthenticationConfig.setSkipConsent(true);
+        serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutboundAuthenticationConfig);
         }
         serviceProvider.setInboundAuthenticationConfig(inboundAuthenticationConfig);
         applicationManagementServiceClient.updateApplicationData(serviceProvider);
@@ -403,6 +420,16 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         return idpInitSpDTO;
     }
 
+    /**
+     * @param config contains the details of the SAML artifact binding enabled service provider application.
+     * @return the created SAMLSSOServiceProviderDTO.
+     */
+    public SAMLSSOServiceProviderDTO createSsoSPDTOForSAMLartifactBinding(SAMLConfig config){
+        SAMLSSOServiceProviderDTO idpInitSpDTO = createSsoSPDTO(config);
+        idpInitSpDTO.setEnableSAML2ArtifactBinding(true);
+        return idpInitSpDTO;
+    }
+
     public SAMLSSOServiceProviderDTO createSsoServiceProviderDTO(SAMLConfig config){
         return createSsoSPDTO(config);
     }
@@ -424,7 +451,6 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
             samlssoServiceProviderDTO.setEnableAttributeProfile(true);
             samlssoServiceProviderDTO.setEnableAttributesByDefault(true);
         }
-
         return samlssoServiceProviderDTO;
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
@@ -286,7 +286,7 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
 
     public void createApplicationForSAMLAartResolve(SAMLConfig config, String appName) throws Exception {
 
-        samlArtResolve =true;
+        samlArtResolve = true;
         createApplication(config, appName);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLARTRESOLVETestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLARTRESOLVETestCase.java
@@ -42,7 +42,6 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
     private static final Log log = LogFactory.getLog(SAMLSSOTestCase.class);
 
     private SAMLConfig config;
-    private String resultPage;
 
     @Factory(dataProvider = "samlConfigProvider")
     public SAMLARTRESOLVETestCase(SAMLConfig config) {
@@ -59,7 +58,7 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
         super.init(config.getUserMode());
         super.testInit();
         super.createUser(config);
-        super.createApplicationForSAMLAartResolve(config, config.getApp().getArtifact());
+        super.createApplicationForSAMLArtResolve(config, config.getApp().getArtifact());
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLARTRESOLVETestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLARTRESOLVETestCase.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.identity.integration.test.saml;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
+import org.wso2.identity.integration.test.util.Utils;
+import org.wso2.identity.integration.test.utils.CommonConstants;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
+
+    private static final Log log = LogFactory.getLog(SAMLSSOTestCase.class);
+
+    private SAMLConfig config;
+    private String resultPage;
+
+    @Factory(dataProvider = "samlConfigProvider")
+    public SAMLARTRESOLVETestCase(SAMLConfig config) {
+
+        if (log.isDebugEnabled()){
+            log.info("SAML Artifact Binding Test initialized for " + config);
+        }
+        this.config = config;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(config.getUserMode());
+        super.testInit();
+        super.createUser(config);
+        super.createApplicationForSAMLAartResolve(config, config.getApp().getArtifact());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testClear() throws Exception{
+
+        super.deleteUser(config);
+        super.deleteApplication(config.getApp().getArtifact());
+        super.testClear();
+    }
+
+    @Test(alwaysRun = true, description = "Testing SAML SSO login", groups = "wso2.is")
+    public void testSAMLSSOLogin() {
+        try {
+            HttpResponse response;
+            Boolean isAddSuccess = ssoConfigServiceClient.
+                    addServiceProvider(super.createSsoSPDTOForSAMLartifactBinding(config));
+            Assert.assertTrue(isAddSuccess, "Adding a service provider has failed for " + config);
+
+            SAMLSSOServiceProviderDTO[] samlssoServiceProviderDTOs = ssoConfigServiceClient
+                    .getServiceProviders().getServiceProviders();
+            Assert.assertEquals(samlssoServiceProviderDTOs[0].getIssuer(), config.getApp().getArtifact(),
+                    "Adding a service provider has failed for " + config);
+
+            response = Utils.sendGetRequest(String.format(SAML_SSO_LOGIN_URL, config.getApp().getArtifact(), config
+                    .getHttpBinding().binding), USER_AGENT, httpClient);
+
+            String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
+            response = Utils.sendPOSTMessage(sessionKey, SAML_SSO_URL, USER_AGENT, ACS_URL, config.getApp()
+                    .getArtifact(), config.getUser().getUsername(), config.getUser().getPassword(), httpClient);
+
+            if (requestMissingClaims(response)) {
+                String pastrCookie = Utils.getPastreCookie(response);
+                Assert.assertNotNull(pastrCookie, "pastr cookie not found in response.");
+                EntityUtils.consume(response.getEntity());
+
+                response = Utils.sendPOSTConsentMessage(response, COMMON_AUTH_URL, USER_AGENT,
+                        String.format(ACS_URL, config.getApp()
+                                .getArtifact()), httpClient, pastrCookie);
+                EntityUtils.consume(response.getEntity());
+            }
+
+            String samlRedirectUrl = Utils.getRedirectUrl(response);
+            Assert.assertTrue(samlRedirectUrl.contains("SAMLart"), "SAML artifact binding failed for " + config);
+            EntityUtils.consume(response.getEntity());
+            response = Utils.sendGetRequest(samlRedirectUrl, USER_AGENT, httpClient);
+            String samlRedirectPage = extractDataFromResponse(response);
+            EntityUtils.consume(response.getEntity());
+
+            Assert.assertTrue(samlRedirectPage.contains("You are logged in as " +
+                            config.getUser().getTenantAwareUsername()),
+                    "SAML artifact binding failed for " + config);
+
+            Boolean isRemoveSuccess = ssoConfigServiceClient.removeServiceProvider(config.getApp().getArtifact());
+            Assert.assertTrue(isRemoveSuccess, "Removing a service provider has failed for " + config);
+
+        } catch (Exception e) {
+            Assert.fail("SAML SSO Login test failed for " + config, e);
+        }
+    }
+
+    @DataProvider(name = "samlConfigProvider")
+    public static Object[][] samlConfigProvider(){
+        return  new SAMLConfig[][]{
+                {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_REDIRECT,
+                        ClaimType.NONE, App.SUPER_TENANT_APP_WITH_SIGNING)},
+                {new SAMLConfig(TestUserMode.TENANT_ADMIN, User.TENANT_USER, HttpBinding.HTTP_REDIRECT,
+                        ClaimType.NONE, App.TENANT_APP_WITHOUT_SIGNING)},
+        };
+    }
+
+    private String extractDataFromResponse(HttpResponse response) throws IOException {
+        BufferedReader rd = new BufferedReader(
+                new InputStreamReader(response.getEntity().getContent()));
+        StringBuilder result = new StringBuilder();
+        String line;
+        while ((line = rd.readLine()) != null) {
+            result.append(line);
+        }
+        rd.close();
+        return result.toString();
+    }
+
+    private Map<String,String> extractClaims(String claimString){
+        String[] dataArray = StringUtils.substringsBetween(claimString, "<td>", "</td>");
+        Map<String,String> attributeMap = new HashMap<String, String>();
+        String key = null;
+        String value;
+        for (int i = 0; i< dataArray.length; i++){
+            if((i%2) == 0){
+                key = dataArray[i];
+            }else{
+                value = dataArray[i].trim();
+                attributeMap.put(key,value);
+            }
+        }
+
+        return attributeMap;
+    }
+
+    private boolean requestMissingClaims (HttpResponse response) {
+
+        String redirectUrl = Utils.getRedirectUrl(response);
+        return redirectUrl.contains("consent.do");
+
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLARTRESOLVETestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLARTRESOLVETestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -36,8 +36,6 @@ import org.wso2.identity.integration.test.utils.CommonConstants;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.Map;
 
 public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
 
@@ -49,7 +47,7 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
     @Factory(dataProvider = "samlConfigProvider")
     public SAMLARTRESOLVETestCase(SAMLConfig config) {
 
-        if (log.isDebugEnabled()){
+        if (log.isDebugEnabled()) {
             log.info("SAML Artifact Binding Test initialized for " + config);
         }
         this.config = config;
@@ -65,7 +63,7 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
     }
 
     @AfterClass(alwaysRun = true)
-    public void testClear() throws Exception{
+    public void testClear() throws Exception {
 
         super.deleteUser(config);
         super.deleteApplication(config.getApp().getArtifact());
@@ -92,17 +90,6 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
             response = Utils.sendPOSTMessage(sessionKey, SAML_SSO_URL, USER_AGENT, ACS_URL, config.getApp()
                     .getArtifact(), config.getUser().getUsername(), config.getUser().getPassword(), httpClient);
 
-            if (requestMissingClaims(response)) {
-                String pastrCookie = Utils.getPastreCookie(response);
-                Assert.assertNotNull(pastrCookie, "pastr cookie not found in response.");
-                EntityUtils.consume(response.getEntity());
-
-                response = Utils.sendPOSTConsentMessage(response, COMMON_AUTH_URL, USER_AGENT,
-                        String.format(ACS_URL, config.getApp()
-                                .getArtifact()), httpClient, pastrCookie);
-                EntityUtils.consume(response.getEntity());
-            }
-
             String samlRedirectUrl = Utils.getRedirectUrl(response);
             Assert.assertTrue(samlRedirectUrl.contains("SAMLart"), "SAML artifact binding failed for " + config);
             EntityUtils.consume(response.getEntity());
@@ -123,8 +110,8 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
     }
 
     @DataProvider(name = "samlConfigProvider")
-    public static Object[][] samlConfigProvider(){
-        return  new SAMLConfig[][]{
+    public static Object[][] samlConfigProvider() {
+        return new SAMLConfig[][]{
                 {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_REDIRECT,
                         ClaimType.NONE, App.SUPER_TENANT_APP_WITH_SIGNING)},
                 {new SAMLConfig(TestUserMode.TENANT_ADMIN, User.TENANT_USER, HttpBinding.HTTP_REDIRECT,
@@ -142,29 +129,5 @@ public class SAMLARTRESOLVETestCase extends AbstractSAMLSSOTestCase {
         }
         rd.close();
         return result.toString();
-    }
-
-    private Map<String,String> extractClaims(String claimString){
-        String[] dataArray = StringUtils.substringsBetween(claimString, "<td>", "</td>");
-        Map<String,String> attributeMap = new HashMap<String, String>();
-        String key = null;
-        String value;
-        for (int i = 0; i< dataArray.length; i++){
-            if((i%2) == 0){
-                key = dataArray[i];
-            }else{
-                value = dataArray[i].trim();
-                attributeMap.put(key,value);
-            }
-        }
-
-        return attributeMap;
-    }
-
-    private boolean requestMissingClaims (HttpResponse response) {
-
-        String redirectUrl = Utils.getRedirectUrl(response);
-        return redirectUrl.contains("consent.do");
-
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSSOTestCase.java
@@ -54,7 +54,9 @@ public class SAMLIdPInitiatedSSOTestCase extends AbstractSAMLSSOTestCase {
     private Log log = LogFactory.getLog(getClass());
 
     private static final String SP_NAME = "travelocity.com";
-    private static final String IDP_INIT_SSO_URL = "https://localhost:%s/samlsso?spEntityID=travelocity.com";
+    private static final String IDP_INIT_SSO_URL = "https://localhost:%s/samlsso?spEntityID=%s";
+    private static final String IDP_INIT_SSO_TENANT_URL
+            = "https://localhost:%s/samlsso?tenantDomain=wso2.com&spEntityID=%s";
     private static final String SAML_SSO_URL = "https://localhost:%s/samlsso";
     private static final String SP_ACS_URL = "http://localhost:8490/%s/home.jsp";
     private HttpClient httpClient;
@@ -76,13 +78,27 @@ public class SAMLIdPInitiatedSSOTestCase extends AbstractSAMLSSOTestCase {
         return new SAMLConfig[][]{
                 {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_REDIRECT,
                         ClaimType.NONE, App.SUPER_TENANT_APP_WITH_SIGNING)},
+                {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_REDIRECT,
+                        ClaimType.LOCAL, App.SUPER_TENANT_APP_WITH_SIGNING)},
+                {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_POST,
+                        ClaimType.NONE, App.SUPER_TENANT_APP_WITH_SIGNING)},
+                {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_POST,
+                        ClaimType.LOCAL, App.SUPER_TENANT_APP_WITH_SIGNING)},
+                {new SAMLConfig(TestUserMode.TENANT_ADMIN, User.TENANT_USER, HttpBinding.HTTP_REDIRECT,
+                        ClaimType.NONE, App.TENANT_APP_WITHOUT_SIGNING)},
+                {new SAMLConfig(TestUserMode.TENANT_ADMIN, User.TENANT_USER, HttpBinding.HTTP_REDIRECT,
+                        ClaimType.LOCAL, App.TENANT_APP_WITHOUT_SIGNING)},
+                {new SAMLConfig(TestUserMode.TENANT_ADMIN, User.TENANT_USER, HttpBinding.HTTP_POST,
+                        ClaimType.NONE, App.TENANT_APP_WITHOUT_SIGNING)},
+                {new SAMLConfig(TestUserMode.TENANT_ADMIN, User.TENANT_USER, HttpBinding.HTTP_POST,
+                        ClaimType.LOCAL, App.TENANT_APP_WITHOUT_SIGNING)},
         };
     }
 
     @BeforeClass(alwaysRun = true)
     public void initTest() throws Exception {
 
-        super.init();
+        super.init(samlConfig.getUserMode());
         super.testInit();
         addServiceProvider();
         httpClient = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).disableRedirectHandling().build();
@@ -93,17 +109,23 @@ public class SAMLIdPInitiatedSSOTestCase extends AbstractSAMLSSOTestCase {
     public void testClear() throws Exception {
 
         super.deleteUser(samlConfig);
-        super.ssoConfigServiceClient.removeServiceProvider(SP_NAME);
-        super.deleteApplication(SP_NAME);
+        super.ssoConfigServiceClient.removeServiceProvider(samlConfig.getApp().getArtifact());
+        super.deleteApplication(samlConfig.getApp().getArtifact());
         super.testClear();
     }
 
     @Test(groups = "wso2.is", description = "This test method will test the IdP initiated SAML SSO process.")
     public void testIdPInitiatedSSO() throws Exception {
 
-        HttpResponse idpInitResponse =
-                Utils.sendGetRequest(String.format(IDP_INIT_SSO_URL, IS_DEFAULT_HTTPS_PORT), USER_AGENT,
-                        httpClient);
+        HttpResponse idpInitResponse;
+        if (samlConfig.getUserMode().name().equals("TENANT_ADMIN")) {
+            idpInitResponse = Utils.sendGetRequest(String.format(IDP_INIT_SSO_TENANT_URL, IS_DEFAULT_HTTPS_PORT,
+                    samlConfig.getApp().getArtifact()), USER_AGENT, httpClient);
+        } else {
+            idpInitResponse = Utils.sendGetRequest(String.format(IDP_INIT_SSO_URL, IS_DEFAULT_HTTPS_PORT,
+                    samlConfig.getApp().getArtifact()), USER_AGENT, httpClient);
+        }
+
         String redirectUrl = Utils.getRedirectUrl(idpInitResponse);
         Assert.assertTrue(redirectUrl.contains("/authenticationendpoint/login.do"), "Cannot find the login page.");
 
@@ -121,13 +143,13 @@ public class SAMLIdPInitiatedSSOTestCase extends AbstractSAMLSSOTestCase {
         HttpResponse samlRedirectResponse = Utils.sendGetRequest(samlRedirectUrl, USER_AGENT, httpClient);
 
         String samlRedirectPage = extractDataFromResponse(samlRedirectResponse);
-        Assert.assertTrue(samlRedirectPage.contains(String.format(SP_ACS_URL, SP_NAME)), "Cannot find the assertion " +
+        Assert.assertTrue(samlRedirectPage.contains(String.format(SP_ACS_URL, samlConfig.getApp().getArtifact())), "Cannot find the assertion " +
                 "consumer URL in the resulting page.");
     }
 
     private void addServiceProvider() throws Exception {
 
-        super.createApplication(samlConfig, SP_NAME);
+        super.createApplication(samlConfig, samlConfig.getApp().getArtifact());
         super.ssoConfigServiceClient.addServiceProvider(super.createSsoSPDTOForIdPInit(samlConfig));
         log.info("Service Provider " + samlConfig.getApp().getArtifact() + " created.");
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/org.wso2.sample.is.sso.agent/travelocity.properties
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/org.wso2.sample.is.sso.agent/travelocity.properties
@@ -65,6 +65,10 @@ SAML2.EnableAssertionEncryption=false
 #Specify if AuthnRequests and LogoutRequests should be signed
 SAML2.EnableRequestSigning=true
 
+SAML2.ArtifactResolveUrl=https://localhost:9853/samlartresolve
+
+SAML2.EnableArtifactResolveSigning=true
+
 #Password of the KeyStore for SAML and OpenID
 KeyStorePassword=wso2carbon
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/tenantwithoutsigning/travelocity.properties
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/tenantwithoutsigning/travelocity.properties
@@ -67,6 +67,10 @@ SAML2.EnableAssertionEncryption=false
 #Specify if AuthnRequests and LogoutRequests should be signed
 SAML2.EnableRequestSigning=true
 
+SAML2.ArtifactResolveUrl=https://localhost:9853/samlartresolve
+
+SAML2.EnableArtifactResolveSigning=true
+
 #Password of the KeyStore for SAML and OpenID
 KeyStorePassword=wso2carbon
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -28,6 +28,7 @@
 
     <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
+            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>
             <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
             <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -28,7 +28,6 @@
 
     <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
-            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>
             <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
             <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
@@ -114,6 +113,7 @@
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />
             <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />
             <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION

### **Description**

This PR will add integration tests for oauth2 endpoints for legacy URL mode.

- Add tests for the samlartresolve endpoint for both tenant and super tenant legacy URL mode.
- Add tests for samlsso, IDP initiated samlsso and saml invalid issuer for tenant legacy URL mode.

Related issue: #8524