### PR TITLE
Create doc_issues.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_issues.md
+++ b/.github/ISSUE_TEMPLATE/doc_issues.md
@@ -1,5 +1,5 @@
 ---
-name: Doc issues
+name: 📕 Doc issues
 about: Please report documentation issues here
 title: ''
 labels: 'docs'

--- a/.github/ISSUE_TEMPLATE/doc_issues.md
+++ b/.github/ISSUE_TEMPLATE/doc_issues.md
@@ -1,0 +1,24 @@
+---
+name: Doc issues
+about: Please report documentation issues here
+title: ''
+labels: 'docs'
+assignees: ''
+
+---
+
+**Is your suggestion related to a missing or misleading document? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex: I couldn't find how to do [...] -->
+
+**Describe the improvement**
+<!-- A clear and concise description of what you want to happen, what needs to be updated. -->
+
+---
+
+### Optional Fields
+
+**Additional context**
+<!-- Add any other context or screenshots about the document issue or suggestion. -->
+
+**Related Issues:**
+<!-- Any related issues from this/other repositories-->

--- a/.github/ISSUE_TEMPLATE/doc_issues.md
+++ b/.github/ISSUE_TEMPLATE/doc_issues.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **Is your suggestion related to a missing or misleading document? Please describe.**
-<!-- A clear and concise description of what the problem is. Ex: I couldn't find how to do [...] -->
+<!-- A clear and concise description of what the problem is, e.g., I couldn't find how to do [...] -->
 
 **Describe the improvement**
-<!-- A clear and concise description of what you want to happen, what needs to be updated. -->
+<!-- A clear and concise description of what needs to be updated. -->
 
 ---
 


### PR DESCRIPTION
Creating a template for doc issues and linking off issues to product-is repo instead of docs-is