### PR TITLE
Bump identity-apps and identity-framework versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2070,7 +2070,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.273</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.276</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2188,7 +2188,7 @@
         <carbon.identity.oauth.uma.version>1.3.7</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.version>1.2.735</identity.apps.version>
+        <identity.apps.version>1.2.741</identity.apps.version>
 
         <!-- Charon -->
         <charon.version>3.4.1</charon.version>


### PR DESCRIPTION
Bump identity apps version 1.2.741 and identity-framework version 5.20.276.