### PR TITLE
Fix maven timeout issue in PR builder git action

### DIFF
--- a/.github/workflows/pr-builder-test.yml
+++ b/.github/workflows/pr-builder-test.yml
@@ -8,6 +8,9 @@ on:
         default: 
         required: true
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
 jobs:   
   build:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
The PR builder seems to timeout when downloading dependencies from maven central for some repos like inbound-oauth and framework

Adding the workaround to solve this  based on

- https://github.com/actions/virtual-environments/issues/1499#issuecomment-718396233
- https://githubmemory.com/repo/apache/iotdb/issues/3121