### PR TITLE
Update README and claim configs

### DIFF
--- a/oidc-conformance-tests/README.md
+++ b/oidc-conformance-tests/README.md
@@ -38,6 +38,7 @@ This workflow will also automatically trigger after a release or a pre-release
 
 * OIDC conformance suite running locally (See the steps for [setting up the conformance suite](conformance-suite-setup-guidelines.md))
 * product-is zip file
+* Python 3 installed with requests, psutil libraries
 
 You can use test_runner.sh script to start and configure identity server locally and run OIDC conformence tests
 1. open test_runner.sh using a text editor and make the following modifications
@@ -45,8 +46,11 @@ You can use test_runner.sh script to start and configure identity server locally
    - assign the path of conformance-suite folder to CONFORMANCE_SUITE_PATH
    - assign the path to identity server zip file to PRODUCT_IS_ZIP_PATH
    - set IS_LOCAL to true. default is false
+   - Remove the `sudo` keyword from the following line 
+
+     ```sudo python3 ./configure_is.py $PRODUCT_IS_ZIP_PATH```
 2. Save and exit
-3. Run the script using ```sudo bash test_runner.sh```
+3. Run the script using ```bash test_runner.sh```
 
 If the identity server is not running on the default port, you need to change `IS_HOSTNAME` in `constants.py` to reflect the correct address. Default is set to `https://localhost:9443`
 

--- a/oidc-conformance-tests/README.md
+++ b/oidc-conformance-tests/README.md
@@ -36,7 +36,7 @@ This workflow will also automatically trigger after a release or a pre-release
 
 ### Prerequisites 
 
-* OIDC conformance suite should be running locally before testing can begin
+* OIDC conformance suite running locally (See the steps for [setting up the conformance suite](conformance-suite-setup-guidelines.md))
 * product-is zip file
 
 You can use test_runner.sh script to start and configure identity server locally and run OIDC conformence tests

--- a/oidc-conformance-tests/README.md
+++ b/oidc-conformance-tests/README.md
@@ -46,9 +46,7 @@ You can use test_runner.sh script to start and configure identity server locally
    - assign the path of conformance-suite folder to CONFORMANCE_SUITE_PATH
    - assign the path to identity server zip file to PRODUCT_IS_ZIP_PATH
    - set IS_LOCAL to true. default is false
-   - Remove the `sudo` keyword from the following line 
 
-     ```sudo python3 ./configure_is.py $PRODUCT_IS_ZIP_PATH```
 2. Save and exit
 3. Run the script using ```bash test_runner.sh```
 

--- a/oidc-conformance-tests/config/service_provider_claim_config.json
+++ b/oidc-conformance-tests/config/service_provider_claim_config.json
@@ -106,6 +106,12 @@
                 },
                 {
                     "claim": {
+                        "uri": "http://wso2.org/claims/formattedName"
+                    },
+                    "mandatory": true
+                },
+                {
+                    "claim": {
                         "uri": "http://wso2.org/claims/modified"
                     },
                     "mandatory": true

--- a/oidc-conformance-tests/config/user_claim_value_config.json
+++ b/oidc-conformance-tests/config/user_claim_value_config.json
@@ -83,6 +83,14 @@
             {
                 "op": "replace",
                 "value": {
+                    "name": {
+                        "formatted": "Rangika"
+                    }
+                }
+            },
+            {
+                "op": "replace",
+                "value": {
                     "emails": [
                         "admin@wso2.com"
                     ]

--- a/oidc-conformance-tests/configure_is.py
+++ b/oidc-conformance-tests/configure_is.py
@@ -374,6 +374,14 @@ change_local_claim_mapping(
     },
     constants.BASE_URL + "/api/server/v1/claim-dialects/aHR0cDovL3dzbzIub3JnL29pZGMvY2xhaW0/claims/d2Vic2l0ZQ")
 
+#change middle_name from middleName to formattedName
+change_local_claim_mapping(
+    {
+        "claimURI": "middle_name",
+        "mappedLocalClaimURI": "http://wso2.org/claims/formattedName"
+    },
+    constants.BASE_URL + "/api/server/v1/claim-dialects/aHR0cDovL3dzbzIub3JnL29pZGMvY2xhaW0/claims/bWlkZGxlX25hbWU")
+
 edit_scope("openid", {
     "claims": [
         "sub"

--- a/oidc-conformance-tests/conformance-suite-setup-guidelines.md
+++ b/oidc-conformance-tests/conformance-suite-setup-guidelines.md
@@ -1,0 +1,63 @@
+
+## Setting up the Conformance Suite Locally
+
+### Prerequisites
+
+* Java 11
+* Git
+* Maven
+* Docker
+
+1. Clone the conformance suite repository
+
+    ```   
+    git clone https://gitlab.com/openid/conformance-suite.git
+    cd conformance-suite
+    ```
+
+2. Compile and package the conformance suite
+
+    ```
+    mvn clean package -Dmaven.test.skip=true
+    ```
+
+3. Configure docker to resolve internal host name of wso2 identity server
+   (Find out the IP address of your host machine and add it as extra hosts under the `mongodb`, `httpd` and `server` sections as follows in the docker-compose-dev.yml file).
+
+    ```
+    version: '3'`
+    services:
+    mongodb:
+        image: mongo:4.2
+        volumes:
+        - ./mongo/data:/data/db
+        extra_hosts:
+        - "localhost.com:<HOST_MACHINE_IP>"
+
+    httpd:
+        build:
+          context: ./httpd
+          dockerfile: Dockerfile-static
+        ports:
+         - "8443:8443"
+        extra_hosts:
+         - "localhost.com:<HOST_MACHINE_IP>"
+        volumes:
+         - ./src/main/resources/:/usr/local/apache2/htdocs/
+        depends_on:
+         - server
+    server:
+        build:
+          context: ./server-dev
+        ports:
+         - "9999:9999"
+        extra_hosts:
+         - "localhost.com:<HOST_MACHINE_IP>"
+    ```
+4. Start the conformance suite in development mode
+    
+    ```
+    docker-compose -f docker-compose-dev.yml up
+    ```
+
+Conformance suite will be available at https://localhost:8443.

--- a/oidc-conformance-tests/conformance-suite-setup-guidelines.md
+++ b/oidc-conformance-tests/conformance-suite-setup-guidelines.md
@@ -22,7 +22,7 @@
     ```
 
 3. Configure docker to resolve internal host name of wso2 identity server
-   (Find out the IP address of your host machine and add it as extra hosts under the `mongodb`, `httpd` and `server` sections as follows in the docker-compose-dev.yml file).
+   (Add `"localhost:host-gateway"` as extra hosts under the `mongodb`, `httpd` and `server` sections as follows in the docker-compose-dev.yml file).
 
     ```
     version: '3'`
@@ -30,9 +30,9 @@
     mongodb:
         image: mongo:4.2
         volumes:
-        - ./mongo/data:/data/db
+         - ./mongo/data:/data/db
         extra_hosts:
-        - "localhost.com:<HOST_MACHINE_IP>"
+         - "localhost:host-gateway"
 
     httpd:
         build:
@@ -41,7 +41,7 @@
         ports:
          - "8443:8443"
         extra_hosts:
-         - "localhost.com:<HOST_MACHINE_IP>"
+         - "localhost:host-gateway"
         volumes:
          - ./src/main/resources/:/usr/local/apache2/htdocs/
         depends_on:
@@ -52,7 +52,7 @@
         ports:
          - "9999:9999"
         extra_hosts:
-         - "localhost.com:<HOST_MACHINE_IP>"
+         - "localhost:host-gateway"
     ```
 4. Start the conformance suite in development mode
     

--- a/oidc-conformance-tests/test_runner.sh
+++ b/oidc-conformance-tests/test_runner.sh
@@ -27,7 +27,7 @@ if $IS_LOCAL; then
   echo "Identity Server Setup"
   echo "====================="
   echo
-  sudo python3 ./configure_is.py $PRODUCT_IS_ZIP_PATH
+  python3 ./configure_is.py $PRODUCT_IS_ZIP_PATH
 fi
 echo "========================"
 echo "Running Tests"
@@ -66,6 +66,6 @@ echo
 
 
 if $IS_LOCAL; then
-  sudo pkill -f wso2
+  pkill -f wso2
 fi
 


### PR DESCRIPTION
This PR will add middle_name as a user claim to the configurations and map it to formattedName local claim to resolve WARNINGs of the conformance suite tests. middle_name is mapped to a different claim since it cannot be added due to https://github.com/wso2/product-is/issues/10638.

A new conformance-suite-setup-guidelines.md file is added to provide guidelines in setting up the OIDC conformance suite locally.