### PR TITLE
Add integration test for revocation endpoint to verify auth failure errors with revoked access tokens

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithRevokedAccessToken.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithRevokedAccessToken.java
@@ -208,7 +208,7 @@ public class OAuth2TokenRevocationWithRevokedAccessToken extends OAuth2ServiceAb
         return revocationRequest.toHTTPRequest().send();
     }
 
-        private HTTPResponse revokeAccessToken(AccessToken accessToken, ClientAuthentication clientAuth) throws Exception {
+    private HTTPResponse revokeAccessToken(AccessToken accessToken, ClientAuthentication clientAuth) throws Exception {
 
         URI tokenRevokeEndpoint = new URI(OAuth2Constant.TOKEN_REVOKE_ENDPOINT);
 

--- a/pom.xml
+++ b/pom.xml
@@ -2092,7 +2092,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.46</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.7.43</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.7.44</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.5</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.13</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.8</identity.inbound.provisioning.scim.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2092,7 +2092,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.46</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.7.42</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.7.43</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.5</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.13</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.8</identity.inbound.provisioning.scim.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2092,7 +2092,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.44</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.7.39</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.7.43</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.6.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.13</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.8</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
In this PR, a new integration test is added to test the following scenario.

- Call revocation request with a revoked access token but with invalid auth credentials - the test should verify the 401 status code.

Git Issue: https://github.com/wso2/product-is/issues/12510