### PR TITLE
Modify SPMetadataTestCase due to enabling assertion signing by default

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SPMetadataTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SPMetadataTestCase.java
@@ -43,7 +43,7 @@ public class SPMetadataTestCase extends ISIntegrationTest {
     private static final String[] ACSs = {"https://metadata-sp:8080/federation/Consumer1/metaAlias/sp",
             "https://metadata-sp:8080/federation/Consumer2/metaAlias/sp"};
     private static String NAMEIDFORMAT = "urn/oasis/names/tc/SAML/2.0/nameid-format/persistent";
-    private static boolean WANTASSERTIONSSIGNED= false;
+    private static boolean WANTASSERTIONSSIGNED= true;
     private static boolean ISAAUTHNREQUESTSSIGNED = false;
     private static String SLOREQUESTURL = "https://metadata-sp:8080/federation/SPSloRedirect/metaAlias/sp";
     private static String SLORESPONSEURL = "https://metadata-sp:8080/federation/SPSloRedirect/metaAlias/sp";


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/9357

With https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/310 the SAML assertions are set to be signed by default. Hence the test case is modified to reflect that behaviour. 