### PR TITLE
Update test cases with affected by the account lock handler modifications

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/IdentityGovernanceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/IdentityGovernanceTestCase.java
@@ -61,7 +61,7 @@ public class IdentityGovernanceTestCase extends ISIntegrationTest {
         boolean accountLockingAvailable = false;
         for (ConnectorConfig connector : connectors) {
             if (connector.getFriendlyName().equals(CONNECTOR_FRIENDLY_NAME)) {
-                Assert.assertEquals(connector.getProperties().length, 5,
+                Assert.assertEquals(connector.getProperties().length, 6,
                         "Account locking feature properties not received properly.");
                 accountLockingAvailable = true;
                 break;

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/default-identity-event.properties
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/default-identity-event.properties
@@ -28,6 +28,7 @@ account.lock.handler.login.fail.timeout.ratio=2
 account.lock.handler.On.Failure.Max.Attempts=5
 account.lock.handler.Time=5
 account.lock.handler.notification.manageInternally=true
+account.lock.handler.notification.notifyOnLockIncrement=false
 module.name.2=emailSend
 emailSend.subscription.1=TRIGGER_NOTIFICATION
 module.name.3=accountConfirmationValidation

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-TG9naW4gQXR0ZW1wdHMgU2VjdXJpdHk-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-TG9naW4gQXR0ZW1wdHMgU2VjdXJpdHk-response.json
@@ -38,6 +38,12 @@
           "value": "true",
           "displayName": "Manage notification sending internally",
           "description": "Disable if the client application handles notification sending"
+        },
+        {
+          "name": "account.lock.handler.notification.notifyOnLockIncrement",
+          "value": "false",
+          "displayName": "Notify user when lock time is increased",
+          "description": "Notify user when the account lock duration is increased due to continuous failed login attempts."
         }
       ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -2092,7 +2092,7 @@
         <identity.data.publisher.audit.version>1.3.4</identity.data.publisher.audit.version>
 
         <!-- Identity Event Handler Versions -->
-        <identity.event.handler.account.lock.version>1.4.26</identity.event.handler.account.lock.version>
+        <identity.event.handler.account.lock.version>1.4.27</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.3.22</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->


### PR DESCRIPTION
This PR updates test cases with affected by the account lock handler modifications done by https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/95.

Note : This should only be merged after https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/95 is merged.