### PR TITLE
Remove third party actions used for google chat notification

### DIFF
--- a/.github/workflows/dependency-updater.yml
+++ b/.github/workflows/dependency-updater.yml
@@ -15,6 +15,7 @@ env:
   PRODUCT_REPOSITORY_PUBLIC: wso2/$REPOSITORY
   BUILD_NUMBER: ${{github.run_id}}
   DEPENDENCY_UPGRADE_BRANCH_NAME: IS_dependency_updater_github_action/$BUILD_NUMBER
+  PR: "https://github.com/wso2/product-is/pulls"
 
 jobs:
   build:
@@ -120,11 +121,16 @@ jobs:
             echo "=========================================================="
 
             TITLE="Bump Dependencies #"${{ env.BUILD_NUMBER }}
-            STATUS=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -k -X \
+            RESPONSE=$(curl -s -w "%{http_code}" -k -X \
             POST https://api.github.com/repos/${{ env.PRODUCT_REPOSITORY_PUBLIC }}/pulls \
             -H "Authorization: Bearer "${{ secrets.PAT }}"" \
             -H "Content-Type: application/json" \
             -d '{ "title": "'"${TITLE}"'","body": "Bumps dependencies for product-is. Link : https://github.com/wso2/product-is/actions/runs/${{github.run_id}}","head": "'"${{ env.GIT_USERNAME }}:${{ env.DEPENDENCY_UPGRADE_BRANCH_NAME }}"'","base":"master"}')
+            RESPONSE_BODY=${RESPONSE::-3}
+            STATUS=$(printf "%s" "$RESPONSE" | tail -c 3)
+            if [[ $STATUS == "201" ]]; then
+              echo "PR=$(echo $RESPONSE_BODY | jq -r '.html_url')" >> $GITHUB_ENV
+            fi
           else
             echo ""
             echo "There are no dependency updates available"
@@ -147,9 +153,68 @@ jobs:
             ${{steps.builder_step.outputs.REPO_NAME}}/mvn-build.log
           if-no-files-found: warn
       - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@releases/v1
-        with:
-          name: Dependency Updater
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}&threadKey=dep_updater
-          status: ${{ job.status }}
+        run: |
+          STATUS_COLOR=$(if [[ ${{ job.status }} == "success" ]];then echo "#009944";
+          elif [[ ${{ job.status }} = "failure" ]];then echo "#ff0000";
+          elif [[ ${{ job.status }} = "cancelled" ]];then echo "#ffc300"; fi)
+
+          curl --location --request POST '${{ secrets.GOOGLE_CHAT_WEBHOOK }}&threadKey=dep_updater' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "cards": [
+                  {
+                      "header": {
+                          "title": "Dependency Updater",
+                          "subtitle": "GitHub Action #${{ env.BUILD_NUMBER }}"
+                      },
+                      "sections": [
+                          {
+                              "widgets": [
+                                  {
+                                      "textParagraph": {
+                                          "text": "Status: <br><b><font color='"${STATUS_COLOR}"'>${{ job.status }}</font></b></br>"
+                                      }
+                                  },
+                                  {
+                                      "keyValue": {
+                                          "topLabel": "Build Job:",
+                                          "content": "GitHub Action",
+                                          "contentMultiline": "false",
+                                          "bottomLabel": "",
+                                          "button": {
+                                              "textButton": {
+                                                  "text": "VIEW",
+                                                  "onClick": {
+                                                      "openLink": {
+                                                          "url": "https://github.com/wso2/product-is/actions/runs/${{github.run_id}}"
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  },
+                                  {
+                                      "keyValue": {
+                                          "topLabel": "Pull Request:",
+                                          "content": "Check Pull Request",
+                                          "contentMultiline": "false",
+                                          "bottomLabel": "",
+                                          "button": {
+                                              "textButton": {
+                                                  "text": "VIEW",
+                                                  "onClick": {
+                                                      "openLink": {
+                                                          "url": "'${{ env.PR }}'"
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              ]
+          }'
         if: always()


### PR DESCRIPTION
Remove third-party actions used for google chat notifications. Instead the notification is sent using the curl command