### PR TITLE
Add RemoteIpValve to IS tomcat valves

### DIFF
--- a/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -67,6 +67,17 @@
 
             <Host name="localhost" unpackWARs="true" deployOnStartup="false" autoDeploy="false"
                   appBase="${carbon.home}/repository/deployment/server/webapps/">
+                {% if catalinaValves.remoteIpValve.enable is sameas true %}
+                <!-- This should be defined before the AuthenticationValve to get the real client IP addresses via request headers. -->
+                <Valve
+                    className="org.apache.catalina.valves.RemoteIpValve"
+                    internalProxies="{{catalinaValves.remoteIpValve.internalProxies}}"
+                    remoteIpHeader="{{catalinaValves.remoteIpValve.remoteIpHeader}}"
+                    protocolHeader="{{catalinaValves.remoteIpValve.protocolHeader}}"
+                    proxiesHeader="{{catalinaValves.remoteIpValve.proxiesHeader}}"
+                    trustedProxies="{{catalinaValves.remoteIpValve.trustedProxies}}"
+                />
+                {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
                        headerToCorrelationIdMapping="{{log_correlation.header_config}}"
                        queryToCorrelationIdMapping="{'RelayState':'Correlation-ID'}"/>


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/10805

With `org.apache.catalina.valves.RemoteIpValve` [1], the real client IP addresses can be added to request headers instead of IP addresses presented by a proxy or a load balancer. This valve can be enabled by the deployment.toml file by adding the following configuration.

```
[catalinaValves.remoteIpValve]
enable=true
remoteIpHeader="X-Forwarded-For"
protocolHeader="X-Forwarded-Proto"
proxiesHeader="X-Forwarded-By"
```

[1] https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/valves/RemoteIpValve.html