### PR TITLE
Fix Integration Tests For ID Token Signing and then Encrypting

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2IDTokenEncryptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2IDTokenEncryptionTestCase.java
@@ -478,7 +478,7 @@ public class OAuth2IDTokenEncryptionTestCase extends OAuth2ServiceAbstractIntegr
         RSADecrypter decrypter = new RSADecrypter(spPrivateKey);
         jwt.decrypt(decrypter);
 
-        JWTClaimsSet claims = jwt.getJWTClaimsSet();
+        JWTClaimsSet claims = jwt.getPayload().toSignedJWT().getJWTClaimsSet();
         Assert.assertNotNull(claims, "ID token claim set is null");
 
         String aud = claims.getAudience().get(0);

--- a/pom.xml
+++ b/pom.xml
@@ -2053,7 +2053,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.32</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.6.26</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.6.27</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.11</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.6</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
### Fix Integration Tests For ID Token Signing and then Encrypting

Fixed ID Tokens to be signed and the singed payload to be be encrypted, creating a nested JWT. This PR contains the fixes for integration tests with regards to [PR#1606](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1606)

1] https://openid.net/specs/openid-connect-core-1_0.html#IDToken
[2] https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.6

Issue : https://github.com/wso2/product-is/issues/11901