### PR TITLE
Make GroupAndRoleSeparation enabled by default

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -260,6 +260,7 @@
                                 <replace file="target/wso2carbon-core-${carbon.kernel.version}/repository/conf/carbon.xml" token="${product.version}" value="${project.version}" />
                                 <replace file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/templates/repository/conf/carbon.xml.j2" token="${product.version}" value="{{product.version}}" />
                                 <replace file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/default.json" token="${product.version}" value="${project.version}" />
+                                <replace file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/default.json" token="&quot;authorization_manager.properties.GroupAndRoleSeparationEnabled&quot;: &quot;false&quot;" value="&quot;authorization_manager.properties.GroupAndRoleSeparationEnabled&quot;: &quot;true&quot;" />
 
                                 <replace file="target/wso2carbon-core-${carbon.kernel.version}/repository/conf/carbon.xml" token="${product.key}" value="IS" />
                                 <replace file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/templates/repository/conf/carbon.xml.j2" token="${product.key}" value="IS" />

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -179,7 +179,6 @@
             <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2GroupTest"/>
             <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>
         </classes>
     </test>


### PR DESCRIPTION
- This PR will enable the GroupAndRoleSeparation feature by default, in the product. 

- The following configuration can be added to `deployment.toml` to disable the feature. 

```
[authorization_manager.properties]
GroupAndRoleSeparationEnabled = false
```

Resolves https://github.com/wso2/product-is/issues/9494