### PR TITLE
Update the conformance suite version 

### DIFF
--- a/.github/workflows/oidc-conformance-test.yml
+++ b/.github/workflows/oidc-conformance-test.yml
@@ -39,7 +39,7 @@ jobs:
     
     - name: Setup Python
       run: |
-        pip3 install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade pip setuptools wheel
         pip3 install psutil
         
     - name: Download IS zip

--- a/.github/workflows/oidc-conformance-test.yml
+++ b/.github/workflows/oidc-conformance-test.yml
@@ -13,7 +13,7 @@ on:
       tag:
         description: 'product-is tag name'
         required: true
-        default: 'v5.12.0-m6'
+        default: 'v5.12.0-alpha9'
       send-email:
         description: 'Send test results to email'
         required: true
@@ -65,16 +65,11 @@ jobs:
       
     - name: Clone conformance suite
       run: |
-        CONFORMANCE_SUITE_VERSION=v4.1.29
+        CONFORMANCE_SUITE_VERSION=v4.1.37
         git clone --depth 1 --branch release-${CONFORMANCE_SUITE_VERSION} https://github.com/openid-certification/conformance-suite.git
     
     - name: Adding extra hosts to docker-compose-dev.yml
       run: sed -i '/^    volumes.*/i \ \ \ \ extra_hosts:\n \ \ \ \ - "localhost:\$IP\"' ./conformance-suite/docker-compose-dev.yml
-
-    # HtmlUnitDriver used by the conformance suite will throw JS errors when trying to load the login page. 
-    # Skipping these errors before testing as a temporary solution to this issue.
-    - name: Suppress JS errors thrown by HtmlUnitDriver used by the conformance suite
-      run: sed -i '/^\t\t\tclient.setCookieManager(cookieManager);.*/a \\t\t\tclient.getOptions().setThrowExceptionOnScriptError(false);' ./conformance-suite/src/main/java/net/openid/conformance/frontchannel/BrowserControl.java
          
     - name: Run IS
       run: |


### PR DESCRIPTION
This is to revert the temporary fix https://github.com/wso2/product-is/pull/12714 and update the conformance suite version carrying that fix. Fixes the pip version issue during Python setup and updates the default IS server version for the workflow as well. 
 
