### PR TITLE
Ship all wars in exploded format

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -515,6 +515,142 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/developer-portal.war" />
 
+                                <!-- Explode the api#health-check#v1.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#health-check#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#health-check#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#health-check#v1.0.war" />
+
+                                <!-- Explode the api#identity#config-mgt#v1.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#config-mgt#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#config-mgt#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#config-mgt#v1.0.war" />
+
+                                <!-- Explode the api#identity#consent-mgt#v1.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#consent-mgt#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#consent-mgt#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#consent-mgt#v1.0.war" />
+
+                                <!-- Explode the api#identity#entitlement.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#entitlement">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#entitlement.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#entitlement.war" />
+
+                                <!-- Explode the api#identity#oauth2#dcr#v1.1.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#dcr#v1.1">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#oauth2#dcr#v1.1.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#dcr#v1.1.war" />
+
+                                <!-- Explode the api#identity#oauth2#uma#permission#v1.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#oauth2#uma#permission#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0.war" />
+
+                                <!-- Explode the api#identity#oauth2#uma#resourceregistration#v1.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#oauth2#uma#resourceregistration#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#resourceregistration#v1.0.war" />
+
+                                <!-- Explode the api#identity#oauth2#v1.0.war-->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#oauth2#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#v1.0.war" />
+
+                                <!-- Explode the api#identity#recovery#v0.9.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#recovery#v0.9">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#recovery#v0.9.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#recovery#v0.9.war" />
+
+                                <!-- Explode the api#identity#template#mgt#v1.0.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#template#mgt#v1.0.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#template#mgt#v1.0.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#template#mgt#v1.0.0.war" />
+
+                                <!-- Explode the api#identity#user#v1.0.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#user#v1.0">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#user#v1.0.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#user#v1.0.war" />
+
+                                <!-- Explode the api#users#v2#me#webauthn.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#users#v2#me#webauthn">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#users#v2#me#webauthn.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#users#v2#me#webauthn.war" />
+
+                                <!-- Explode the lsp.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/lsp">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="lsp.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/lsp.war" />
+
+                                <!-- Explode the mexut.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/mexut">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="mexut.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/mexut.war" />
+
+                                <!-- Explode the scim2.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/scim2">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="scim2.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/scim2.war" />
+
+                                <!-- Explode the oauth2.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/oauth2">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="oauth2.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/oauth2.war" />
+
+                                <!-- Explode the wso2.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/wso2">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="wso2.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/wso2.war" />
+
                                 <!-- Explode the admin-portal.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/admin-portal">
                                     <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -604,12 +604,12 @@
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#user#v1.0.war" />
 
                                 <!-- Explode the api#users#v2#me#webauthn.war -->
-                                <unzip dest="../connectors/target/authenticatorCopied/war/api#users#v2#me#webauthn">
-                                    <fileset dir="../connectors/target/authenticatorCopied/war">
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#users#v2#me#webauthn">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
                                         <include name="api#users#v2#me#webauthn.war" />
                                     </fileset>
                                 </unzip>
-                                <delete file=".../connectors/target/authenticatorCopied/war/api#users#v2#me#webauthn.war" />
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#users#v2#me#webauthn.war" />
 
                                 <!-- Explode the lsp.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/lsp">
@@ -651,6 +651,14 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/wso2.war" />
 
+                                <!-- Explode the admin-portal.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/admin-portal">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="admin-portal.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/admin-portal.war" />
+
                                 <!-- Explode the smsotpauthenticationendpoint.war -->
                                 <unzip dest="../connectors/target/authenticatorCopied/war/smsotpauthenticationendpoint">
                                     <fileset dir="../connectors/target/authenticatorCopied/war">
@@ -684,20 +692,12 @@
                                 <delete file="../connectors/target/authenticatorCopied/war/x509certificateauthenticationendpoint.war" />
 
                                 <!-- Explode the api#identity#auth#v1.1.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#auth#v1.1">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                <unzip dest="../connectors/target/authenticatorCopied/war/api#identity#auth#v1.1">
+                                    <fileset dir="../connectors/target/authenticatorCopied/war/">
                                         <include name="api#identity#auth#v1.1.war" />
                                     </fileset>
                                 </unzip>
                                 <delete file="../connectors/target/authenticatorCopied/war/api#identity#auth#v1.1.war" />
-
-                                <!-- Explode the admin-portal.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/admin-portal">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
-                                        <include name="admin-portal.war" />
-                                    </fileset>
-                                </unzip>
-                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/admin-portal.war" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -564,7 +564,7 @@
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0.war" />
 
                                 <!-- Explode the api#identity#oauth2#uma#resourceregistration#v1.0.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0">
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#resourceregistration#v1.0">
                                     <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
                                         <include name="api#identity#oauth2#uma#resourceregistration#v1.0.war" />
                                     </fileset>
@@ -604,12 +604,12 @@
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#user#v1.0.war" />
 
                                 <!-- Explode the api#users#v2#me#webauthn.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#users#v2#me#webauthn">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                <unzip dest="../connectors/target/authenticatorCopied/war/api#users#v2#me#webauthn">
+                                    <fileset dir="../connectors/target/authenticatorCopied/war">
                                         <include name="api#users#v2#me#webauthn.war" />
                                     </fileset>
                                 </unzip>
-                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#users#v2#me#webauthn.war" />
+                                <delete file=".../connectors/target/authenticatorCopied/war/api#users#v2#me#webauthn.war" />
 
                                 <!-- Explode the lsp.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/lsp">
@@ -650,6 +650,46 @@
                                     </fileset>
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/wso2.war" />
+
+                                <!-- Explode the smsotpauthenticationendpoint.war -->
+                                <unzip dest="../connectors/target/authenticatorCopied/war/smsotpauthenticationendpoint">
+                                    <fileset dir="../connectors/target/authenticatorCopied/war">
+                                        <include name="smsotpauthenticationendpoint.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../connectors/target/authenticatorCopied/war/smsotpauthenticationendpoint.war" />
+
+                                <!-- Explode the totpauthenticationendpoint.war -->
+                                <unzip dest="../connectors/target/authenticatorCopied/war/totpauthenticationendpoint">
+                                    <fileset dir="../connectors/target/authenticatorCopied/war">
+                                        <include name="totpauthenticationendpoint.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../connectors/target/authenticatorCopied/war/totpauthenticationendpoint.war" />
+
+                                <!-- Explode the emailotpauthenticationendpoint.war -->
+                                <unzip dest="../connectors/target/authenticatorCopied/war/emailotpauthenticationendpoint">
+                                    <fileset dir="../connectors/target/authenticatorCopied/war">
+                                        <include name="emailotpauthenticationendpoint.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../connectors/target/authenticatorCopied/war/emailotpauthenticationendpoint.war" />
+
+                                <!-- Explode the x509certificateauthenticationendpoint.war -->
+                                <unzip dest="../connectors/target/authenticatorCopied/war/x509certificateauthenticationendpoint">
+                                    <fileset dir="../connectors/target/authenticatorCopied/war">
+                                        <include name="x509certificateauthenticationendpoint.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../connectors/target/authenticatorCopied/war/x509certificateauthenticationendpoint.war" />
+
+                                <!-- Explode the api#identity#auth#v1.1.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#auth#v1.1">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
+                                        <include name="api#identity#auth#v1.1.war" />
+                                    </fileset>
+                                </unzip>
+                                <delete file="../connectors/target/authenticatorCopied/war/api#identity#auth#v1.1.war" />
 
                                 <!-- Explode the admin-portal.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/admin-portal">

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -713,7 +713,7 @@
                 <include>accountrecoveryendpoint/</include>
                 <include>api#identity#recovery#v0.9/</include>
                 <include>api#identity#user#v1.0/</include>
-                <include>api#users#v2#me#webauthn/</include
+                <include>api#users#v2#me#webauthn/</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -465,7 +465,7 @@
             </includes>
         </fileSet>
 
-        <!--copy web apps api#identity#auth#v1.1 -->
+        <!--Copy web apps api#identity#auth#v1.1 -->
         <fileSet>
             <directory>../connectors/target/authenticatorCopied/war</directory>
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -385,7 +385,7 @@
             </includes>
         </fileSet>
 
-        <!--copy the lsp-debug webapp -->
+        <!--Copy the lsp-debug webapp -->
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
@@ -438,13 +438,52 @@
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/components/dropins</outputDirectory>
         </fileSet>
 
-        <!--copy web apps for for totp, smsotp and emailotp authenticators-->
+        <!--Copy web apps for for smsotp authenticators-->
         <fileSet>
             <directory>../connectors/target/authenticatorCopied/war</directory>
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>smsotpauthenticationendpoint.war</include>
+            </includes>
         </fileSet>
 
-        <!--copy web app for identity management feature -->
+        <!--Copy web apps for for totp authenticators-->
+        <fileSet>
+            <directory>../connectors/target/authenticatorCopied/war</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>totpauthenticationendpoint.war</include>
+            </includes>
+        </fileSet>
+
+        <!--Copy web apps for for emailotp authenticators-->
+        <fileSet>
+            <directory>../connectors/target/authenticatorCopied/war</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>emailotpauthenticationendpoint.war</include>
+            </includes>
+        </fileSet>
+
+        <!--copy web apps api#identity#auth#v1.1 -->
+        <fileSet>
+            <directory>../connectors/target/authenticatorCopied/war</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>api#identity#auth#v1.1.war</include>
+            </includes>
+        </fileSet>
+
+        <!--Copy web apps for for x509 certificate authenticators-->
+        <fileSet>
+            <directory>../connectors/target/authenticatorCopied/war</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>x509certificateauthenticationendpoint.war</include>
+            </includes>
+        </fileSet>
+
+        <!--Copy web app for account recovery endpoint -->
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
@@ -456,7 +495,7 @@
         </fileSet>
 
 
-        <!--copy web app for identity recovery feature -->
+        <!--Copy web app api#identity#recovery#v0.9 -->
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
@@ -467,7 +506,7 @@
             </includes>
         </fileSet>
 
-        <!--copy web app for identity recovery feature -->
+        <!--Copy web app api#identity#user#v1.0 -->
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
@@ -478,7 +517,7 @@
             </includes>
         </fileSet>
 
-        <!--copy  web app for FIDO2 endpoint feature-->
+        <!--Copy  web app api#users#v2#me#webauthn.-->
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
@@ -696,6 +735,7 @@
             <includes>
                 <include>api/</include>
                 <include>authenticationendpoint/</include>
+                <include>mex</include>
                 <include>mexut/</include>
                 <include>oauth2/</include>
                 <include>scim2/</include>
@@ -713,7 +753,20 @@
                 <include>accountrecoveryendpoint/</include>
                 <include>api#identity#recovery#v0.9/</include>
                 <include>api#identity#user#v1.0/</include>
+                <include>api#identity#oauth2#uma#resourceregistration#v1.0/</include>
                 <include>api#users#v2#me#webauthn/</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
+            <directory>../connectors/target/authenticatorCopied/war</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>smsotpauthenticationendpoint/</include>
+                <include>totpauthenticationendpoint/</include>
+                <include>emailotpauthenticationendpoint/</include>
+                <include>api#identity#auth#v1.1/</include>
+                <include>x509certificateauthenticationendpoint</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -696,7 +696,24 @@
             <includes>
                 <include>api/</include>
                 <include>authenticationendpoint/</include>
+                <include>mexut/</include>
+                <include>oauth2/</include>
+                <include>scim2/</include>
+                <include>wso2</include>
+                <include>api#identity#oauth2#v1.0/</include>
+                <include>api#identity#oauth2#dcr#v1.1/</include>
+                <include>api#identity#template#mgt#v1.0.0/</include>
+                <include>api#identity#config-mgt#v1.0/</include>
+                <include>api#identity#entitlement</include>
+                <include>api#identity#consent-mgt#v1.0/</include>
+                <include>api#identity#oauth2#uma#permission#v1.0</include>
+                <include>api#identity#oauth2#uma#resourceregistration#v1.0</include>
+                <include>api#health-check#v1.0</include>
+                <include>lsp</include>
                 <include>accountrecoveryendpoint/</include>
+                <include>api#identity#recovery#v0.9/</include>
+                <include>api#identity#user#v1.0/</include>
+                <include>api#users#v2#me#webauthn/</include
             </includes>
         </fileSet>
     </fileSets>

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -735,21 +735,21 @@
             <includes>
                 <include>api/</include>
                 <include>authenticationendpoint/</include>
-                <include>mex</include>
+                <include>mex/</include>
                 <include>mexut/</include>
                 <include>oauth2/</include>
                 <include>scim2/</include>
-                <include>wso2</include>
+                <include>wso2/</include>
                 <include>api#identity#oauth2#v1.0/</include>
                 <include>api#identity#oauth2#dcr#v1.1/</include>
                 <include>api#identity#template#mgt#v1.0.0/</include>
                 <include>api#identity#config-mgt#v1.0/</include>
-                <include>api#identity#entitlement</include>
+                <include>api#identity#entitlement/</include>
                 <include>api#identity#consent-mgt#v1.0/</include>
-                <include>api#identity#oauth2#uma#permission#v1.0</include>
-                <include>api#identity#oauth2#uma#resourceregistration#v1.0</include>
-                <include>api#health-check#v1.0</include>
-                <include>lsp</include>
+                <include>api#identity#oauth2#uma#permission#v1.0/</include>
+                <include>api#identity#oauth2#uma#resourceregistration#v1.0/</include>
+                <include>api#health-check#v1.0/</include>
+                <include>lsp/</include>
                 <include>accountrecoveryendpoint/</include>
                 <include>api#identity#recovery#v0.9/</include>
                 <include>api#identity#user#v1.0/</include>
@@ -766,7 +766,7 @@
                 <include>totpauthenticationendpoint/</include>
                 <include>emailotpauthenticationendpoint/</include>
                 <include>api#identity#auth#v1.1/</include>
-                <include>x509certificateauthenticationendpoint</include>
+                <include>x509certificateauthenticationendpoint/</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
**Description**

With this PR changes, the server starting average time will reduce from 75 seconds to 42 seconds.

This PR will ship the following wars in exploded format.
- api#health-check#v1.0
- api#identity#config-mgt#v1.0
- api#identity#consent-mgt#v1.0
- api#identity#entitlement
- api#identity#oauth2#dcr#v1.1
- api#identity#oauth2#uma#permission#v1.0
- api#identity#oauth2#uma#resourceregistration#v1.0
- api#identity#oauth2#v1.0
- api#identity#recovery#v0.9
- api#identity#template#mgt#v1.0.0
- api#identity#user#v1.0
- api#users#v2#me#webauthn
- authenticationendpoint
- lsp
- mexut
- oauth2
- scim2
- wso2
- smsotpauthenticationendpoint
- totpauthenticationendpoint
- emailotpauthenticationendpoint
- api#identity#auth#v1.1
- x509certificateauthenticationendpoint

Already exploded wars
- accountrecoveryendpoint
- authenticationendpoint
- admin-portal
- api
- mex
- user-portal
- developer-portal


**Related issue** : https://github.com/wso2/product-is/issues/8559


