### PR TITLE
Added integration tests for DCR API

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
-import org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase;
 import org.wso2.identity.integration.test.oauth2.dcrm.api.util.OAuthDCRMConstants;
 
 import java.io.BufferedReader;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
@@ -139,7 +139,6 @@ public class OAuthDCRMTestCase extends ISIntegrationTest {
         dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
         dcrRequest.put(OAuthDCRMConstants.AUD, audience);
         dcrRequest.put(OAuthDCRMConstants.SOFTWARE_ID, OAuthDCRMConstants.SOFTWARE_ID_VALUE);
-        dcrRequest.put(OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD, OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD_VALUE);
         dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG,
                 OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE);
         dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC,
@@ -160,8 +159,6 @@ public class OAuthDCRMTestCase extends ISIntegrationTest {
         client_id = ((JSONObject) responseObj).get("client_id").toString();
         assertNotNull(client_id, "client_id cannot be null");
         assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.AUD), "aud cannot be null");
-        assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD),
-                "token_endpoint_auth_method cannot be null");
         assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG),
                 "id_token_encrypted_response_alg cannot be null");
         assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC),
@@ -342,43 +339,6 @@ public class OAuthDCRMTestCase extends ISIntegrationTest {
         EntityUtils.consume(successResponse.getEntity());
         client_id = ((JSONObject) responseObj).get("client_id").toString();
         assertNotNull(client_id, "client_id cannot be null");
-    }
-
-    @Test(alwaysRun = true, groups = "wso2.is", priority = 7, description = "Try to register service provider with " +
-            "invalid token_endpoint_auth_method")
-    public void testCreateServiceProviderRequestWithInvalidTokenEndpointAuthMethod() throws IOException {
-        HttpPost request = new HttpPost(getPath());
-        setRequestHeaders(request);
-
-        JSONArray grantTypes = new JSONArray();
-        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_AUTHORIZATION_CODE);
-        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_IMPLICIT);
-
-        JSONArray redirectURI = new JSONArray();
-        redirectURI.add(OAuthDCRMConstants.REDIRECT_URI);
-
-        JSONObject dcrRequest = new JSONObject();
-        dcrRequest.put(OAuthDCRMConstants.CLIENT_NAME, DUMMY_DCR_APP);
-        dcrRequest.put(OAuthDCRMConstants.GRANT_TYPES, grantTypes);
-        dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
-        dcrRequest.put(OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD,
-                OAuthDCRMConstants.INVALID_TOKEN_ENDPOINT_AUTH_METHOD_VALUE);
-
-        StringEntity entity = new StringEntity(dcrRequest.toJSONString());
-
-        request.setEntity(entity);
-
-        HttpResponse response = client.execute(request);
-        assertEquals(response.getStatusLine().getStatusCode(), 400, "Service Provider " +
-                "creation request with invalid token_endpoint_auth_method should have returned a bad request");
-
-        BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
-        Object responseObj = JSONValue.parse(rd);
-        EntityUtils.consume(response.getEntity());
-
-        String errorMsg = ((JSONObject) responseObj).get("error").toString();
-
-        assertEquals(errorMsg, "invalid_client_metadata", "Invalid error message");
     }
 
     @Test(alwaysRun = true, groups = "wso2.is", priority = 8, description = "Try to register service provider with " +

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
@@ -158,8 +158,15 @@ public class OAuthDCRMTestCase extends ISIntegrationTest {
         Object responseObj = JSONValue.parse(rd);
         EntityUtils.consume(response.getEntity());
         client_id = ((JSONObject) responseObj).get("client_id").toString();
-
         assertNotNull(client_id, "client_id cannot be null");
+        assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.AUD), "aud cannot be null");
+        assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD),
+                "token_endpoint_auth_method cannot be null");
+        assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG),
+                "id_token_encrypted_response_alg cannot be null");
+        assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC),
+                "id_token_encrypted_response_enc cannot be null");
+        assertNotNull(((JSONObject) responseObj).get(OAuthDCRMConstants.SOFTWARE_ID), "software_id cannot be null");
     }
 
     @Test(alwaysRun = true, groups = "wso2.is", priority = 2, description =

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/OAuthDCRMTestCase.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase;
 import org.wso2.identity.integration.test.oauth2.dcrm.api.util.OAuthDCRMConstants;
 
 import java.io.BufferedReader;
@@ -115,6 +116,51 @@ public class OAuthDCRMTestCase extends ISIntegrationTest {
 
         assertNotNull(client_id, "client_id cannot be null");
 
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", priority = 1, description = "Create a service provider with optional " +
+            "client metadata values successfully")
+    public void testCreateServiceProviderRequestWithOptionalAttributes() throws IOException {
+        HttpPost request = new HttpPost(getPath());
+        setRequestHeaders(request);
+
+        JSONArray grantTypes = new JSONArray();
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_AUTHORIZATION_CODE);
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_IMPLICIT);
+
+        JSONArray redirectURI = new JSONArray();
+        redirectURI.add(OAuthDCRMConstants.REDIRECT_URI);
+
+        JSONArray audience = new JSONArray();
+        audience.add(OAuthDCRMConstants.AUD_VALUE);
+
+        JSONObject dcrRequest = new JSONObject();
+        dcrRequest.put(OAuthDCRMConstants.CLIENT_NAME, OAuthDCRMConstants.APPLICATION_NAME_OPTIONAL_ATTRIBUTES);
+        dcrRequest.put(OAuthDCRMConstants.GRANT_TYPES, grantTypes);
+        dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
+        dcrRequest.put(OAuthDCRMConstants.AUD, audience);
+        dcrRequest.put(OAuthDCRMConstants.SOFTWARE_ID, OAuthDCRMConstants.SOFTWARE_ID_VALUE);
+        dcrRequest.put(OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD, OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD_VALUE);
+        dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG,
+                OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE);
+        dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC,
+                OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE);
+
+        StringEntity entity = new StringEntity(dcrRequest.toJSONString());
+
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 201, "Service Provider " +
+                "has not been created successfully");
+
+        BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+
+        Object responseObj = JSONValue.parse(rd);
+        EntityUtils.consume(response.getEntity());
+        client_id = ((JSONObject) responseObj).get("client_id").toString();
+
+        assertNotNull(client_id, "client_id cannot be null");
     }
 
     @Test(alwaysRun = true, groups = "wso2.is", priority = 2, description =
@@ -290,6 +336,153 @@ public class OAuthDCRMTestCase extends ISIntegrationTest {
         EntityUtils.consume(successResponse.getEntity());
         client_id = ((JSONObject) responseObj).get("client_id").toString();
         assertNotNull(client_id, "client_id cannot be null");
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", priority = 7, description = "Try to register service provider with " +
+            "invalid token_endpoint_auth_method")
+    public void testCreateServiceProviderRequestWithInvalidTokenEndpointAuthMethod() throws IOException {
+        HttpPost request = new HttpPost(getPath());
+        setRequestHeaders(request);
+
+        JSONArray grantTypes = new JSONArray();
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_AUTHORIZATION_CODE);
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_IMPLICIT);
+
+        JSONArray redirectURI = new JSONArray();
+        redirectURI.add(OAuthDCRMConstants.REDIRECT_URI);
+
+        JSONObject dcrRequest = new JSONObject();
+        dcrRequest.put(OAuthDCRMConstants.CLIENT_NAME, DUMMY_DCR_APP);
+        dcrRequest.put(OAuthDCRMConstants.GRANT_TYPES, grantTypes);
+        dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
+        dcrRequest.put(OAuthDCRMConstants.TOKEN_ENDPOINT_AUTH_METHOD,
+                OAuthDCRMConstants.INVALID_TOKEN_ENDPOINT_AUTH_METHOD_VALUE);
+
+        StringEntity entity = new StringEntity(dcrRequest.toJSONString());
+
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 400, "Service Provider " +
+                "creation request with invalid token_endpoint_auth_method should have returned a bad request");
+
+        BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+        Object responseObj = JSONValue.parse(rd);
+        EntityUtils.consume(response.getEntity());
+
+        String errorMsg = ((JSONObject) responseObj).get("error").toString();
+
+        assertEquals(errorMsg, "invalid_client_metadata", "Invalid error message");
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", priority = 8, description = "Try to register service provider with " +
+            "invalid id_token_encrypted_response_alg")
+    public void testCreateServiceProviderRequestWithInvalidIdTokenEncryptedResponseAlg() throws IOException {
+        HttpPost request = new HttpPost(getPath());
+        setRequestHeaders(request);
+
+        JSONArray grantTypes = new JSONArray();
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_AUTHORIZATION_CODE);
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_IMPLICIT);
+
+        JSONArray redirectURI = new JSONArray();
+        redirectURI.add(OAuthDCRMConstants.REDIRECT_URI);
+
+        JSONObject dcrRequest = new JSONObject();
+        dcrRequest.put(OAuthDCRMConstants.CLIENT_NAME, DUMMY_DCR_APP);
+        dcrRequest.put(OAuthDCRMConstants.GRANT_TYPES, grantTypes);
+        dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
+        dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG,
+                OAuthDCRMConstants.INVALID_ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE);
+
+
+        StringEntity entity = new StringEntity(dcrRequest.toJSONString());
+
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 500, "Service Provider " +
+                "creation request with invalid id_token_encrypted_response_alg should have returned an internal " +
+                "server error");
+
+        EntityUtils.consume(response.getEntity());
+
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", priority = 9, description = "Try to register service provider with " +
+            "invalid id_token_encrypted_response_enc")
+    public void testCreateServiceProviderRequestWithInvalidIdTokenEncryptedResponseEnc() throws IOException {
+        HttpPost request = new HttpPost(getPath());
+        setRequestHeaders(request);
+
+        JSONArray grantTypes = new JSONArray();
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_AUTHORIZATION_CODE);
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_IMPLICIT);
+
+        JSONArray redirectURI = new JSONArray();
+        redirectURI.add(OAuthDCRMConstants.REDIRECT_URI);
+
+        JSONObject dcrRequest = new JSONObject();
+        dcrRequest.put(OAuthDCRMConstants.CLIENT_NAME, DUMMY_DCR_APP);
+        dcrRequest.put(OAuthDCRMConstants.GRANT_TYPES, grantTypes);
+        dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
+        dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG,
+                OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE);
+        dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC,
+                OAuthDCRMConstants.INVALID_ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE);
+
+
+        StringEntity entity = new StringEntity(dcrRequest.toJSONString());
+
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 500, "Service Provider " +
+                "creation request with invalid id_token_encrypted_response_enc should have returned an internal " +
+                "server error");
+
+        EntityUtils.consume(response.getEntity());
+
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", priority = 10, description = "Try to register service provider with " +
+            "id_token_encrypted_response_enc without id_token_encrypted_response_alg")
+    public void testCreateServiceProviderRequestWithoutIdTokenEncryptedResponseAlg() throws IOException {
+        HttpPost request = new HttpPost(getPath());
+        setRequestHeaders(request);
+
+        JSONArray grantTypes = new JSONArray();
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_AUTHORIZATION_CODE);
+        grantTypes.add(OAuthDCRMConstants.GRANT_TYPE_IMPLICIT);
+
+        JSONArray redirectURI = new JSONArray();
+        redirectURI.add(OAuthDCRMConstants.REDIRECT_URI);
+
+        JSONObject dcrRequest = new JSONObject();
+        dcrRequest.put(OAuthDCRMConstants.CLIENT_NAME, DUMMY_DCR_APP);
+        dcrRequest.put(OAuthDCRMConstants.GRANT_TYPES, grantTypes);
+        dcrRequest.put(OAuthDCRMConstants.REDIRECT_URIS, redirectURI);
+        dcrRequest.put(OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC,
+                OAuthDCRMConstants.ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE);
+
+
+        StringEntity entity = new StringEntity(dcrRequest.toJSONString());
+
+        request.setEntity(entity);
+
+        HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 400, "Service Provider " +
+                "creation request with id_token_encrypted_response_enc and without id_token_encrypted_response_alg  " +
+                "should have returned a bad request");
+
+        BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+        Object responseObj = JSONValue.parse(rd);
+        EntityUtils.consume(response.getEntity());
+
+        String errorMsg = ((JSONObject) responseObj).get("error").toString();
+
+        assertEquals(errorMsg, "invalid_client_metadata", "Invalid error message");
+
     }
 
     private void setRequestHeaders(HttpPost request) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/util/OAuthDCRMConstants.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/util/OAuthDCRMConstants.java
@@ -42,7 +42,6 @@ public class OAuthDCRMConstants {
 
     public static final String INVALID_CLIENT_ID = "invalid_client_id";
     public static final String INVALID_CLIENT_SECRET = "invalid_client_secret";
-    public static final String INVALID_TOKEN_ENDPOINT_AUTH_METHOD_VALUE = "invalid_token_endpoint_auth_method";
     public static final String INVALID_ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE = "invalid_id_token_encryption_alg";
     public static final String INVALID_ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE = "invalid_id_token_encryption_method";
 
@@ -51,7 +50,6 @@ public class OAuthDCRMConstants {
     public static final String REDIRECT_URI = "http://TestApp.com";
     public static final String AUD_VALUE = "testAud";
     public static final String SOFTWARE_ID_VALUE = "testId";
-    public static final String TOKEN_ENDPOINT_AUTH_METHOD_VALUE = "none";
     public static final String ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE = "RSA-OAEP";
     public static final String ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE = "A128GCM";
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/util/OAuthDCRMConstants.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/dcrm/api/util/OAuthDCRMConstants.java
@@ -27,6 +27,12 @@ public class OAuthDCRMConstants {
     public static final String CLIENT_SECRET = "client_secret";
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
+    public static final String AUD = "aud";
+    public static final String SOFTWARE_ID = "software_id";
+    public static final String TOKEN_ENDPOINT_AUTH_METHOD = "token_endpoint_auth_method";
+    public static final String ID_TOKEN_ENCRYPTED_RESPONSE_ALG= "id_token_encrypted_response_alg";
+    public static final String ID_TOKEN_ENCRYPTED_RESPONSE_ENC= "id_token_encrypted_response_enc";
+
 
     public static final String BACKEND_FAILED = "backend_failed";
 
@@ -36,9 +42,18 @@ public class OAuthDCRMConstants {
 
     public static final String INVALID_CLIENT_ID = "invalid_client_id";
     public static final String INVALID_CLIENT_SECRET = "invalid_client_secret";
+    public static final String INVALID_TOKEN_ENDPOINT_AUTH_METHOD_VALUE = "invalid_token_endpoint_auth_method";
+    public static final String INVALID_ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE = "invalid_id_token_encryption_alg";
+    public static final String INVALID_ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE = "invalid_id_token_encryption_method";
 
     public static final String APPLICATION_NAME = "TestApp";
+    public static final String APPLICATION_NAME_OPTIONAL_ATTRIBUTES = "TestApp2";
     public static final String REDIRECT_URI = "http://TestApp.com";
+    public static final String AUD_VALUE = "testAud";
+    public static final String SOFTWARE_ID_VALUE = "testId";
+    public static final String TOKEN_ENDPOINT_AUTH_METHOD_VALUE = "none";
+    public static final String ID_TOKEN_ENCRYPTED_RESPONSE_ALG_VALUE = "RSA-OAEP";
+    public static final String ID_TOKEN_ENCRYPTED_RESPONSE_ENC_VALUE = "A128GCM";
 
     public static final String OAUTH_VERSION = "OAuth-2.0";
 


### PR DESCRIPTION
Added integration tests for DCR API to incorporate following additional client metadata values

- aud
- software_id
- token_endpoint_auth_method
- id_token_encrypted_response_alg
- id_token_encrypted_response_enc  