### PR TITLE
Change updated role name in the test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/UserManagementServiceAbstractTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/UserManagementServiceAbstractTest.java
@@ -72,8 +72,8 @@ public abstract class UserManagementServiceAbstractTest extends ISIntegrationTes
         if (userMgtClient.roleNameExists(newUserRole)) {
             userMgtClient.deleteRole(newUserRole);
         }
-        if (userMgtClient.roleNameExists(newUserRole + "tmpupdated")) {
-            userMgtClient.deleteRole(newUserRole + "tmpupdated");
+        if (userMgtClient.roleNameExists(newUserRole + "tmpupdate")) {
+            userMgtClient.deleteRole(newUserRole + "tmpupdate");
         }
         if (userMgtClient.roleNameExists(newUserRole + "tmp")) {
             userMgtClient.deleteRole(newUserRole + "tmp");
@@ -241,11 +241,11 @@ public abstract class UserManagementServiceAbstractTest extends ISIntegrationTes
     @Test(groups = "wso2.is", description = "Check update role name", dependsOnMethods = "testUpdateUsersOfRole")
     public void testUpdateRoleName() throws Exception {
 
-        userMgtClient.updateRoleName(userRoleTmp, userRoleTmp + "new");
+        userMgtClient.updateRoleName(userRoleTmp, userRoleTmp + "update");
 
         Assert.assertFalse(nameExists(userMgtClient.getAllRolesNames(userRoleTmp, 10), userRoleTmp), "Role update failed.");
-        Assert.assertTrue(nameExists(userMgtClient.getAllRolesNames(userRoleTmp + "new", 10), userRoleTmp + "update"), "Updating role has failed. Role not updated");
-        userRoleTmp = userRoleTmp + "new";
+        Assert.assertTrue(nameExists(userMgtClient.getAllRolesNames(userRoleTmp + "update", 10), userRoleTmp + "update"), "Updating role has failed. Role not updated");
+        userRoleTmp = userRoleTmp + "update";
 
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/UserManagementServiceAbstractTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/UserManagementServiceAbstractTest.java
@@ -241,11 +241,13 @@ public abstract class UserManagementServiceAbstractTest extends ISIntegrationTes
     @Test(groups = "wso2.is", description = "Check update role name", dependsOnMethods = "testUpdateUsersOfRole")
     public void testUpdateRoleName() throws Exception {
 
-        userMgtClient.updateRoleName(userRoleTmp, userRoleTmp + "updated");
+        userMgtClient.updateRoleName(userRoleTmp, userRoleTmp + "new");
 
-        Assert.assertFalse(nameExists(userMgtClient.getAllRolesNames(userRoleTmp, 10), userRoleTmp), "Role update failed.");
-        Assert.assertTrue(nameExists(userMgtClient.getAllRolesNames(userRoleTmp + "updated", 10), userRoleTmp + "updated"), "Updating role has failed. Role not updated");
-        userRoleTmp = userRoleTmp + "updated";
+        Assert.assertFalse(nameExists(userMgtClient.getAllRolesNames(userRoleTmp, 10), userRoleTmp),
+                "Role update failed.");
+        Assert.assertTrue(nameExists(userMgtClient.getAllRolesNames(userRoleTmp + "new", 10), userRoleTmp + "update"),
+                "Updating role has failed. Role not updated");
+        userRoleTmp = userRoleTmp + "new";
 
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/UserManagementServiceAbstractTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/UserManagementServiceAbstractTest.java
@@ -243,10 +243,8 @@ public abstract class UserManagementServiceAbstractTest extends ISIntegrationTes
 
         userMgtClient.updateRoleName(userRoleTmp, userRoleTmp + "new");
 
-        Assert.assertFalse(nameExists(userMgtClient.getAllRolesNames(userRoleTmp, 10), userRoleTmp),
-                "Role update failed.");
-        Assert.assertTrue(nameExists(userMgtClient.getAllRolesNames(userRoleTmp + "new", 10), userRoleTmp + "update"),
-                "Updating role has failed. Role not updated");
+        Assert.assertFalse(nameExists(userMgtClient.getAllRolesNames(userRoleTmp, 10), userRoleTmp), "Role update failed.");
+        Assert.assertTrue(nameExists(userMgtClient.getAllRolesNames(userRoleTmp + "new", 10), userRoleTmp + "update"), "Updating role has failed. Role not updated");
         userRoleTmp = userRoleTmp + "new";
 
     }


### PR DESCRIPTION
Fix integration test failure due to https://github.com/wso2/carbon-kernel/pull/2906/

The following exception occurred. (https://github.com/wso2/product-is/actions/runs/511163486)
```
[ERROR] testUpdateRoleName(org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase)  Time elapsed: 0.132 s  <<< FAILURE!
org.wso2.carbon.user.mgt.stub.UserAdminUserAdminException: UserAdminUserAdminException
```
Reason is the updated role name in ReadWriteLDAPUserStoreManagerTestCase test case 
 is **ReadWriteLDAPUserRoletmpupdated**. It has 31 characters. 
Since `  <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>`, userstore exception is thrown from userstore level.