### PR TITLE
Update integration test data to resolve test failure of mentioned PR 

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-VXNlciBPbmJvYXJkaW5n-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-VXNlciBPbmJvYXJkaW5n-response.json
@@ -22,6 +22,12 @@
           "description": "Lock self registered user account until e-mail verification."
         },
         {
+          "name": "SelfRegistration.SendConfirmationOnCreation",
+          "value": "false",
+          "displayName": "Enable Account Confirmation On Creation",
+          "description": "Enable user account confirmation when the user account is not locked on creation"
+        },
+        {
           "name": "SelfRegistration.Notification.InternallyManage",
           "value": "true",
           "displayName": "Manage notifications sending internally",

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
@@ -11,6 +11,10 @@
         "value": "true"
       },
       {
+        "name": "SelfRegistration.SendConfirmationOnCreation",
+        "value": "false"
+      },
+      {
         "name": "SelfRegistration.Notification.InternallyManage",
         "value": "true"
       },


### PR DESCRIPTION
Resolves: wso2/product-is/issues/10356

This pull request related with:
https://github.com/wso2-extensions/identity-governance/pull/464
https://github.com/wso2/carbon-identity-framework/pull/3392

### Purpose				
In self registration, there is no option to enable send verification notification to the user if disable account lock on creation. 
And also sometimes users may have to access the self registered account without verifying the account. 

### Describe the improvement
After a user creates an account, the user gets access to the account without verifying. 
And also the user has an option to verify the account by clicking verification notification. 
The client application has the ability to determine the user account state whether it is verified or not. (using accountState claim ). Then the client application can limit the user access according to the user account state. 

### Additional context
Application can be configured to enable send verification notification even if disable “Account Lock On Creation” option.
accountState claim value:
 Before verify the account : PENDING_SR
After verified the account : UNLOCK

This PR is related with  https://github.com/wso2/carbon-identity-framework/pull/3392

### Product Version
Wso2 IS 5.10.0
### How to reproduce
Identity -> Identity Providers and then click Resident
Expand the Account Management Policies section, and then expand the User Self Registration section
enable “Enable Send Notification On Creation”
