### PR TITLE
Add a test for testing getting homeRealmIdentifiers using api/server/v1/configs/homeRealmIdentifiers endpoint

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigSuccessTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -135,6 +136,17 @@ public class ConfigSuccessTest extends ConfigTestBase {
                 .body("realmConfig.adminUser", is(adminUserName))
                 .body("realmConfig.adminRole", notNullValue())
                 .body("realmConfig.everyoneRole", notNullValue());
+    }
+
+    @Test(dependsOnMethods = {"testGetConfigs"})
+    public void testGetHomeRealmIdentifiers() throws Exception {
+
+        Response response = getResponseOfGet(HOME_REALM_IDENTIFIERS_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("\"localhost\""));
     }
 
     @Test(dependsOnMethods = {"testGetConfigs"})

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
@@ -39,7 +39,7 @@ public class ConfigTestBase extends RESTAPIServerTestBase {
     public static final String CONFIGS_AUTHENTICATOR_API_BASE_PATH = "/configs/authenticators";
     public static final String CONFIGS_INBOUND_SCIM_API_BASE_PATH = "/configs/provisioning/inbound/scim";
     public static final String CORS_CONFIGS_API_BASE_PATH = "/configs/cors";
-    public static final String HOME_REALM_IDENTIFIERS_API_BASE_PATH = "/configs/homeRealmIdentifiers";
+    public static final String HOME_REALM_IDENTIFIERS_API_BASE_PATH = "/configs/home-realm-identifiers";
 
     public static final String PATH_SEPARATOR = "/";
     public static final String SAMPLE_AUTHENTICATOR_ID = "QmFzaWNBdXRoZW50aWNhdG9y";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
@@ -39,6 +39,7 @@ public class ConfigTestBase extends RESTAPIServerTestBase {
     public static final String CONFIGS_AUTHENTICATOR_API_BASE_PATH = "/configs/authenticators";
     public static final String CONFIGS_INBOUND_SCIM_API_BASE_PATH = "/configs/provisioning/inbound/scim";
     public static final String CORS_CONFIGS_API_BASE_PATH = "/configs/cors";
+    public static final String HOME_REALM_IDENTIFIERS_API_BASE_PATH = "/configs/homeRealmIdentifiers";
 
     public static final String PATH_SEPARATOR = "/";
     public static final String SAMPLE_AUTHENTICATOR_ID = "QmFzaWNBdXRoZW50aWNhdG9y";


### PR DESCRIPTION
This PR adds an integration test for testing getting home realm identifiers from the server configs using the newly introduced  `api/server/v1/configs/homeRealmIdentifiers` endpoint.

Should be merged after : https://github.com/wso2/identity-api-server/pull/260, https://github.com/wso2/carbon-identity-framework/pull/3349, and after bumping the identity.api.dispatcher.version