### PR TITLE
Move TOTP into plugins

### DIFF
--- a/modules/connectors/pom.xml
+++ b/modules/connectors/pom.xml
@@ -146,30 +146,6 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!-- Download totp authenticator jar from nexus and copy to the authenticatorCopied/jar folder-->
-                    <execution>
-                        <id>download_totp_jar</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
-                                    <artifactId>
-                                        org.wso2.carbon.extension.identity.authenticator.totp.connector
-                                    </artifactId>
-                                    <version>${authenticator.totp.version}</version>
-                                    <type>jar</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${basedir}/target/authenticatorCopied/jar
-                                    </outputDirectory>
-                                    <includes>**/*.jar</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
                     <!-- Download local authentication API jar from nexus and copy to the authenticatorCopied/jar
                     folder-->
                     <execution>
@@ -239,29 +215,6 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!-- Download TOTP endpoint war from nexus and copy to the authenticatorCopied/war folder-->
-                    <execution>
-                        <id>download_totp_war</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.wso2.identity.apps</groupId>
-                                    <artifactId>totp-authentication-portal</artifactId>
-                                    <version>${identity.apps.version}</version>
-                                    <type>war</type>
-                                    <overWrite>true</overWrite>
-                                    <destFileName>totpauthenticationendpoint.war</destFileName>
-                                    <outputDirectory>${basedir}/target/authenticatorCopied/war
-                                    </outputDirectory>
-                                    <includes>**/*.war</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>download_x509certificateauthenticationendpoint_war</id>
                         <phase>compile</phase>
@@ -306,28 +259,6 @@
                                     <outputDirectory>${basedir}/target/authenticatorCopied/war
                                     </outputDirectory>
                                     <includes>**/*.war</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                    <!-- Download authenticator util module copied to authenticatorCopied/jar folder-->
-                    <execution>
-                        <id>download_authenticator_utils</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
-                                    <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
-                                    <version>${identity.extension.utils}</version>
-                                    <type>jar</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${basedir}/target/authenticatorCopied/jar
-                                    </outputDirectory>
-                                    <includes>**/*.jar</includes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -659,14 +659,6 @@
                                 </unzip>
                                 <delete file="../connectors/target/authenticatorCopied/war/smsotpauthenticationendpoint.war" />
 
-                                <!-- Explode the totpauthenticationendpoint.war -->
-                                <unzip dest="../connectors/target/authenticatorCopied/war/totpauthenticationendpoint">
-                                    <fileset dir="../connectors/target/authenticatorCopied/war">
-                                        <include name="totpauthenticationendpoint.war" />
-                                    </fileset>
-                                </unzip>
-                                <delete file="../connectors/target/authenticatorCopied/war/totpauthenticationendpoint.war" />
-
                                 <!-- Explode the emailotpauthenticationendpoint.war -->
                                 <unzip dest="../connectors/target/authenticatorCopied/war/emailotpauthenticationendpoint">
                                     <fileset dir="../connectors/target/authenticatorCopied/war">

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -436,15 +436,6 @@
             </includes>
         </fileSet>
 
-        <!--Copy web apps for for totp authenticators-->
-        <fileSet>
-            <directory>../connectors/target/authenticatorCopied/war</directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
-            <includes>
-                <include>totpauthenticationendpoint.war</include>
-            </includes>
-        </fileSet>
-
         <!--Copy web apps for for emailotp authenticators-->
         <fileSet>
             <directory>../connectors/target/authenticatorCopied/war</directory>
@@ -752,7 +743,6 @@
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
             <includes>
                 <include>smsotpauthenticationendpoint/</include>
-                <include>totpauthenticationendpoint/</include>
                 <include>emailotpauthenticationendpoint/</include>
                 <include>api#identity#auth#v1.1/</include>
                 <include>x509certificateauthenticationendpoint/</include>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -249,6 +249,12 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.carbon.auth.mutualssl:org.wso2.carbon.identity.authenticator.mutualssl.feature:${identity.carbon.auth.mutual.ssl.version}
                                 </featureArtifactDef>
+                                <featureArtifactDef>
+                                    org.wso2.carbon.extension.identity.authenticator.utils:org.wso2.carbon.extension.identity.utils.helper.feature:${identity.extension.utils}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
+                                    org.wso2.carbon.extension.identity.authenticator.outbound.totp:org.wso2.carbon.extension.identity.authenticator.totp.feature:${authenticator.totp.version}
+                                </featureArtifactDef>
 
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.user.ws:org.wso2.carbon.um.ws.service.feature:${identity.user.ws.version}
@@ -945,6 +951,17 @@
                                     <id>org.wso2.carbon.identity.developer.language-server.feature.group</id>
                                     <version>${org.wso2.carbon.identity.developer.version}</version>
                                 </feature>
+
+
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.helper.feature.group</id>
+                                    <version>${identity.extension.utils}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.authenticator.totp.connector.feature.group</id>
+                                    <version>${authenticator.totp.version}</version>
+                                </feature>
+
                             </features>
                         </configuration>
                     </execution>
@@ -1428,6 +1445,16 @@
                                     <id>org.wso2.carbon.identity.developer.language-server.feature.group</id>
                                     <version>${org.wso2.carbon.identity.developer.version}</version>
                                 </feature>
+
+                                <!-- Connectors -->
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.helper.feature.group</id>
+                                    <version>${identity.extension.utils}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.authenticator.totp.connector.feature.group</id>
+                                    <version>${authenticator.totp.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -1848,6 +1875,16 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.developer.language-server.feature.group</id>
                                     <version>${org.wso2.carbon.identity.developer.version}</version>
+                                </feature>
+
+                                <!-- Connectors -->
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.helper.feature.group</id>
+                                    <version>${identity.extension.utils}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.authenticator.totp.connector.feature.group</id>
+                                    <version>${authenticator.totp.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2041,7 +2041,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.226</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.228</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2134,7 +2134,7 @@
         <identity.metadata.saml.version>1.4.3</identity.metadata.saml.version>
 
         <!-- Connector Versions -->
-        <authenticator.totp.version>2.2.7</authenticator.totp.version>
+        <authenticator.totp.version>3.0.0</authenticator.totp.version>
         <authenticator.office365.version>2.0.2</authenticator.office365.version>
         <authenticator.smsotp.version>3.0.12</authenticator.smsotp.version>
         <authenticator.emailotp.version>3.0.15</authenticator.emailotp.version>
@@ -2154,7 +2154,7 @@
         <carbon.identity.oauth.uma.version>1.2.7</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.version>1.0.643</identity.apps.version>
+        <identity.apps.version>1.0.645</identity.apps.version>
 
         <!-- Charon -->
         <charon.version>3.3.26</charon.version>


### PR DESCRIPTION
Part of #10998

- Remove totp connector from dropins
- Remove totp webapps from being added (TOTP page are now in authentication portal)
- Install TOTP via feature into plugins
- Install Identity Extension helper via feature into plugins
