### PR TITLE
Fix integration test failures in SCIM2CustomSchemaMeTestCase and SCIM2CustomSchemaUserTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIMUtils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIMUtils.java
@@ -40,7 +40,7 @@ import java.util.LinkedHashMap;
 public class SCIMUtils {
 
     private static final String SCIM_USER_SCHEMAS = "[urn:ietf:params:scim:schemas:core:2.0:User, " +
-            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User, urn:scim:custom:schema]";
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User, urn:scim:wso2:schema]";
     private static final UserStoreConfigUtils userStoreConfigUtils = new UserStoreConfigUtils();
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
@@ -69,8 +69,8 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
     private ClaimMetadataManagementServiceClient claimMetadataManagementServiceClient = null;
 
     // Custom schema related constants.
-    private static final String CUSTOM_SCHEMA_URI = "urn:scim:custom:schema";
-    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:custom:schema\"";
+    private static final String CUSTOM_SCHEMA_URI = "urn:scim:wso2:schema";
+    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:wso2:schema\"";
     // Country claim related constants.
     private static final String COUNTRY_CLAIM_ATTRIBUTE_NAME = "country";
     private static final String COUNTRY_CLAIM_ATTRIBUTE_URI = CUSTOM_SCHEMA_URI + ":" + COUNTRY_CLAIM_ATTRIBUTE_NAME;
@@ -80,7 +80,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
     private static final String COUNTRY_LOCAL_CLAIM_VALUE_AFTER_PUT = "India";
     // Manager claim related constants.
     private static final String MANAGER_CLAIM_ATTRIBUTE_NAME = "manager";
-    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:custom:schema:manager";
+    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:wso2:schema:manager";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME = "email";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI =
             MANAGER_CLAIM_ATTRIBUTE_URI + "." + MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
@@ -71,8 +71,8 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
     private ClaimMetadataManagementServiceClient claimMetadataManagementServiceClient = null;
 
     // Custom schema related constants.
-    private static final String CUSTOM_SCHEMA_URI = "urn:scim:custom:schema";
-    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:custom:schema\"";
+    private static final String CUSTOM_SCHEMA_URI = "urn:scim:wso2:schema";
+    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:wso2:schema\"";
     // Country claim related constants.
     private static final String COUNTRY_CLAIM_ATTRIBUTE_NAME = "country";
     private static final String COUNTRY_CLAIM_ATTRIBUTE_URI = CUSTOM_SCHEMA_URI + ":" + COUNTRY_CLAIM_ATTRIBUTE_NAME;
@@ -82,7 +82,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
     private static final String COUNTRY_LOCAL_CLAIM_VALUE_AFTER_PUT = "India";
     // Manager claim related constants.
     private static final String MANAGER_CLAIM_ATTRIBUTE_NAME = "manager";
-    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:custom:schema:manager";
+    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:wso2:schema:manager";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME = "email";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI =
             MANAGER_CLAIM_ATTRIBUTE_URI + "." + MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME;

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/apiSwaggerFiles/scim2.yaml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/apiSwaggerFiles/scim2.yaml
@@ -934,9 +934,6 @@ paths:
           description: Valid users are not found
           schema:
             $ref: '#/definitions/GroupSearchErrorResponseObject'
-        409:
-          description: Users already exists
-
   '/Users/{id}':
     get:
       tags:

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/apiSwaggerFiles/scim2.yaml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/apiSwaggerFiles/scim2.yaml
@@ -893,6 +893,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorInternalServerError'
+        409:
+          description: Users already exists
   /Users/.search:
     post:
       tags:
@@ -932,6 +934,8 @@ paths:
           description: Valid users are not found
           schema:
             $ref: '#/definitions/GroupSearchErrorResponseObject'
+        409:
+          description: Users already exists
 
   '/Users/{id}':
     get:
@@ -1359,7 +1363,7 @@ definitions:
           example:
             - urn:ietf:params:scim:schemas:core:2.0:User
             - urn:ietf:params:scim:schemas:extension:enterprise:2.0:User
-            - urn:scim:custom:schema
+            - urn:scim:wso2:schema
       username:
         type: string
         example: "PRIMARY/kim"
@@ -1512,7 +1516,7 @@ definitions:
           example:
             - urn:ietf:params:scim:schemas:core:2.0:User
             - urn:ietf:params:scim:schemas:extension:enterprise:2.0:User
-            - urn:scim:custom:schema
+            - urn:scim:wso2:schema
       username:
         type: string
         example: "kim"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-add-user.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-add-user.json
@@ -6,18 +6,7 @@
   },
   "userName": "userkim",
   "password": "abc123",
-  "emails": [
-    {
-      "type": "home",
-      "value": "kim@gmail.com",
-      "primary": true
-    },
-    {
-      "type": "work",
-      "value": "kim@wso2.com"
-    }
-  ],
-  "urn:scim:custom:schema": {
+  "urn:scim:wso2:schema": {
     "country": "France",
     "manager": {
       "email": "piraveena@gmail.com"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-add-attribute.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-add-attribute.json
@@ -6,7 +6,7 @@
     {
       "op": "add",
       "value": {
-        "urn:scim:custom:schema": {
+        "urn:scim:wso2:schema": {
           "manager": {
             "email": "piraveenaAdd@gmail.com"
           }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-remove-attribute.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-remove-attribute.json
@@ -9,7 +9,7 @@
     },
     {
       "op": "remove",
-      "path": "urn:scim:custom:schema:country"
+      "path": "urn:scim:wso2:schema:country"
     }
   ]
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-replace-attribute.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-replace-attribute.json
@@ -6,7 +6,7 @@
     {
       "op": "replace",
       "value": {
-        "urn:scim:custom:schema": {
+        "urn:scim:wso2:schema": {
           "country": "Sri Lanka",
           "manager": {
             "email": "piraveenaReplace@gmail.com"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-put-user.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-put-user.json
@@ -5,7 +5,7 @@
     "familyName": "jackson",
     "givenName": "kim"
   },
-  "urn:scim:custom:schema": {
+  "urn:scim:wso2:schema": {
     "country": "India"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2062,7 +2062,7 @@
         <identity.inbound.auth.openid.version>5.6.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.11</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.7</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>1.5.95</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>1.5.96</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity workflow Versions -->
         <identity.user.workflow.version>5.4.7</identity.user.workflow.version>


### PR DESCRIPTION
Fix integration test failures in ``SCIM2CustomSchemaMeTestCase`` and ``SCIM2CustomSchemaUserTestCase`` caused by refactoring ``"urn:scim:custom:schema"`` to ``"urn:scim:wso2:schema"``  of  identity-inbound-provisioning-scim2.
* * *
#### Before Merge
1. Merge this PR ([identity-inbound-provisioning-scim2/pull/370](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/370))
2. Bump the scim2 version in product-is