### PR TITLE
Disable device authorisation grant test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -28,7 +28,9 @@
 
     <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>
+            <!--Disabling the test as the grant type is disabled by default.-->
+            <!--<class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>-->
+
             <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
             <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
             <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>


### PR DESCRIPTION
The test is being disabled as the device authorisation grant is being disabled by default. We need to enable the test once the grant type is enabled.

Related to https://github.com/wso2/product-is/issues/10090