### PR TITLE
Upgraded Java versions from 1.7 to 1.8 on few components

### DIFF
--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -159,6 +159,11 @@
             <version>${opensaml3.version}</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
+            <version>${javax.xml.soap.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml-soap-api</artifactId>
             <version>${opensaml3.version}</version>
@@ -266,6 +271,7 @@
     <properties>
         <java-support.version>7.3.0</java-support.version>
         <opensaml3.version>3.3.0</opensaml3.version>
+        <javax.xml.soap.version>1.4.0</javax.xml.soap.version>
     </properties>
 
 </project>

--- a/modules/styles/product/pom.xml
+++ b/modules/styles/product/pom.xml
@@ -36,8 +36,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/modules/styles/service/pom.xml
+++ b/modules/styles/service/pom.xml
@@ -31,8 +31,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
The product was not built on JDK 14. Updated the source and target versions to 1.8, which is the minimal supported version at present.

**Related PRs:**
https://github.com/wso2/product-is/pull/9131

The above mentioned PR has been rendered obsolete due to the migration of the samples code from [product-is](https://github.com/wso2/product-is) to [samples-is](https://github.com/wso2/samples-is). 
This PR reflects the changes of the above PR to the relevant samples in this repo.