### PR TITLE
Align kernel build with jenkins PR builder

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -125,7 +125,11 @@ else
   echo ""
   echo "Building dependency repo $REPO..."
   echo "=========================================================="
-  mvn clean install --batch-mode | tee mvn-build.log
+  if [ "$REPO" = "carbon-kernel" ]; then
+    mvn clean install -Dmaven.test.skip=true --batch-mode | tee mvn-build.log
+  else 
+    mvn clean install --batch-mode | tee mvn-build.log
+  fi 
 
   echo ""
   echo "Dependency repo $REPO build complete."


### PR DESCRIPTION
This PR aligns kernel build with the jenkins PR builder. It is removing tests when building the kernel repo as in the jenkins based PR builder. Doing this as there were some issues when running kernel tests. This change is temporary until the proper solution is found.