### PR TITLE
Fix OIDC meta data to include device code as a supported grant type

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
@@ -26,6 +26,10 @@
         "displayName": "IWA-NTLM"
       },
       {
+        "name": "urn:ietf:params:oauth:grant-type:device_code",
+        "displayName": "urn:ietf:params:oauth:grant-type:device_code"
+      },
+      {
         "name": "authorization_code",
         "displayName": "Code"
       },


### PR DESCRIPTION
$subject