### PR TITLE
Skip the session nonce cookie validation for the secondary IS in integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/AbstractIdentityFederationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/AbstractIdentityFederationTestCase.java
@@ -99,9 +99,7 @@ public abstract class AbstractIdentityFederationTestCase extends ISIntegrationTe
             return;
         }
 
-        String serviceUrl = getSecureServiceUrl(portOffset,
-                automationContextMap.get(portOffset).getContextUrls()
-                        .getSecureServiceUrl());
+        String serviceUrl = automationContextMap.get(portOffset).getContextUrls().getSecureServiceUrl() + "/";;
 
         if (sessionCookie == null) {
             AuthenticatorClient authenticatorClient = new AuthenticatorClient(serviceUrl);
@@ -287,10 +285,4 @@ public abstract class AbstractIdentityFederationTestCase extends ISIntegrationTe
 
         return HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
     }
-
-    private String getSecureServiceUrl(int portOffset, String baseUrl) {
-
-        return baseUrl.replace("9853", String.valueOf(DEFAULT_PORT + portOffset)) + "/";
-    }
-
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/ConditionalAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/ConditionalAuthenticationTestCase.java
@@ -65,7 +65,6 @@ public class ConditionalAuthenticationTestCase extends AbstractAdaptiveAuthentic
     private static final String IDENTITY_PROVIDER_ALIAS =
             "https://localhost:" + IS_DEFAULT_HTTPS_PORT + "/oauth2/token/";
     private static final String SECONDARY_IS_SAMLSSO_URL = "https://localhost:9854/samlsso";
-    private static final int PORT_OFFSET_1 = 1;
     private static final String SAML_NAME_ID_FORMAT = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     private static final String PRIMARY_IS_APPLICATION_NAME = "testOauthApp";
     private static final String SECONDARY_IS_APPLICATION_NAME = "testSAMLApp";
@@ -411,8 +410,7 @@ public class ConditionalAuthenticationTestCase extends AbstractAdaptiveAuthentic
     private void startSecondaryIS() throws Exception {
 
         AutomationContext context = testDataHolder.getAutomationContext();
-        String serviceUrl = (context.getContextUrls().getSecureServiceUrl())
-                .replace("9853", String.valueOf(IS_DEFAULT_HTTPS_PORT + PORT_OFFSET_1)) + "/";
+        String serviceUrl = context.getContextUrls().getSecureServiceUrl() + "/";
 
         AuthenticatorClient authenticatorClient = new AuthenticatorClient(serviceUrl);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/ConditionalAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/ConditionalAuthenticationTestCase.java
@@ -163,6 +163,9 @@ public class ConditionalAuthenticationTestCase extends AbstractAdaptiveAuthentic
     public void testConditionalAuthentication() throws Exception {
 
         updateAuthScript("ConditionalAuthenticationTestCase.js");
+        log.info("Conditional Authentication userName: " + userInfo.getUserName());
+        log.info("Conditional Authentication userPassword: " + userInfo.getPassword());
+        log.info("Conditional Authentication userDomain: " + userInfo.getUserDomain());
         response = loginWithOIDC(PRIMARY_IS_APPLICATION_NAME, consumerKey, client);
         /* Here if the client is redirected to the secondary IS, it indicates that the conditional authentication steps
          has been successfully completed. */

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/ConditionalAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/ConditionalAuthenticationTestCase.java
@@ -409,8 +409,10 @@ public class ConditionalAuthenticationTestCase extends AbstractAdaptiveAuthentic
 
     private void startSecondaryIS() throws Exception {
 
+        log.info("Starting secondary IS");
         AutomationContext context = testDataHolder.getAutomationContext();
         String serviceUrl = context.getContextUrls().getSecureServiceUrl() + "/";
+        log.info("Service url for the secondary IS: " + serviceUrl);
 
         AuthenticatorClient authenticatorClient = new AuthenticatorClient(serviceUrl);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/SecondaryCarbonServerInitializerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/SecondaryCarbonServerInitializerTestCase.java
@@ -11,7 +11,6 @@ import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException
 import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
-import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 
 import java.io.File;
@@ -91,12 +90,12 @@ public class SecondaryCarbonServerInitializerTestCase extends AbstractIdentityFe
     private void changeServerConfiguration(String fileName, AutomationContext server) throws IOException,
             XPathExpressionException, AutomationUtilException {
 
-        log.info("Using the embedded H2 database for the secondary server.");
-        String carbonHome = Utils.getResidentCarbonHome();
+        String carbonHome = System.getProperty("carbon.home");
+        log.info("Using the embedded H2 database for the secondary server. " + carbonHome);
         File defaultTomlFile = getDeploymentTomlFile(carbonHome);
         File configuredTomlFile = new File
                 (getISResourceLocation() + File.separator + "provisioning" + File.separator + fileName);
-        serverConfigurationManager = new ServerConfigurationManager(server);
+        ServerConfigurationManager serverConfigurationManager = new ServerConfigurationManager(server);
         serverConfigurationManager.applyConfigurationWithoutRestart(configuredTomlFile, defaultTomlFile, true);
         serverConfigurationManager.restartGracefully();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/provisioning/ProvisioningTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/provisioning/ProvisioningTestCase.java
@@ -129,13 +129,9 @@ public class ProvisioningTestCase extends ISIntegrationTest {
         createServiceClientsForServers(null, PORT_OFFSET_2, new CommonConstants.AdminClients[]{CommonConstants
                 .AdminClients.USER_MANAGEMENT_CLIENT});
 
-        // TODO: port offset will no longer needed if TAF 4.3.1 issue get fixed
-        scim_url_0 = getSCIMUrl(PORT_OFFSET_0, automationContextMap.get(PORT_OFFSET_0).getContextUrls()
-                .getSecureServiceUrl());
-        scim_url_1 = getSCIMUrl(PORT_OFFSET_1, automationContextMap.get(PORT_OFFSET_1).getContextUrls()
-                .getSecureServiceUrl());
-        scim_url_2 = getSCIMUrl(PORT_OFFSET_2, automationContextMap.get(PORT_OFFSET_2).getContextUrls()
-                .getSecureServiceUrl());
+        scim_url_0 = getSCIMUrl(automationContextMap.get(PORT_OFFSET_0).getContextUrls().getSecureServiceUrl());
+        scim_url_1 = getSCIMUrl(automationContextMap.get(PORT_OFFSET_1).getContextUrls().getSecureServiceUrl());
+        scim_url_2 = getSCIMUrl(automationContextMap.get(PORT_OFFSET_2).getContextUrls().getSecureServiceUrl());
     }
 
     @AfterClass(alwaysRun = true)
@@ -310,10 +306,7 @@ public class ProvisioningTestCase extends ISIntegrationTest {
             return;
         }
 
-        //TODO: Need to remove getSecureServiceUrl method when server start issue got fixed / TAF 4.3.1
-        String serviceUrl = getSecureServiceUrl(portOffset,
-                automationContextMap.get(portOffset).getContextUrls()
-                        .getSecureServiceUrl());
+        String serviceUrl = automationContextMap.get(portOffset).getContextUrls().getSecureServiceUrl() + "/";;
 
         if (sessionCookie == null) {
 
@@ -427,15 +420,8 @@ public class ProvisioningTestCase extends ISIntegrationTest {
         manager.startServers(server2);
     }
 
-    //TODO: Need to remove
+    private String getSCIMUrl(String baseUrl) {
 
-    private String getSecureServiceUrl(int portOffset, String baseUrl) {
-
-        return baseUrl.replace("9853", String.valueOf(DEFAULT_PORT + portOffset)) + "/";
-    }
-
-    private String getSCIMUrl(int portOffset, String baseUrl) {
-
-        return baseUrl.replace("9853/services", String.valueOf(DEFAULT_PORT + portOffset)) + "/wso2/scim/";
+        return baseUrl.replace("/services", "/wso2/scim/");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/provisioning/default_configs_with_h2_db.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/provisioning/default_configs_with_h2_db.toml
@@ -30,3 +30,7 @@ password = "wso2carbon"
 [keystore.primary]
 file_name = "wso2carbon.jks"
 password = "wso2carbon"
+
+# Disable the session cookie validation in the secondary IS as it is conflicting with the primary IS nonce Cookie
+[session.nonce.cookie]
+enabled = false

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/automation.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/automation.xml
@@ -193,9 +193,8 @@
                     <host type="default">localhost</host>
                 </hosts>
                 <ports>
-                    <!-- TODO: keeping ports without a offset due to a bug in TAF 4.3.1, Need to be changed to 9764 and 9444-->
-                    <port type="http">10173</port>
-                    <port type="https">9853</port>
+                    <port type="http">10174</port>
+                    <port type="https">9854</port>
                 </ports>
                 <properties>
                 </properties>
@@ -205,9 +204,8 @@
                     <host type="default">localhost</host>
                 </hosts>
                 <ports>
-                    <!-- TODO: keeping ports without a offset due to a bug in TAF 4.3.1, Need to be changed to 9765 and 9445 -->
-                    <port type="http">10173</port>
-                    <port type="https">9853</port>
+                    <port type="http">10175</port>
+                    <port type="https">9855</port>
                 </ports>
                 <properties>
                 </properties>


### PR DESCRIPTION
Related to: https://github.com/wso2/product-is/pull/10890

Disable the session cookie validation in the secondary IS as it is conflicting with the primary IS nonce Cookie and failing federated login tests due to the fix of https://github.com/wso2/carbon-identity-framework/pull/3296
```
[session.nonce.cookie]
enabled = false
```

With this, the following also fixed (Server urls generated from the TAF will be used in test cases)
- Remove added workaround due to a bug in TAF 4.3.1 

