### PR TITLE
Exclude cassandra and sso.agent jars

### DIFF
--- a/modules/distribution/src/assembly/dist.xml
+++ b/modules/distribution/src/assembly/dist.xml
@@ -40,6 +40,10 @@
                 <exclude>features/org.wso2.carbon.as.runtimes.cxf_*/cxf3/*.jar</exclude>
                 <exclude>features/org.wso2.carbon.identity.oauth.server_*/runtimes/cxf3/*.jar</exclude>
                 <exclude>features/org.wso2.carbon.identity.oauth2.validators.xacml.server_*/dropins/*.jar</exclude>
+                <exclude>features/org.wso2.carbon.event.output.adapter.cassandra.server_*</exclude>
+                <exclude>plugins/cassandra-thrift_*.jar</exclude>
+                <exclude>plugins/org.wso2.carbon.event.output.adapter.cassandra_*.jar</exclude>
+                <exclude>plugins/org.wso2.carbon.identity.sso.agent_*.jar</exclude>
             </excludes>
         </fileSet>
         <!-- Creates an empty directory -->


### PR DESCRIPTION
- Exclude org.wso2.carbon.identity.sso.agent jar and this dependency being used by a dashboard (jaggery apps) and since we are not using the dashboard, exclude this from product distribution.
- Exclude cassandra-thrift as there are no usages of this jar in the product. It's being packed from  Cassandra adapter (org.wso2.carbon.event.output.adapter.cassandra) and there are no usages of this adapter as well in the product.

[1] https://github.com/wso2-attic/identity-agent-sso/blob/master/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/util/SSOAgentUtils.java#L243