### PR TITLE
Fix role claim URI

### DIFF
--- a/oidc-conformance-tests/config/service_provider_claim_config.json
+++ b/oidc-conformance-tests/config/service_provider_claim_config.json
@@ -113,7 +113,7 @@
             ],
             "role": {
                 "claim": {
-                    "uri": "http://wso2.org/claims/role"
+                    "uri": "http://wso2.org/claims/roles"
                 },
                 "includeUserDomain": true
             },


### PR DESCRIPTION
Fix OIDC conformance suite failure during bootstrap stage (Ref: https://github.com/wso2/product-is/runs/2585500491?check_suite_focus=true)

Failed with error
```
Adding claims to service provider
400 Client Error:  for url: https://localhost:9443/api/server/v1/applications/a87d7bec-676b-4cda-832f-2150ecf4255e
{"code":"APP-60001","message":"Error patching application with id: a87d7bec-676b-4cda-832f-2150ecf4255e","description":"Invalid application configuration for application: 'oidc_basic1' of tenantDomain: carbon.super. Local claim http://wso2.org/claims/role is not available in the server for tenantDomain:carbon.super.","traceId":"43843496-8a98-4fb1-95d9-4bc4d692fd87"}
```

This was due to changes done in https://github.com/wso2/carbon-identity-framework/pull/3419/files to deprecate the http://wso2.org/claims/role URI for representing roles and representing roles with the new URI http://wso2.org/claims/roles