### PR TITLE
Modify telephone number in test cases to support new telephone regex

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/tenant/management/v1/add-tenant-conflict.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/tenant/management/v1/add-tenant-conflict.json
@@ -11,7 +11,7 @@
       "additionalClaims": [
         {
           "claim": "http://wso2.org/claims/telephone",
-          "value": "+94 562 8723"
+          "value": "+94 77 123 4567"
         },
         {
           "claim": "http://wso2.org/claims/country",

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/tenant/management/v1/add-tenant-inline-password.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/tenant/management/v1/add-tenant-inline-password.json
@@ -11,7 +11,7 @@
       "additionalClaims": [
         {
           "claim": "http://wso2.org/claims/telephone",
-          "value": "+94 562 8723"
+          "value": "+94 77 123 4567"
         },
         {
           "claim": "http://wso2.org/claims/country",

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/tenant/management/v1/add-tenant.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/tenant/management/v1/add-tenant.json
@@ -11,7 +11,7 @@
       "additionalClaims": [
         {
           "claim": "http://wso2.org/claims/telephone",
-          "value": "+94 562 8723"
+          "value": "+94 77 123 4567"
         },
         {
           "claim": "http://wso2.org/claims/country",


### PR DESCRIPTION
Related Issues: wso2/product-is#12618
Releated PRs: https://github.com/wso2/carbon-identity-framework/pull/3787

**Purpose**
Before, the telephone number did not have a regex to validate. With current fix in above PR, regex added to telephone number claim. So modifying the telephone number with a valid phone number. 