### PR TITLE
Add default.json of certificate-validation.xml to product IS

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -162,6 +162,7 @@
                                         <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.humantask.server.feature.default.json</param>
                                         <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.ldap.server.server.feature.default.json</param>
                                         <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.tenant.common.server.default.json</param>
+                                        <param>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature.default.json</param>
                                     </include>
                                     <target>${basedir}/../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/default.json</target>
                                     <mergeChildren>true</mergeChildren>

--- a/pom.xml
+++ b/pom.xml
@@ -2104,7 +2104,7 @@
         <identity.tool.samlsso.validator.version>5.4.0</identity.tool.samlsso.validator.version>
         <identity.app.authz.xacml.version>2.2.1</identity.app.authz.xacml.version>
         <identity.oauth.addons.version>2.3.1</identity.oauth.addons.version>
-        <org.wso2.carbon.extension.identity.x509certificate.version>1.0.6</org.wso2.carbon.extension.identity.x509certificate.version>
+        <org.wso2.carbon.extension.identity.x509certificate.version>1.0.7</org.wso2.carbon.extension.identity.x509certificate.version>
         <conditional.authentication.functions.version>0.1.40</conditional.authentication.functions.version>
         <carbon.identity.oauth.uma.version>1.2.1</carbon.identity.oauth.uma.version>
 


### PR DESCRIPTION
Partially fixes https://github.com/wso2/product-is/issues/8632

### Purpose

This PR is to add the default.json of certificate-validation.xml to the product IS.

This should be merged after merging PR [1].

[1] https://github.com/wso2-extensions/identity-x509-commons/pull/11