### PR TITLE
Move uma, recovery and user endpoints as jars pack inside dispatcher

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -539,22 +539,6 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#dcr#v1.1.war" />
 
-                                <!-- Explode the api#identity#oauth2#uma#permission#v1.0.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
-                                        <include name="api#identity#oauth2#uma#permission#v1.0.war" />
-                                    </fileset>
-                                </unzip>
-                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#permission#v1.0.war" />
-
-                                <!-- Explode the api#identity#oauth2#uma#resourceregistration#v1.0.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#resourceregistration#v1.0">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
-                                        <include name="api#identity#oauth2#uma#resourceregistration#v1.0.war" />
-                                    </fileset>
-                                </unzip>
-                                <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#uma#resourceregistration#v1.0.war" />
-
                                 <!-- Explode the api#identity#oauth2#v1.0.war-->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#v1.0">
                                     <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
@@ -563,12 +547,7 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#oauth2#v1.0.war" />
 
-                                <!-- Explode the api#identity#recovery#v0.9.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#recovery#v0.9">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
-                                        <include name="api#identity#recovery#v0.9.war" />
-                                    </fileset>
-                                </unzip>
+                                <!-- Delete the api#identity#recovery#v0.9.war -->
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#recovery#v0.9.war" />
 
                                 <!-- Explode the api#identity#template#mgt#v1.0.0.war -->
@@ -579,12 +558,7 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#template#mgt#v1.0.0.war" />
 
-                                <!-- Explode the api#identity#user#v1.0.war -->
-                                <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#user#v1.0">
-                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
-                                        <include name="api#identity#user#v1.0.war" />
-                                    </fileset>
-                                </unzip>
+                                <!-- Delete the api#identity#user#v1.0.war -->
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/api#identity#user#v1.0.war" />
 
                                 <!-- Explode the api#users#v2#me#webauthn.war -->

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -298,28 +298,6 @@
             </includes>
         </fileSet>
 
-        <!--copy  web app for UMA 2.0 permission endpoint feature-->
-        <fileSet>
-            <directory>
-                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
-            </directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
-            <includes>
-                <include>api#identity#oauth2#uma#permission#v1.0.war</include>
-            </includes>
-        </fileSet>
-
-        <!--copy  web app for UMA 2.0 resource endpoint feature-->
-        <fileSet>
-            <directory>
-                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
-            </directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
-            <includes>
-                <include>api#identity#oauth2#uma#resourceregistration#v1.0.war</include>
-            </includes>
-        </fileSet>
-
         <fileSet>
             <directory>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
@@ -440,29 +418,6 @@
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
             <includes>
                 <include>accountrecoveryendpoint.war</include>
-            </includes>
-        </fileSet>
-
-
-        <!--Copy web app api#identity#recovery#v0.9 -->
-        <fileSet>
-            <directory>
-                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
-            </directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
-            <includes>
-                <include>api#identity#recovery#v0.9.war</include>
-            </includes>
-        </fileSet>
-
-        <!--Copy web app api#identity#user#v1.0 -->
-        <fileSet>
-            <directory>
-                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
-            </directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
-            <includes>
-                <include>api#identity#user#v1.0.war</include>
             </includes>
         </fileSet>
 
@@ -693,14 +648,9 @@
                 <include>api#identity#oauth2#dcr#v1.1/</include>
                 <include>api#identity#template#mgt#v1.0.0/</include>
                 <include>api#identity#consent-mgt#v1.0/</include>
-                <include>api#identity#oauth2#uma#permission#v1.0/</include>
-                <include>api#identity#oauth2#uma#resourceregistration#v1.0/</include>
                 <include>api#health-check#v1.0/</include>
                 <include>lsp/</include>
                 <include>accountrecoveryendpoint/</include>
-                <include>api#identity#recovery#v0.9/</include>
-                <include>api#identity#user#v1.0/</include>
-                <include>api#identity#oauth2#uma#resourceregistration#v1.0/</include>
                 <include>api#users#v2#me#webauthn/</include>
             </includes>
         </fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -2041,7 +2041,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.19.56-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.1</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2052,7 +2052,7 @@
         <carbon.consent.mgt.version>2.2.16</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.4.94-SNAPSHOT</identity.governance.version>
+        <identity.governance.version>1.5.0</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.5.2</identity.carbon.auth.saml2.version>
@@ -2143,7 +2143,7 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
 
         <!-- Identity REST API feature -->
-        <identity.api.dispatcher.version>1.0.162-SNAPSHOT</identity.api.dispatcher.version>
+        <identity.api.dispatcher.version>1.0.163</identity.api.dispatcher.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.4.3</identity.tool.samlsso.validator.version>
@@ -2151,7 +2151,7 @@
         <identity.oauth.addons.version>2.3.5</identity.oauth.addons.version>
         <org.wso2.carbon.extension.identity.x509certificate.version>1.0.10</org.wso2.carbon.extension.identity.x509certificate.version>
         <conditional.authentication.functions.version>1.1.6</conditional.authentication.functions.version>
-        <carbon.identity.oauth.uma.version>1.2.8-SNAPSHOT</carbon.identity.oauth.uma.version>
+        <carbon.identity.oauth.uma.version>1.3.0</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
         <identity.apps.version>1.2.93</identity.apps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2041,7 +2041,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.56-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2052,7 +2052,7 @@
         <carbon.consent.mgt.version>2.2.16</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.4.95</identity.governance.version>
+        <identity.governance.version>1.4.94-SNAPSHOT</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.5.2</identity.carbon.auth.saml2.version>
@@ -2143,7 +2143,7 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
 
         <!-- Identity REST API feature -->
-        <identity.api.dispatcher.version>1.0.162</identity.api.dispatcher.version>
+        <identity.api.dispatcher.version>1.0.162-SNAPSHOT</identity.api.dispatcher.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.4.3</identity.tool.samlsso.validator.version>
@@ -2151,7 +2151,7 @@
         <identity.oauth.addons.version>2.3.5</identity.oauth.addons.version>
         <org.wso2.carbon.extension.identity.x509certificate.version>1.0.10</org.wso2.carbon.extension.identity.x509certificate.version>
         <conditional.authentication.functions.version>1.1.6</conditional.authentication.functions.version>
-        <carbon.identity.oauth.uma.version>1.2.7</carbon.identity.oauth.uma.version>
+        <carbon.identity.oauth.uma.version>1.2.8-SNAPSHOT</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
         <identity.apps.version>1.2.93</identity.apps.version>


### PR DESCRIPTION
Removes  `api#identity#oauth2#uma#permission#v1.0.war`, `api#identity#oauth2#uma#permission#v1.0.war`, `api#identity#recovery#v0.9.war` and `api#identity#user#v1.0.war` from webapps and deploy them as jars inside API rest dispatcher 
Related to https://github.com/wso2/product-is/issues/11425