### PR TITLE
Add tests for oauth app update REST API

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementOAuthSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementOAuthSuccessTest.java
@@ -23,7 +23,9 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.assertNotBlank;
 import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.extractApplicationIdFromLocationHeader;
 
@@ -139,6 +141,32 @@ public class ApplicationManagementOAuthSuccessTest extends ApplicationManagement
     }
 
     @Test(dependsOnMethods = "testGetOAuthInboundDetailsOfSecondApp")
+    public void testUpdateOAuthInboundDetailsOfSecondApp() throws Exception {
+
+        String body = readResource("update-oauth-app-with-predefined-clientid.json");
+        String path = APPLICATION_MANAGEMENT_API_BASE_PATH + "/" + createdAppId + INBOUND_PROTOCOLS_OIDC_CONTEXT_PATH;
+
+        getResponseOfPut(path, body)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+
+        getResponseOfGet(path)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("accessToken.bindingType", equalTo("cookie"))
+                .body("grantTypes", containsInAnyOrder("refresh_token", "authorization_code", "account_switch",
+                        "password"))
+                .body("callbackURLs" , hasItem("http://localhost:8080/playground2/oauth2client"))
+                .body("pkce.mandatory", equalTo(true))
+                .body("pkce.supportPlainTransformAlgorithm", equalTo(true))
+                .body("publicClient", equalTo(false));
+    }
+
+    @Test(dependsOnMethods = "testUpdateOAuthInboundDetailsOfSecondApp")
     public void testDeleteOAuthInboundOfSecondApp() throws Exception {
 
         String path = APPLICATION_MANAGEMENT_API_BASE_PATH + "/" + createdAppId + INBOUND_PROTOCOLS_OIDC_CONTEXT_PATH;
@@ -154,7 +182,7 @@ public class ApplicationManagementOAuthSuccessTest extends ApplicationManagement
         getResponseOfGet(path).then().assertThat().statusCode(HttpStatus.SC_NOT_FOUND);
     }
 
-    @Test(dependsOnMethods = "testGetOAuthInboundDetailsOfSecondApp")
+    @Test(dependsOnMethods = "testUpdateOAuthInboundDetailsOfSecondApp")
     public void testDeleteSecondApp() throws Exception {
 
         String path = APPLICATION_MANAGEMENT_API_BASE_PATH + "/" + createdAppId;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OIDCMetaData.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OIDCMetaData.java
@@ -33,6 +33,7 @@ public class OIDCMetaData  {
     private MetadataProperty idTokenEncryptionMethod;
     private MetadataProperty scopeValidators;
     private MetadataProperty accessTokenType;
+    private MetadataProperty accessTokenBindingType;
 
     /**
      **/
@@ -196,7 +197,23 @@ public class OIDCMetaData  {
         this.accessTokenType = accessTokenType;
     }
 
+    /**
+     **/
+    public OIDCMetaData accessTokenBindingType(MetadataProperty accessTokenBindingType) {
 
+        this.accessTokenBindingType = accessTokenBindingType;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("accessTokenBindingType")
+    @Valid
+    public MetadataProperty getAccessTokenBindingType() {
+        return accessTokenBindingType;
+    }
+    public void setAccessTokenBindingType(MetadataProperty accessTokenBindingType) {
+        this.accessTokenBindingType = accessTokenBindingType;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -216,12 +233,13 @@ public class OIDCMetaData  {
                 Objects.equals(this.idTokenEncryptionAlgorithm, oiDCMetaData.idTokenEncryptionAlgorithm) &&
                 Objects.equals(this.idTokenEncryptionMethod, oiDCMetaData.idTokenEncryptionMethod) &&
                 Objects.equals(this.scopeValidators, oiDCMetaData.scopeValidators) &&
-                Objects.equals(this.accessTokenType, oiDCMetaData.accessTokenType);
+                Objects.equals(this.accessTokenType, oiDCMetaData.accessTokenType) &&
+                Objects.equals(this.accessTokenBindingType, oiDCMetaData.accessTokenBindingType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(allowedGrantTypes, defaultUserAccessTokenExpiryTime, defaultApplicationAccessTokenExpiryTime, defaultRefreshTokenExpiryTime, defaultIdTokenExpiryTime, idTokenEncryptionAlgorithm, idTokenEncryptionMethod, scopeValidators, accessTokenType);
+        return Objects.hash(allowedGrantTypes, defaultUserAccessTokenExpiryTime, defaultApplicationAccessTokenExpiryTime, defaultRefreshTokenExpiryTime, defaultIdTokenExpiryTime, idTokenEncryptionAlgorithm, idTokenEncryptionMethod, scopeValidators, accessTokenType, accessTokenBindingType);
     }
 
     @Override
@@ -239,6 +257,7 @@ public class OIDCMetaData  {
         sb.append("    idTokenEncryptionMethod: ").append(toIndentedString(idTokenEncryptionMethod)).append("\n");
         sb.append("    scopeValidators: ").append(toIndentedString(scopeValidators)).append("\n");
         sb.append("    accessTokenType: ").append(toIndentedString(accessTokenType)).append("\n");
+        sb.append("    accessTokenBindingType: ").append(toIndentedString(accessTokenBindingType)).append("\n");
         sb.append("}");
         return sb.toString();
     }
@@ -255,4 +274,3 @@ public class OIDCMetaData  {
         return o.toString().replace("\n", "\n");
     }
 }
-

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
@@ -80,5 +80,13 @@
       "Default"
     ],
     "defaultValue": "Default"
+  },
+  "accessTokenBindingType": {
+    "options": [
+      "None",
+      "cookie",
+      "sso-session"
+    ],
+    "defaultValue": "None"
   }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/update-oauth-app-with-predefined-clientid.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/update-oauth-app-with-predefined-clientid.json
@@ -1,0 +1,46 @@
+{
+  "accessToken": {
+    "applicationAccessTokenExpiryInSeconds": 3600,
+    "type": "Default",
+    "userAccessTokenExpiryInSeconds": 3600,
+    "bindingType" : "cookie"
+  },
+  "allowedOrigins": [],
+  "callbackURLs": [
+    "http://localhost:8080/playground2/oauth2client"
+  ],
+  "grantTypes": [
+    "refresh_token",
+    "authorization_code",
+    "account_switch",
+    "password"
+  ],
+  "idToken": {
+    "audience": [
+      ""
+    ],
+    "encryption": {
+      "algorithm": "RSA-OAEP",
+      "enabled": false,
+      "method": "A128GCM"
+    },
+    "expiryInSeconds": 3600
+  },
+  "logout": {
+    "backChannelLogoutUrl": "",
+    "frontChannelLogoutUrl": ""
+  },
+  "pkce": {
+    "mandatory": true,
+    "supportPlainTransformAlgorithm": true
+  },
+  "publicClient": false,
+  "refreshToken": {
+    "expiryInSeconds": 86400,
+    "renewRefreshToken": true
+  },
+  "scopeValidators": [],
+  "validateRequestObjectSignature": false,
+  "clientId": "my_custom_client_id",
+  "clientSecret": "my_custom_client_secret"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2098,7 +2098,7 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
 
         <!-- Identity REST API feature -->
-        <identity.api.dispatcher.version>1.0.117</identity.api.dispatcher.version>
+        <identity.api.dispatcher.version>1.0.118</identity.api.dispatcher.version>
 
         <identity.agent.sso.version>5.4.0</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.4.0</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
This PR will add integration tests
1. for `api/server/v1/applications/{{applicationId}}/inbound-protocols/oidc` PUT endpoint
2. for validating the access token binding type meta-information retrieved from `api/server/v1/applications/meta/inbound-protocols/oidc` endpoint. This was introduced with PR https://github.com/wso2/identity-api-server/pull/186