### PR TITLE
Update automation utils component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2267,7 +2267,7 @@
 
         <!--  Test dependencies -->
         <carbon.automation.version>4.4.3</carbon.automation.version>
-        <carbon.automationutils.version>4.5.1</carbon.automationutils.version>
+        <carbon.automationutils.version>4.5.4</carbon.automationutils.version>
         <selenium.version>2.40.0</selenium.version>
         <testng.version>6.1.1</testng.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Upgrading the component version for https://github.com/wso2/carbon-platform-integration-utils/pull/60

After a server restart, ServerConfigurationManager waits 2 mins before continuing the tests. This will add a significant delay when there are multiple server restarts during the tests. Test suit has more than 30 restarts and this will reduce 2 minutes per each restart, which will result in at least one hour improvement to test execution time.