### PR TITLE
Modify integration test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/AdaptiveScriptTemporaryClaimPersistenceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/AdaptiveScriptTemporaryClaimPersistenceTestCase.java
@@ -235,7 +235,9 @@ public class AdaptiveScriptTemporaryClaimPersistenceTestCase extends AbstractAda
 
         List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
-        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID_WITH_INTERNAL_LOGIN));
+        urlParameters.add(new BasicNameValuePair("scope",
+                OAuth2Constant.OAUTH2_SCOPE_OPENID_WITH_INTERNAL_LOGIN + " " +
+                        OAuth2Constant.OAUTH2_SCOPE_PROFILE));
         urlParameters.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
         urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
         urlParameters.add(new BasicNameValuePair("acr_values", "acr1"));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RoleClaimTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RoleClaimTestCase.java
@@ -135,7 +135,8 @@ public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTes
 
         String encodedIdToken = ((JSONObject) obj).get("id_token").toString().split("\\.")[1];
         Object idToken = JSONValue.parse(new String(Base64.decodeBase64(encodedIdToken)));
-        Assert.assertNull(((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI), "Id token must not contain role claim");
+        Assert.assertNull(((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI), 
+                "Id token must not contain role claim which is not configured for the requested scope.");
     }
 
     @Test(groups = "wso2.is", description = "Check id_token after updating roles", dependsOnMethods =
@@ -167,7 +168,8 @@ public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTes
 
         String encodedIdToken = ((JSONObject) obj).get("id_token").toString().split("\\.")[1];
         Object idToken = JSONValue.parse(new String(Base64.decodeBase64(encodedIdToken)));
-        Assert.assertNull(((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI), "Id token must not contain role claim");
+        Assert.assertNull(((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI), 
+                "Id token must not contain role claim which is not configured for the requested scope.");
     }
 
     private ClaimValue[] getUserClaims() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RoleClaimTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RoleClaimTestCase.java
@@ -135,11 +135,7 @@ public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTes
 
         String encodedIdToken = ((JSONObject) obj).get("id_token").toString().split("\\.")[1];
         Object idToken = JSONValue.parse(new String(Base64.decodeBase64(encodedIdToken)));
-        Object roles = ((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI);
-        Assert.assertNotNull(roles, "Id token should contain at least one role");
-        if (!(roles instanceof String)) {
-            Assert.fail("Id token should contain Internal/everyone role only");
-        }
+        Assert.assertNull(((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI), "Id token must not contain role claim");
     }
 
     @Test(groups = "wso2.is", description = "Check id_token after updating roles", dependsOnMethods =
@@ -171,8 +167,7 @@ public class OAuth2RoleClaimTestCase extends OAuth2ServiceAbstractIntegrationTes
 
         String encodedIdToken = ((JSONObject) obj).get("id_token").toString().split("\\.")[1];
         Object idToken = JSONValue.parse(new String(Base64.decodeBase64(encodedIdToken)));
-        Object roles = ((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI);
-        Assert.assertTrue((((JSONArray) roles).contains(OAUTH_ROLE)), "Id token does not contain updated role claim");
+        Assert.assertNull(((JSONObject) idToken).get(OIDC_ROLES_CLAIM_URI), "Id token must not contain role claim");
     }
 
     private ClaimValue[] getUserClaims() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
@@ -151,7 +151,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
         URI tokenEndpoint = new URI(OAuth2Constant.ACCESS_TOKEN_ENDPOINT);
         TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, passwordGrant,
-                new Scope(OAuth2Constant.OAUTH2_SCOPE_OPENID));
+                new Scope(OAuth2Constant.OAUTH2_SCOPE_OPENID + " " + OAuth2Constant.OAUTH2_SCOPE_EMAIL));
 
         HTTPResponse tokenHTTPResp = request.toHTTPRequest().send();
         Assert.assertNotNull(tokenHTTPResp, "JWT access token http response is null.");
@@ -167,7 +167,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         jwtAssertion = oidcTokens.getIDTokenString();
         alias = oidcTokens.getIDToken().getJWTClaimsSet().getAudience().get(0);
         issuer = oidcTokens.getIDToken().getJWTClaimsSet().getIssuer();
-        Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM), COUNTRY_CLAIM_VALUE,
+        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
                 "Requested user claims is not returned back in self contained access token based on password "
                         + "claim.");
         Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM), EMAIL_CLAIM_VALUE,
@@ -180,7 +180,6 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_LOCAL_CLAIM_URI),
                 "User claim " + EMAIL_LOCAL_CLAIM_URI + " is not returned in local claim uri format without being "
                         + "converted to OIDC claim");
-        changeCountryOIDDialect();
     }
 
     @Test(description = "This test case tests the behaviour when ConvertOIDCDialect is set to true in identity.xml "
@@ -213,8 +212,8 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM),
                 "User claims is returned back without mappings in SP and IDP side when ConvertToOIDCDialect is "
                         + "set to true in identity.xml");
-        Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_NEW_OIDC_CLAIM),
-                COUNTRY_CLAIM_VALUE, "User claims is not returned back with proper mappings in SP and IDP side when "
+        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_NEW_OIDC_CLAIM),
+                "User claims is not returned back with proper mappings in SP and IDP side when "
                         + "ConvertToOIDCDialect is set to true in identity.xml");
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_LOCAL_CLAIM_URI),
                 "User claims conversion is wrong as per the claim mapping in SP and IDP");
@@ -259,7 +258,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM), EMAIL_CLAIM_VALUE,
                 "User claims are not proxied when there are no SP and IDP Claim mappings "
                         + "returned when ConvertToOIDCDialect is set to true in identity.xml");
-        Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM), COUNTRY_CLAIM_VALUE,
+        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
                 "User claims are not proxied when there are no SP and IDP Claim mappings "
                         + "returned when ConvertToOIDCDialect is set to true in identity.xml");
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_LOCAL_CLAIM_URI),
@@ -359,8 +358,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         identityProviderMgtServiceClient.deleteIdP(issuer);
         addFederatedIdentityProvider();
         OIDCTokens oidcTokens = makeJWTBearerGrantRequest();
-        Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
-                COUNTRY_CLAIM_VALUE,
+        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
                 "User claims are not returned back as it is when ConvertToOIDCDialect is set to false");
         updateIdentityProviderWithClaimMappings();
         oidcTokens = makeJWTBearerGrantRequest();
@@ -402,7 +400,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
         URI tokenEndpoint = new URI(OAuth2Constant.ACCESS_TOKEN_ENDPOINT);
         TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, authorizationGrant,
-                new Scope(OAuth2Constant.OAUTH2_SCOPE_OPENID));
+                new Scope(OAuth2Constant.OAUTH2_SCOPE_OPENID + " " + OAuth2Constant.OAUTH2_SCOPE_EMAIL));
 
         HTTPResponse tokenHTTPResp = request.toHTTPRequest().send();
         Assert.assertNotNull(tokenHTTPResp, "JWT access token http response is null.");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
@@ -168,8 +168,8 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         alias = oidcTokens.getIDToken().getJWTClaimsSet().getAudience().get(0);
         issuer = oidcTokens.getIDToken().getJWTClaimsSet().getIssuer();
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
-                "Requested user claims is not returned back in self contained access token based on password "
-                        + "claim.");
+                "Requested user claims contains claims which are not configured in requested scopes in self contained "
+                        + "access token based on password claim");
         Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM), EMAIL_CLAIM_VALUE,
                 "Requested user claims is not returned back in self contained access token based on password "
                         + "claim.");
@@ -213,8 +213,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
                 "User claims is returned back without mappings in SP and IDP side when ConvertToOIDCDialect is "
                         + "set to true in identity.xml");
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_NEW_OIDC_CLAIM),
-                "User claims is not returned back with proper mappings in SP and IDP side when "
-                        + "ConvertToOIDCDialect is set to true in identity.xml");
+                "User claims contains claims which are not configured in requested scopes");
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_LOCAL_CLAIM_URI),
                 "User claims conversion is wrong as per the claim mapping in SP and IDP");
     }
@@ -259,8 +258,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
                 "User claims are not proxied when there are no SP and IDP Claim mappings "
                         + "returned when ConvertToOIDCDialect is set to true in identity.xml");
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
-                "User claims are not proxied when there are no SP and IDP Claim mappings "
-                        + "returned when ConvertToOIDCDialect is set to true in identity.xml");
+                "User claims contains claims which are not configured in requested scopes");
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_LOCAL_CLAIM_URI),
                 "User claims conversion happened wrongly.");
         Assert.assertNotNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_NEW_OIDC_CLAIM),
@@ -359,7 +357,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         addFederatedIdentityProvider();
         OIDCTokens oidcTokens = makeJWTBearerGrantRequest();
         Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_OIDC_CLAIM),
-                "User claims are not returned back as it is when ConvertToOIDCDialect is set to false");
+                "User claims contains claims which are not configured in requested scopes");
         updateIdentityProviderWithClaimMappings();
         oidcTokens = makeJWTBearerGrantRequest();
         Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM), EMAIL_CLAIM_VALUE,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithSessionTerminationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithSessionTerminationTestCase.java
@@ -258,7 +258,8 @@ public class OAuth2TokenRevocationWithSessionTerminationTestCase extends OAuth2S
         urlParameters.add(new BasicNameValuePair("callbackurl", OAuth2Constant.CALLBACK_URL));
         urlParameters.add(new BasicNameValuePair("authorizeEndpoint", OAuth2Constant.APPROVAL_URL));
         urlParameters.add(new BasicNameValuePair("authorize", OAuth2Constant.AUTHORIZE_PARAM));
-        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID));
+        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID + " " +
+                OAuth2Constant.OAUTH2_SCOPE_EMAIL));
         return urlParameters;
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCPasswordGrantTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCPasswordGrantTest.java
@@ -100,7 +100,7 @@ public class OIDCPasswordGrantTest extends OIDCAbstractIntegrationTest {
 
         Map<String, String> params = new HashMap<>();
         params.put("grant_type", "password");
-        params.put("scope", "openid");
+        params.put("scope", "openid email profile");
         params.put("username", user.getUsername());
         params.put("password", user.getPassword());
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
@@ -117,8 +117,8 @@ public class OIDCUtilTest {
         urlParameters.add(new BasicNameValuePair("callbackurl", application.getCallBackURL()));
         urlParameters.add(new BasicNameValuePair("authorizeEndpoint", OAuth2Constant.APPROVAL_URL));
         urlParameters.add(new BasicNameValuePair("authorize", OAuth2Constant.AUTHORIZE_PARAM));
-        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID + " " + OAuth2Constant
-                .OAUTH2_SCOPE_EMAIL));
+        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID + " " +
+                OAuth2Constant.OAUTH2_SCOPE_EMAIL + " " + OAuth2Constant.OAUTH2_SCOPE_PROFILE));
         return urlParameters;
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
@@ -56,6 +56,7 @@ public final class OAuth2Constant {
     public final static String OAUTH2_SCOPE_OPENID = "openid";
     public static final String OAUTH2_SCOPE_OPENID_WITH_INTERNAL_LOGIN = "openid internal_login";
     public final static String OAUTH2_SCOPE_EMAIL = "email";
+    public final static String OAUTH2_SCOPE_PROFILE = "profile";
     public final static String OAUTH2_SCOPE_DEFAULT = "";
     public final static String OAUTH_APPLICATION_NAME = "oauthTestApplication";
     public static final String UNSUPPORTED_GRANT_TYPE = "unsupported_grant_type";

--- a/pom.xml
+++ b/pom.xml
@@ -2053,7 +2053,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.32</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.6.30</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.6.32-SNAPSHOT</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.11</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.7</identity.inbound.provisioning.scim.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2053,7 +2053,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.32</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.6.32-SNAPSHOT</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.6.31</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.11</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.7</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
Modify the test cases as no user attributes must not be send for the 'openid' scope.