### PR TITLE
Upgraded Java versions from 1.6 to 1.8 on few samples

### DIFF
--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -159,6 +159,11 @@
             <version>${opensaml3.version}</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml-soap-api</artifactId>
             <version>${opensaml3.version}</version>

--- a/modules/samples/authenticators/components/org.wso2.carbon.identity.sample.extension.auth.endpoint/pom.xml
+++ b/modules/samples/authenticators/components/org.wso2.carbon.identity.sample.extension.auth.endpoint/pom.xml
@@ -76,8 +76,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
                 <version>2.3.2</version>
             </plugin>

--- a/modules/samples/identity-mgt/info-recovery-sample/pom.xml
+++ b/modules/samples/identity-mgt/info-recovery-sample/pom.xml
@@ -132,8 +132,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/modules/samples/oauth2/custom-grant/pom.xml
+++ b/modules/samples/oauth2/custom-grant/pom.xml
@@ -74,8 +74,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/samples/passive-sts/passive-sts-client/PassiveSTSFilter/pom.xml
+++ b/modules/samples/passive-sts/passive-sts-client/PassiveSTSFilter/pom.xml
@@ -66,8 +66,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/samples/sts/sts-client/pom.xml
+++ b/modules/samples/sts/sts-client/pom.xml
@@ -86,8 +86,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/samples/user-mgt/remote-user-mgt/pom.xml
+++ b/modules/samples/user-mgt/remote-user-mgt/pom.xml
@@ -72,8 +72,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/samples/user-mgt/sample-custom-user-store-manager/pom.xml
+++ b/modules/samples/user-mgt/sample-custom-user-store-manager/pom.xml
@@ -33,8 +33,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/samples/workflow/handler/service-provider/pom.xml
+++ b/modules/samples/workflow/handler/service-provider/pom.xml
@@ -67,8 +67,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/samples/xacml/kmarket-trading-sample/pom.xml
+++ b/modules/samples/xacml/kmarket-trading-sample/pom.xml
@@ -51,8 +51,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/styles/product/pom.xml
+++ b/modules/styles/product/pom.xml
@@ -36,8 +36,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/modules/styles/service/pom.xml
+++ b/modules/styles/service/pom.xml
@@ -31,8 +31,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
The product was not built on JDK 14. Updated the source and target versions to 1.8, which is the minimal supported version at present.