### PR TITLE
Increase waiting time for workflow deployment

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/approval/v1/UserMeApprovalTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/approval/v1/UserMeApprovalTest.java
@@ -51,6 +51,7 @@ public class UserMeApprovalTest extends UserApprovalTestBase {
     private static final String TEST_WORKFLOW_ADD_USER_FOR_REST_TASK = addUserWorkflowName + "Task";
     private static final String JSON_PATH_MATCHING_REST_API_TEST_APPROVAL_TASK = "findAll{ it.presentationName == '"
             + TEST_WORKFLOW_ADD_USER_FOR_REST_TASK + "' }";
+    private static final int WAIT_TILL_WORKFLOW_DEPLOYMENT = 6;
 
     private static String swaggerDefinition;
     private String taskIdToApprove;
@@ -117,7 +118,7 @@ public class UserMeApprovalTest extends UserApprovalTestBase {
     public void testListTasksWhenAvailable() throws Exception {
 
         addAssociationForMatch();
-        for (int i = 1; i <= 3; i++) {
+        for (int i = 1; i <= WAIT_TILL_WORKFLOW_DEPLOYMENT; i++) {
             int numOfTasks = getResponseOfGet(ME_APPROVAL_TASKS_ENDPOINT_URI)
                     .then()
                     .extract()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/approval/v1/UserMeApprovalTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/approval/v1/UserMeApprovalTest.java
@@ -51,7 +51,7 @@ public class UserMeApprovalTest extends UserApprovalTestBase {
     private static final String TEST_WORKFLOW_ADD_USER_FOR_REST_TASK = addUserWorkflowName + "Task";
     private static final String JSON_PATH_MATCHING_REST_API_TEST_APPROVAL_TASK = "findAll{ it.presentationName == '"
             + TEST_WORKFLOW_ADD_USER_FOR_REST_TASK + "' }";
-    private static final int WAIT_TILL_WORKFLOW_DEPLOYMENT = 6;
+    private static final int MAX_WAIT_ITERATIONS_TILL_WORKFLOW_DEPLOYMENT = 6;
 
     private static String swaggerDefinition;
     private String taskIdToApprove;
@@ -118,7 +118,7 @@ public class UserMeApprovalTest extends UserApprovalTestBase {
     public void testListTasksWhenAvailable() throws Exception {
 
         addAssociationForMatch();
-        for (int i = 1; i <= WAIT_TILL_WORKFLOW_DEPLOYMENT; i++) {
+        for (int i = 1; i <= MAX_WAIT_ITERATIONS_TILL_WORKFLOW_DEPLOYMENT; i++) {
             int numOfTasks = getResponseOfGet(ME_APPROVAL_TASKS_ENDPOINT_URI)
                     .then()
                     .extract()


### PR DESCRIPTION
The response of me approval task endpoint should provide 3 TestWorkflowAddUserForRestTask to pass the test. But in Jenkins this intermittently fails because the response comes as 4. To fix this issue I have increased the waiting time so it will have enough time to deploy all the workflows. Fix : https://github.com/wso2/product-is/issues/9440 