### PR TITLE
Fix test failures for group role separation

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTenantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTenantTestCase.java
@@ -78,7 +78,7 @@ public class ApplicationAuthzTenantTestCase extends AbstractApplicationAuthzTest
                     "            <Apply FunctionId=\"urn:oasis:names:tc:xacml:1.0:function:string-is-in\">\n" +
                     "                <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">" +
                     AZ_TEST_TENANT_ROLE + "</AttributeValue>\n" +
-                    "                <AttributeDesignator AttributeId=\"http://wso2.org/claims/role\" Category=\"urn:oasis:names:tc:xacml:1.0:subject-category:access-subject\" DataType=\"http://www.w3.org/2001/XMLSchema#string\" MustBePresent=\"true\"/>\n" +
+                    "                <AttributeDesignator AttributeId=\"http://wso2.org/claims/roles\" Category=\"urn:oasis:names:tc:xacml:1.0:subject-category:access-subject\" DataType=\"http://www.w3.org/2001/XMLSchema#string\" MustBePresent=\"true\"/>\n" +
                     "            </Apply>\n" +
                     "        </Condition>\n" +
                     "    </Rule>\n" +

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/authz/ApplicationAuthzTestCase.java
@@ -74,7 +74,7 @@ public class ApplicationAuthzTestCase extends AbstractApplicationAuthzTestCase {
                     "            <Apply FunctionId=\"urn:oasis:names:tc:xacml:1.0:function:string-is-in\">\n" +
                     "                <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">" +
                     AZ_TEST_ROLE + "</AttributeValue>\n" +
-                    "                <AttributeDesignator AttributeId=\"http://wso2.org/claims/role\" Category=\"urn:oasis:names:tc:xacml:1.0:subject-category:access-subject\" DataType=\"http://www.w3.org/2001/XMLSchema#string\" MustBePresent=\"true\"/>\n" +
+                    "                <AttributeDesignator AttributeId=\"http://wso2.org/claims/roles\" Category=\"urn:oasis:names:tc:xacml:1.0:subject-category:access-subject\" DataType=\"http://www.w3.org/2001/XMLSchema#string\" MustBePresent=\"true\"/>\n" +
                     "            </Apply>\n" +
                     "        </Condition>\n" +
                     "    </Rule>\n" +

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RoleClaimTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RoleClaimTestCase.java
@@ -26,7 +26,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.testng.Assert;
@@ -43,25 +42,25 @@ import org.wso2.carbon.identity.application.common.model.xsd.Property;
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.um.ws.api.stub.ClaimValue;
-import org.wso2.identity.integration.common.clients.oauth.OauthAdminClient;
-import org.wso2.identity.integration.common.clients.claim.metadata.mgt.ClaimMetadataManagementServiceClient;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
     private static final String OAUTH_ROLE = "oauthRole";
-    private static final String ROLE_CLAIM_URI = "http://wso2.org/claims/role";
+    private static final String ROLES_CLAIM_URI = "http://wso2.org/claims/roles";
     private static final String OIDC_GROUP_CLAIM_URI = "groups";
     private static final String FIRST_NAME_VALUE = "FirstName";
     private static final String LAST_NAME_VALUE = "LastName";
     private static final String EMAIL_VALUE = "email@wso2.com";
     private static final String OPENID_SCOPE_PROPERTY = "openid";
     private static final String OPENID_SCOPE_RESOURCE = "/_system/config/oidc";
+    private static final String MULTI_ATTRIBUTE_SEPARATOR = ",";
 
     private String consumerKey;
     private String consumerSecret;
@@ -173,9 +172,7 @@ public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTes
         Object idToken = JSONValue.parse(new String(Base64.decodeBase64(encodedIdToken)));
         Object roles = ((JSONObject) idToken).get(OIDC_GROUP_CLAIM_URI);
         ArrayList<String> roleList = new ArrayList<>();
-        for (int i = 0; i < ((JSONArray) roles).size(); i++) {
-            roleList.add(((JSONArray) roles).get(i).toString());
-        }
+        roleList.addAll(Arrays.asList(((String) roles).split(MULTI_ATTRIBUTE_SEPARATOR)));
         Assert.assertTrue(roleList.contains(OAUTH_ROLE), "Id token does not contain updated role claim");
     }
 
@@ -232,7 +229,7 @@ public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTes
         emailClaimMapping.setRemoteClaim(emailClaim);
 
         Claim roleClaim = new Claim();
-        roleClaim.setClaimUri(ROLE_CLAIM_URI);
+        roleClaim.setClaimUri(ROLES_CLAIM_URI);
         ClaimMapping roleClaimMapping = new ClaimMapping();
         roleClaimMapping.setRequested(true);
         roleClaimMapping.setLocalClaim(roleClaim);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
@@ -453,7 +453,7 @@ public class IdPSuccessTest extends IdPTestBase {
                 .statusCode(HttpStatus.SC_OK)
                 .body("userIdClaim", notNullValue())
                 .body("userIdClaim.uri", equalTo("country"))
-                .body("roleClaim.uri", equalTo("role"));
+                .body("roleClaim.uri", equalTo("roles"));
     }
 
     @Test(dependsOnMethods = {"testUpdateIdPClaims"})
@@ -468,16 +468,16 @@ public class IdPSuccessTest extends IdPTestBase {
                 .body("userIdClaim", notNullValue())
                 .body("userIdClaim.uri", equalTo("country"))
                 .body("roleClaim", notNullValue())
-                .body("roleClaim.uri", equalTo("role"))
+                .body("roleClaim.uri", equalTo("roles"))
                 .body("mappings", notNullValue())
                 .body("mappings[0].idpClaim", equalTo("country"))
                 .body("mappings[0].localClaim.id", equalTo("aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ"))
                 .body("mappings[0].localClaim.uri", equalTo("http://wso2.org/claims/username"))
                 .body("mappings[0].localClaim.displayName", equalTo("Username"))
-                .body("mappings[1].idpClaim", equalTo("role"))
-                .body("mappings[1].localClaim.id", equalTo("aHR0cDovL3dzbzIub3JnL2NsYWltcy9yb2xl"))
-                .body("mappings[1].localClaim.uri", equalTo("http://wso2.org/claims/role"))
-                .body("mappings[1].localClaim.displayName", equalTo("Role"))
+                .body("mappings[1].idpClaim", equalTo("roles"))
+                .body("mappings[1].localClaim.id", equalTo("aHR0cDovL3dzbzIub3JnL2NsYWltcy9ncm91cHM"))
+                .body("mappings[1].localClaim.uri", equalTo("http://wso2.org/claims/roles"))
+                .body("mappings[1].localClaim.displayName", equalTo("Roles"))
                 .body("provisioningClaims", notNullValue())
                 .body("provisioningClaims[0].claim.uri", equalTo("country"))
                 .body("provisioningClaims[0].defaultValue", equalTo("sathya"));

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/idp/v1/update-idp-claims.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/idp/v1/update-idp-claims.json
@@ -3,7 +3,7 @@
     "uri": "country"
   },
   "roleClaim": {
-    "uri": "role"
+    "uri": "roles"
   },
   "mappings": [
     {
@@ -13,9 +13,9 @@
       }
     },
     {
-      "idpClaim": "role",
+      "idpClaim": "roles",
       "localClaim": {
-        "uri": "http://wso2.org/claims/role"
+        "uri": "http://wso2.org/claims/roles"
       }
     }
   ],


### PR DESCRIPTION
Fixes #11327.

Tests need to use roles claim as it suits instead of the legacy role claim.