### PR TITLE
Rename `user-portal` refs in distribution to `myaccount`

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -500,13 +500,13 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/accountrecoveryendpoint.war" />
 
-                                <!-- Explode the user-portal.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/user-portal">
+                                <!-- Explode the myaccount.war -->
+                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/myaccount">
                                     <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
-                                        <include name="user-portal.war" />
+                                        <include name="myaccount.war" />
                                     </fileset>
                                 </unzip>
-                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/user-portal.war" />
+                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/myaccount.war" />
 
                                 <!-- Explode the api#health-check#v1.0.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#health-check#v1.0">

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -352,14 +352,14 @@
             </includes>
         </fileSet>
 
-        <!--copy user-portal web app-->
+        <!--copy myaccount web app-->
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
             </directory>
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
             <includes>
-                <include>user-portal/</include>
+                <include>myaccount/</include>
             </includes>
         </fileSet>
 

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -1232,7 +1232,7 @@
                                 </feature>
 
                                 <feature>
-                                    <id>org.wso2.identity.apps.user.portal.server.feature.group</id>
+                                    <id>org.wso2.identity.apps.myaccount.server.feature.group</id>
                                     <version>${identity.apps.version}</version>
                                 </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2136,7 +2136,7 @@
         <carbon.deployment.version>4.10.2</carbon.deployment.version>
         <carbon.commons.version>4.7.28</carbon.commons.version>
         <carbon.registry.version>4.7.33</carbon.registry.version>
-        <carbon.multitenancy.version>4.9.0</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.9.2</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.7</carbon.metrics.version>
         <carbon.business-process.version>4.5.33</carbon.business-process.version>
         <carbon.analytics-common.version>5.2.24</carbon.analytics-common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2011,7 +2011,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.69</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.70</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2124,7 +2124,7 @@
         <carbon.identity.oauth.uma.version>1.2.1</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.version>1.0.380</identity.apps.version>
+        <identity.apps.version>1.0.382</identity.apps.version>
 
         <!-- Charon -->
         <charon.version>3.3.0</charon.version>


### PR DESCRIPTION
- Rename user-portal references to myaccount to align with the portal rename.

Fixes #9288