### PR TITLE
Add integration tests for token revocation when session is terminated via RESTapi

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identityServlet/ExtendSessionEndpointAuthCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identityServlet/ExtendSessionEndpointAuthCodeGrantTestCase.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.identityServlet;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
+import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
+import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_CLIENT_ID;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_CODE;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_REDIRECT_URI;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_RESPONSE_TYPE;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_SCOPE;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_SCOPE_OPENID;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.SESSION_DATA_KEY;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_CODE_NAME;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.SESSION_DATA_KEY_CONSENT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.USER_AGENT;
+
+/**
+ * Test for Session Extender endpoint functionality with claims obtained via an Authorization Code Grant and Refresh
+ * Grant.
+ */
+public class ExtendSessionEndpointAuthCodeGrantTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    private static final String CALLBACK_URL = "https://localhost/callback";
+    private static final String IDP_SESSION_KEY_CLAIM_NAME = "isk";
+    private static final String SESSION_EXTENDER_ENDPOINT_URL = "https://localhost:9853/identity/extend-session";
+    private static final String SESSION_EXTENDER_ENDPOINT_GET_URL = SESSION_EXTENDER_ENDPOINT_URL + "?%s=%s";
+    private static final String SESSIONS_ENDPOINT_URI = "https://localhost:9853/api/users/v1/me/sessions";
+
+    private CloseableHttpClient firstPartyClient;
+    private CloseableHttpClient thirdPartyClient;
+    private String sessionDataKey;
+    private String sessionDataKeyConsent;
+    private AuthorizationCode authorizationCode;
+    private String idToken;
+    private RefreshToken refreshToken;
+    private String idpSessionKey;
+    private String authenticatingUserName;
+    private String authenticatingCredential;
+    private AutomationContext context;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(TestUserMode.SUPER_TENANT_USER);
+        context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getContextUser().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getContextUser().getPassword();
+        firstPartyClient = HttpClientBuilder.create().disableRedirectHandling().build();
+        thirdPartyClient = HttpClientBuilder.create().disableRedirectHandling().build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        deleteApplication();
+        removeOAuthApplicationData();
+
+        consumerKey = null;
+        consumerSecret = null;
+        firstPartyClient.close();
+        thirdPartyClient.close();
+    }
+
+    @Test(groups = "wso2.is", description = "Check Oauth2 application registration.")
+    public void testRegisterApplication() throws Exception {
+
+        OAuthConsumerAppDTO oAuthConsumerAppDTO = getBasicOAuthApp(CALLBACK_URL);
+        ServiceProvider serviceProvider = registerServiceProviderWithOAuthInboundConfigs(oAuthConsumerAppDTO);
+        Assert.assertNotNull(serviceProvider, "OAuth App creation failed.");
+        Assert.assertNotNull(consumerKey, "Consumer Key is null.");
+        Assert.assertNotNull(consumerSecret, "Consumer Secret is null.");
+    }
+
+    @Test(groups = "wso2.is", description = "Send authorize user request for authorization code grant type.",
+            dependsOnMethods = "testRegisterApplication")
+    public void testAuthCodeGrantSendAuthRequestPost() throws Exception {
+
+        // Send a direct auth code request to IS instance.
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair(OAUTH2_RESPONSE_TYPE, OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair(OAUTH2_CLIENT_ID, consumerKey));
+        urlParameters.add(new BasicNameValuePair(OAUTH2_REDIRECT_URI, CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair(OAUTH2_SCOPE, OAUTH2_SCOPE_OPENID));
+
+        HttpResponse response = sendPostRequestWithParameters(firstPartyClient, urlParameters, AUTHORIZE_ENDPOINT_URL);
+        Assert.assertNotNull(response, "Authorization request failed. Authorized response is null");
+
+        String locationValue = getLocationHeaderValue(response);
+        Assert.assertTrue(locationValue.contains(SESSION_DATA_KEY),
+                "sessionDataKey not found in response.");
+
+        // Extract sessionDataKey from the location value.
+        sessionDataKey = DataExtractUtil.getParamFromURIString(locationValue, SESSION_DATA_KEY);
+        Assert.assertNotNull(sessionDataKey, "Session data key is null.");
+        EntityUtils.consume(response.getEntity());
+    }
+
+    @Test(groups = "wso2.is", description = "Send login post request.",
+            dependsOnMethods = "testAuthCodeGrantSendAuthRequestPost")
+    public void testAuthCodeGrantSendLoginPost() throws Exception {
+
+        sessionDataKeyConsent = getSessionDataKeyConsent(firstPartyClient, sessionDataKey);
+        Assert.assertNotNull(sessionDataKeyConsent, "Invalid session key consent.");
+    }
+
+    @Test(groups = "wso2.is", description = "Send approval post request.",
+            dependsOnMethods = "testAuthCodeGrantSendLoginPost")
+    public void testAuthCodeGrantSendApprovalPost() throws Exception {
+
+        HttpResponse response = sendApprovalPost(firstPartyClient, sessionDataKeyConsent);
+        Assert.assertNotNull(response, "Approval request failed. response is invalid.");
+
+        Header locationHeader =
+                response.getFirstHeader(HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "Approval request failed. Location header is null.");
+
+        String locationValue = getLocationHeaderValue(response);
+        Assert.assertTrue(locationValue.contains(AUTHORIZATION_CODE_NAME),
+                "Authorization code not found in the response.");
+
+        // Extract authorization code from the location value.
+        authorizationCode = new AuthorizationCode(DataExtractUtil.getParamFromURIString(locationValue,
+                AUTHORIZATION_CODE_NAME));
+        Assert.assertNotNull(authorizationCode, "Authorization code is null.");
+        EntityUtils.consume(response.getEntity());
+    }
+
+    @Test(groups = "wso2.is", description = "Send get access token request.",
+            dependsOnMethods = "testAuthCodeGrantSendApprovalPost")
+    public void testAuthCodeGrantIdTokenClaimAvailability() throws Exception {
+
+        URI callbackURI = new URI(CALLBACK_URL);
+        AuthorizationCodeGrant authorizationCodeGrant = new AuthorizationCodeGrant(authorizationCode, callbackURI);
+        OIDCTokens oidcTokens = makeTokenRequest(authorizationCodeGrant, ACCESS_TOKEN_ENDPOINT,null);
+
+        idToken = oidcTokens.getIDTokenString();
+        refreshToken = oidcTokens.getRefreshToken();
+        Assert.assertNotNull(idToken, "ID token is null");
+        Assert.assertNotNull(refreshToken, "Refresh token is null");
+
+        testIdTokenClaimAvailability();
+    }
+
+    @Test(groups = "wso2.is", description = "Sends a request for session extension with a valid cookie.",
+            dependsOnMethods = "testAuthCodeGrantIdTokenClaimAvailability")
+    public void testSessionExtensionWithValidCookie() throws Exception {
+
+        Long lastAccessedTimeBeforeExtension = getLastAccessedTimeOfSession();
+
+        // A valid commonAuthIdCookie is already available in the HttpClient, which had been obtained during the
+        // authorization code grant.
+        HttpResponse response = sendGetRequest(firstPartyClient, SESSION_EXTENDER_ENDPOINT_URL);
+        Assert.assertNotNull(response, "Session extension request failed. Response is invalid.");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, HttpServletResponse.SC_OK, "Session extension failed for request with valid " +
+                "cookie");
+        EntityUtils.consume(response.getEntity());
+
+        Long lastAccessedTimeAfterExtension = getLastAccessedTimeOfSession();
+        Assert.assertTrue(lastAccessedTimeAfterExtension > lastAccessedTimeBeforeExtension,
+                "Session has not been extended.");
+    }
+
+    @Test(groups = "wso2.is", description = "Sends a request for session extension with a valid cookie.",
+            dependsOnMethods = "testSessionExtensionWithValidCookie")
+    public void testSessionExtensionWithMismatchingCookieAndParameter() throws Exception {
+
+        // A valid commonAuthIdCookie is already available in the HttpClient, which had been obtained during the
+        // authorization code grant.
+        String locationUrl = String.format(SESSION_EXTENDER_ENDPOINT_GET_URL, "idpSessionKey", "abcd1234");
+        testSessionExtensionResponse(firstPartyClient, locationUrl, HttpServletResponse.SC_CONFLICT, "ISE-60005");
+    }
+
+    @Test(groups = "wso2.is", description = "Sends a valid request for session extension.",
+            dependsOnMethods = "testSessionExtensionWithMismatchingCookieAndParameter")
+    public void testSessionExtensionWithValidParameters() throws Exception {
+
+        Long lastAccessedTimeBeforeExtension = getLastAccessedTimeOfSession();
+
+        // Using the fresh third party client without any cookies as the firstPartyClient holds a valid cookie,
+        String locationUrl = String.format(SESSION_EXTENDER_ENDPOINT_GET_URL, "idpSessionKey", idpSessionKey);
+        HttpResponse response = sendGetRequest(thirdPartyClient, locationUrl);
+        Assert.assertNotNull(response, "Session extension request failed. Response is invalid.");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, HttpServletResponse.SC_OK, "Session extension failed for request with valid " +
+                "session key parameter.");
+        EntityUtils.consume(response.getEntity());
+
+        Long lastAccessedTimeAfterExtension = getLastAccessedTimeOfSession();
+        Assert.assertTrue(lastAccessedTimeAfterExtension > lastAccessedTimeBeforeExtension,
+                "Session has not been extended.");
+    }
+
+    @Test(groups = "wso2.is", description = "Checks whether the IDP session key is available as a claim in the" +
+            " ID token obtained from a Refresh Grant",
+            dependsOnMethods = "testSessionExtensionWithValidParameters")
+    public void testRefreshGrantIdTokenClaimAvailability() throws Exception {
+
+        RefreshTokenGrant refreshGrant = new RefreshTokenGrant(refreshToken);
+        OIDCTokens oidcTokens = makeTokenRequest(refreshGrant, ACCESS_TOKEN_ENDPOINT, OAUTH2_SCOPE_OPENID);
+
+        idToken = oidcTokens.getIDTokenString();
+        Assert.assertNotNull(idToken, "ID token is null");
+
+        testIdTokenClaimAvailability();
+    }
+
+    @Test(groups = "wso2.is", description = "Sends a valid request for session extension.",
+            dependsOnMethods = "testRefreshGrantIdTokenClaimAvailability")
+    public void testSessionExtensionWithInValidParameters() throws Exception {
+
+        // Using the fresh third party client without any cookies as the firstPartyClient holds a valid cookie,
+        String invalidParamNameUrl = String.format(SESSION_EXTENDER_ENDPOINT_GET_URL, "idpKey", idpSessionKey);
+        testSessionExtensionResponse(thirdPartyClient, invalidParamNameUrl, HttpServletResponse.SC_BAD_REQUEST,
+                "ISE-60001");
+
+        String invalidKeyValueUrl =  String.format(SESSION_EXTENDER_ENDPOINT_GET_URL, "idpSessionKey", "12345");
+        testSessionExtensionResponse(thirdPartyClient, invalidKeyValueUrl, HttpServletResponse.SC_BAD_REQUEST,
+                "ISE-60004");
+    }
+
+    /**
+     * Checks whether the isk claim is available in the ID token.
+     *
+     * @throws Exception Exception.
+     */
+    private void testIdTokenClaimAvailability() throws Exception {
+
+        JWTClaimsSet claims = SignedJWT.parse(idToken).getJWTClaimsSet();
+        Assert.assertNotNull(claims, "ID token claim set is null");
+
+        idpSessionKey = (String) claims.getClaim(IDP_SESSION_KEY_CLAIM_NAME);
+        Assert.assertNotNull(idpSessionKey, "IDP session key not available in ID token.");
+    }
+
+    /**
+     * To make a token request with specified grant.
+     *
+     * @param authorizationGrant    Relevant authorization grant.
+     * @return                      OIDC tokens coming from request.
+     * @throws Exception            Exception.
+     */
+    private OIDCTokens makeTokenRequest(AuthorizationGrant authorizationGrant, String uriString, String scopeString)
+            throws Exception {
+
+        ClientID clientID = new ClientID(consumerKey);
+        Secret clientSecret = new Secret(consumerSecret);
+        ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
+        URI uri = new URI(uriString);
+        Scope scope = null;
+        if (StringUtils.isNotBlank(scopeString)) {
+            scope = new Scope(scopeString);
+        }
+        TokenRequest request = new TokenRequest(uri, clientAuth, authorizationGrant, scope);
+
+        HTTPResponse tokenHTTPResp = request.toHTTPRequest().send();
+        Assert.assertNotNull(tokenHTTPResp, "Token http response is null.");
+
+        TokenResponse tokenResponse = OIDCTokenResponseParser.parse(tokenHTTPResp);
+        Assert.assertNotNull(tokenResponse, "Token response of access token response is null.");
+
+        Assert.assertFalse(tokenResponse instanceof TokenErrorResponse, "JWT access token response contains errors.");
+
+        OIDCTokenResponse oidcTokenResponse = (OIDCTokenResponse) tokenResponse;
+        OIDCTokens oidcTokens = oidcTokenResponse.getOIDCTokens();
+        Assert.assertNotNull(oidcTokens, "OIDC Tokens object is null.");
+        return oidcTokens;
+    }
+
+    /**
+     * Method for testing the error responses from the API.
+     *
+     * @param url                   URL of the request.
+     * @param expectedStatusCode    Expected status code of the response.
+     * @param expectedErrorCode     Expected error code of the API response JSON.
+     * @throws Exception            Error if executing the request fails.
+     */
+    private void testSessionExtensionResponse(CloseableHttpClient client, String url, int expectedStatusCode,
+                                              String expectedErrorCode)
+            throws Exception {
+
+        HttpResponse response = sendGetRequest(client, url);
+        Assert.assertNotNull(response, "Session extension request failed. Response is invalid.");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, expectedStatusCode);
+
+        HttpEntity entity = response.getEntity();
+        String responseString = EntityUtils.toString(entity, "UTF-8");
+        JSONObject responseJson = new JSONObject(responseString);
+        Assert.assertEquals(responseJson.get("code"), expectedErrorCode);
+        EntityUtils.consume(entity);
+    }
+
+    /**
+     * Extract the location header value from a HttpResponse.
+     *
+     * @param response HttpResponse object that needs the header extracted.
+     * @return String value of the location header.
+     */
+    private String getLocationHeaderValue(HttpResponse response) {
+
+        Header location = response.getFirstHeader(HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(location);
+        return location.getValue();
+    }
+
+    /**
+     * Sends a log in post to the IS instance and extract and return the sessionDataKeyConsent from the response.
+     *
+     * @param client         CloseableHttpClient object to send the login post.
+     * @param sessionDataKey String sessionDataKey obtained.
+     * @return Extracted sessionDataKeyConsent.
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    private String getSessionDataKeyConsent(CloseableHttpClient client, String sessionDataKey)
+            throws IOException, URISyntaxException {
+
+        HttpResponse response = sendLoginPost(client, sessionDataKey);
+        Assert.assertNotNull(response, "Login request failed. response is null.");
+
+        Header locationHeader = response.getFirstHeader(HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "Login response header is null");
+        EntityUtils.consume(response.getEntity());
+
+        // Request will return with a 302 to the authorize end point. Doing a GET will give the sessionDataKeyConsent
+        response = sendGetRequest(client, locationHeader.getValue());
+
+        String locationValue = getLocationHeaderValue(response);
+        Assert.assertTrue(locationValue.contains(SESSION_DATA_KEY_CONSENT),
+                "sessionDataKeyConsent not found in response.");
+
+        EntityUtils.consume(response.getEntity());
+
+        // Extract sessionDataKeyConsent from the location value.
+        return DataExtractUtil.getParamFromURIString(locationValue, SESSION_DATA_KEY_CONSENT);
+    }
+
+    /**
+     * Retrieves the last accessed time of the existing session.
+     *
+     * @return              Last accessed time of the session.
+     * @throws Exception    Exception.
+     */
+    private Long getLastAccessedTimeOfSession() throws Exception {
+
+        String encodedCredentials =
+                Base64.encodeBase64String((authenticatingUserName + ":" + authenticatingCredential).getBytes());
+        BasicHeader authorizationHeader = new BasicHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials);
+        List<Header> headers = new ArrayList<>();
+        headers.add(authorizationHeader);
+        HttpResponse response = sendGetRequestWithCustomHeaders(firstPartyClient, SESSIONS_ENDPOINT_URI, headers);
+        Assert.assertNotNull(response.getEntity(), "Session extension validation request failed. Response is invalid.");
+
+        HttpEntity entity = response.getEntity();
+        String responseString = EntityUtils.toString(entity, "UTF-8");
+        Assert.assertTrue(responseString.startsWith("{"), "No session information returned by the sessions endpoint.");
+
+        JSONObject responseJson = new JSONObject(responseString);
+        Assert.assertNotNull(responseJson.get("sessions"), "No session information returned by the sessions endpoint.");
+        JSONArray sessionsList = (JSONArray) responseJson.get("sessions");
+        JSONObject session = (JSONObject) sessionsList.get(0);
+        String lastAccessTime = (String) session.get("lastAccessTime");
+        Assert.assertNotNull(lastAccessTime, "No session information returned by the sessions endpoint.");
+        EntityUtils.consume(entity);
+        return Long.parseLong(lastAccessTime);
+    }
+
+    /**
+     * Returns the response of a GET request to a REST API.
+     *
+     * @param client        Http client.
+     * @param locationURL   URL of the request.
+     * @param headerList    List of headers.
+     * @return              Http response.
+     * @throws Exception    Exception.
+     */
+    private HttpResponse sendGetRequestWithCustomHeaders(HttpClient client,
+                                                         String locationURL,
+                                                         List<Header> headerList)
+            throws Exception {
+
+        HttpGet getRequest = new HttpGet(locationURL);
+        Header[] headers = new Header[headerList.size()];
+        for (int i = 0; i < headerList.size(); i++) {
+            headers[i] = headerList.get(i);
+        }
+        getRequest.setHeaders(headers);
+        getRequest.setHeader(HttpHeaders.USER_AGENT, USER_AGENT);
+        HttpResponse response = client.execute(getRequest);
+
+        return response;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -522,7 +522,7 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 		appDTO.setApplicationName(OAUTH_APPLICATION_NAME);
 		appDTO.setCallbackUrl(callBackURL);
 		appDTO.setOAuthVersion(OAuth2Constant.OAUTH_VERSION_2);
-		appDTO.setGrantTypes("authorization_code implicit password client_credentials");
+		appDTO.setGrantTypes("authorization_code implicit password client_credentials refresh_token");
 		return appDTO;
 	}
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithSessionTerminationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithSessionTerminationTestCase.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.oauth2;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
+import org.wso2.identity.integration.test.util.Utils;
+import org.wso2.identity.integration.test.utils.CommonConstants;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * This test class is used to check the behaviour of token revocation when user session is terminated via Session
+ * termination REST API. When the accesstoken is issued, we store a mapping to session to token (irrespective of
+ * binding type). So when the session is terminated via REST API, the respective token should be revoked.
+ */
+public class OAuth2TokenRevocationWithSessionTerminationTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    private String consumerKey;
+    private String consumerSecret;
+    private String sessionDataKeyConsent;
+    private String sessionDataKey;
+    private String authorizationCode;
+    private HttpClient client;
+    private String accessToken;
+    private List<String> sessionIdList;
+    private static final String SESSION_API_ENDPOINT = "https://localhost:9853/t/carbon.super/api/users/v1/me/sessions";
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init();
+        setSystemproperties();
+        super.init(TestUserMode.SUPER_TENANT_USER);
+        client = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() throws Exception {
+
+        deleteApplication();
+    }
+
+    @Test(groups = "wso2.is", description = "Create OAuth2 application")
+    public void testRegisterApplication() throws Exception {
+
+        OAuthConsumerAppDTO appDto = createApplication();
+        Assert.assertNotNull(appDto, "Application creation failed.");
+        consumerKey = appDto.getOauthConsumerKey();
+        Assert.assertNotNull(consumerKey, "OAuth clientId is invalid.");
+        consumerSecret = appDto.getOauthConsumerSecret();
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = {"testRegisterApplication"}, description = "Test login using openId connect " +
+            "authorization code flow")
+    public void testOIDCLogin() throws Exception {
+
+        initiateAuthorizationRequest();
+        authenticateUser();
+        performConsentApproval();
+        generateAuthzCodeAccessToken();
+        introspectActiveAccessToken();
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = {"testOIDCLogin"}, description = "Get User session using session termination REST API")
+    public void testGetUserSessions() {
+
+        Response response = getResponseOfGet(SESSION_API_ENDPOINT);
+        response.then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .log().ifValidationFails()
+                .body("size()", notNullValue())
+                .body("userId", notNullValue())
+                .body("sessions", notNullValue())
+                .body("sessions.applications", notNullValue())
+                .body("sessions.applications.subject", notNullValue())
+                .body("sessions.applications.appName[0]", notNullValue())
+                .body("sessions.applications.appId", notNullValue())
+                .body("sessions.userAgent", notNullValue())
+                .body("sessions.ip", notNullValue())
+                .body("sessions.loginTime", notNullValue())
+                .body("sessions.lastAccessTime", notNullValue())
+                .body("sessions.id", notNullValue());
+        sessionIdList = response.jsonPath().getList("sessions.id");
+        Assert.assertEquals(sessionIdList.size(), 1);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = {"testGetUserSessions"}, description = "Terminate User session using session termination " +
+            "REST API")
+    public void testDeleteUserSessionById() {
+
+        String endpointURI = SESSION_API_ENDPOINT + "/" + sessionIdList.get(0);
+        // Delete the sessionId using session termination api.
+        getResponseOfDelete(endpointURI).then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+        // Get all sessions.
+        getResponseOfGet(SESSION_API_ENDPOINT)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("size()", is(0));
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = {"testGetUserSessions"}, description = " The expected behaviour is, When the session is " +
+            "terminated via REST API, the corresponding mapped accesstoken should be revoked")
+    public void testTokenRevocationWhenSessionIsTerminated() throws Exception {
+
+        JSONObject object = testIntrospectionEndpoint();
+        Assert.assertEquals(object.get("active"), false);
+    }
+
+    /**
+     * Playground app will initiate authorization request to IS and obtain session data key.
+     *
+     * @throws IOException
+     */
+    private void initiateAuthorizationRequest() throws IOException {
+
+        List<NameValuePair> urlParameters = getOIDCInitiationRequestParams();
+        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, OAuth2Constant.AUTHORIZED_USER_URL);
+        Assert.assertNotNull(response, "Authorization response is null");
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "Authorization response header is null.");
+
+        EntityUtils.consume(response.getEntity());
+        response = sendGetRequest(client, locationHeader.getValue());
+        sessionDataKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
+        EntityUtils.consume(response.getEntity());
+    }
+
+    /**
+     * Provide user credentials and authenticate to the system.
+     *
+     * @throws IOException
+     */
+    private void authenticateUser() throws IOException {
+
+        // Pass user credentials to commonauth endpoint and authenticate the user.
+        HttpResponse response = sendLoginPost(client, sessionDataKey);
+        Assert.assertNotNull(response, "OIDC login request response is null.");
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "OIDC login response header is null.");
+        EntityUtils.consume(response.getEntity());
+        // Get the sessionDatakeyConsent from the redirection after authenticating the user.
+        response = sendGetRequest(client, locationHeader.getValue());
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
+        keyPositionMap.put("name=\"sessionDataKeyConsent\"", 1);
+        List<DataExtractUtil.KeyValue> keyValues = DataExtractUtil.extractSessionConsentDataFromResponse(response,
+                keyPositionMap);
+        Assert.assertNotNull(keyValues, "SessionDataKeyConsent keyValues map is null.");
+        sessionDataKeyConsent = keyValues.get(0).getValue();
+        Assert.assertNotNull(sessionDataKeyConsent, "sessionDataKeyConsent is null.");
+        EntityUtils.consume(response.getEntity());
+    }
+
+    /**
+     * Approve the consent.
+     *
+     * @throws IOException
+     */
+    private void performConsentApproval() throws IOException {
+
+        HttpResponse response = sendApprovalPostWithConsent(client, sessionDataKeyConsent, null);
+        Assert.assertNotNull(response, "OIDC consent approval request response is null.");
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "OIDC consent approval request location header is null.");
+        EntityUtils.consume(response.getEntity());
+        // Get authorization code flow.
+        response = sendPostRequest(client, locationHeader.getValue());
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
+        keyPositionMap.put("Authorization Code", 1);
+        List<DataExtractUtil.KeyValue> keyValues = DataExtractUtil.extractTableRowDataFromResponse(response,
+                keyPositionMap);
+        Assert.assertNotNull(keyValues, "Authorization code not received.");
+        authorizationCode = keyValues.get(0).getValue();
+        Assert.assertNotNull(authorizationCode, "Authorization code not received.");
+        EntityUtils.consume(response.getEntity());
+    }
+
+    /**
+     * Exchange authorization code and get accesstoken.
+     *
+     * @throws Exception
+     */
+    private void generateAuthzCodeAccessToken() throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair(OAuth2Constant.GRANT_TYPE_NAME,
+                OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        urlParameters.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_REDIRECT_URI, OAuth2Constant.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair(OAuth2Constant.AUTHORIZATION_CODE_NAME, authorizationCode));
+        JSONObject jsonResponse = responseObject(OAuth2Constant.ACCESS_TOKEN_ENDPOINT, urlParameters, consumerKey,
+                consumerSecret);
+        Assert.assertNotNull(jsonResponse.get(OAuth2Constant.ACCESS_TOKEN), "Access token is null.");
+        Assert.assertNotNull(jsonResponse.get(OAuth2Constant.REFRESH_TOKEN), "Refresh token is null.");
+        accessToken = (String) jsonResponse.get(OAuth2Constant.ACCESS_TOKEN);
+    }
+
+    private List<NameValuePair> getOIDCInitiationRequestParams() {
+
+        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        urlParameters.add(new BasicNameValuePair("grantType", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("consumerKey", consumerKey));
+        urlParameters.add(new BasicNameValuePair("callbackurl", OAuth2Constant.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("authorizeEndpoint", OAuth2Constant.APPROVAL_URL));
+        urlParameters.add(new BasicNameValuePair("authorize", OAuth2Constant.AUTHORIZE_PARAM));
+        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID));
+        return urlParameters;
+    }
+
+    /**
+     * Introspect the obtained accesstoken and it should be an active token.
+     *
+     * @throws Exception
+     */
+    private void introspectActiveAccessToken() throws Exception {
+
+        JSONObject object = testIntrospectionEndpoint();
+        Assert.assertEquals(object.get("active"), true);
+    }
+
+    /**
+     * Invoke given endpointUri for GET with given body and Basic authentication.
+     *
+     * @param endpointURI EndpointURI.
+     * @return Response Response of the GET request.
+     */
+    private Response getResponseOfGet(String endpointURI) {
+
+        return given().auth().preemptive().basic(userInfo.getUserName(), userInfo.getPassword())
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .when()
+                .get(endpointURI);
+    }
+
+    /**
+     * Invoke given endpointUri for DELETE with given body and Basic authentication, authentication credential being
+     * the authenticatingUserName and authenticatingCredential.
+     *
+     * @param endpointURI EndpointURI.
+     * @return Response Response of the DELETE request.
+     */
+    private Response getResponseOfDelete(String endpointURI) {
+
+        return given().auth().preemptive().basic(userInfo.getUserName(), userInfo.getPassword())
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails().log().ifValidationFails()
+                .when().log().ifValidationFails()
+                .delete(endpointURI);
+    }
+
+    /**
+     * Get introspection endpoint response by callling introspection endpoint.
+     *
+     * @return JSONObject
+     * @throws Exception
+     */
+    private JSONObject testIntrospectionEndpoint() throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        urlParameters.add(new BasicNameValuePair("token", accessToken));
+        return responseObject(OAuth2Constant.INTRO_SPEC_ENDPOINT, urlParameters, userInfo.getUserName(),
+                userInfo.getPassword());
+    }
+
+    /**
+     * Build post request and return json response object.
+     *
+     * @param endpoint       Endpoint.
+     * @param postParameters postParameters.
+     * @param key            Basic authentication key.
+     * @param secret         Basic authentication secret.
+     * @return JSON object of the response.
+     * @throws Exception
+     */
+    private JSONObject responseObject(String endpoint, List<NameValuePair> postParameters, String key, String secret)
+            throws Exception {
+
+        HttpPost httpPost = new HttpPost(endpoint);
+        httpPost.setHeader("Authorization", "Basic " + getBase64EncodedString(key, secret));
+        httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded");
+        httpPost.setEntity(new UrlEncodedFormEntity(postParameters));
+        HttpResponse response = client.execute(httpPost);
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        EntityUtils.consume(response.getEntity());
+        JSONParser parser = new JSONParser();
+        JSONObject json = (JSONObject) parser.parse(responseString);
+        if (json == null) {
+            throw new Exception("Error occurred while getting the response.");
+        }
+        return json;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -69,6 +69,7 @@
             <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>
 
             <!--TODO Remove following open id tests since deprecated-->
             <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -116,6 +116,7 @@
             <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />
             <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>
             <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>
+            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>
         </classes>
     </test>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2046,7 +2046,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.214</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.215</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2068,7 +2068,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.20</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.4.121</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.4.123</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.5</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.2</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
This needs to be merged after bumping the oauth version (6.4.122) in the product-is