### PR TITLE
Make GroupAndRoleSeparation enabled by default

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -33,5 +33,7 @@
   "system.parameter.\u0027org.wso2.CipherTransformation\u0027": "AES/GCM/NoPadding",
 
   "encryption.internal_crypto_provider": "org.wso2.carbon.crypto.provider.SymmetricKeyInternalCryptoProvider",
-  "encryption.key": "03BAFEB27A8E871CAD83C5CD4E771DAB"
+  "encryption.key": "03BAFEB27A8E871CAD83C5CD4E771DAB",
+
+  "authorization_manager.properties.GroupAndRoleSeparationEnabled": "true"
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/uuid/AbstractUUIDUMTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/uuid/AbstractUUIDUMTestCase.java
@@ -176,7 +176,7 @@ public abstract class AbstractUUIDUMTestCase extends ISIntegrationTest {
 
     public void testGetUserListOfRoleWithID() throws Exception {
 
-        String roleName = "admin";
+        String roleName = "Internal/admin";
         UserDTO[] userDTOs = userMgtClient.getUserListOfRoleWithID(roleName);
         Assert.assertNotNull(userDTOs);
         Assert.assertTrue(userDTOs.length > 0);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -179,7 +179,6 @@
             <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>
             <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2GroupTest"/>
             <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>
         </classes>
     </test>

--- a/pom.xml
+++ b/pom.xml
@@ -2046,7 +2046,7 @@
         <identity.inbound.auth.openid.version>5.6.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.3</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.1</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>1.5.23</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>1.5.24</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity workflow Versions -->
         <identity.user.workflow.version>5.4.1</identity.user.workflow.version>


### PR DESCRIPTION
- This PR will enable the GroupAndRoleSeparation feature by default, in the product. 

- The following configuration can be added to `deployment.toml` to disable the feature. 

```
[authorization_manager.properties]
GroupAndRoleSeparationEnabled = false
```

Resolves https://github.com/wso2/product-is/issues/9494