### PR TITLE
Bump log4j2 and pax-logging versions

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.7.0.m7" useFeatures="true" includeLaunchers="true">
+version="4.7.0.m8" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.7.0.m7" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.7.0.m7"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.7.0.m8"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2195,11 +2195,11 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.7.0-m7</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-m8</carbon.kernel.version>
 
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.7</carbon.deployment.version>
-        <carbon.commons.version>4.7.39</carbon.commons.version>
+        <carbon.commons.version>4.7.42</carbon.commons.version>
         <carbon.registry.version>4.7.47</carbon.registry.version>
         <carbon.multitenancy.version>4.9.17</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.7</carbon.metrics.version>
@@ -2212,7 +2212,7 @@
         <!-- Common tool Versions -->
         <cipher-tool.version>1.1.9</cipher-tool.version>
         <securevault.wso2.version>1.1.4</securevault.wso2.version>
-        <forgetme.tool.version>1.3.3</forgetme.tool.version>
+        <forgetme.tool.version>1.3.5</forgetme.tool.version>
 
         <!-- Feature dependency Versions -->
         <stratos.version.221>2.2.1</stratos.version.221>
@@ -2287,7 +2287,7 @@
         <wsdl4j.version>1.6.2.wso2v2</wsdl4j.version>
         <commons.pool.wso2.version>1.5.6.wso2v1</commons.pool.wso2.version>
         <liberty.maven.plugin.version>2.2</liberty.maven.plugin.version>
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <pax.logging.api.version>1.11.13</pax.logging.api.version>
         <org.wso2.orbit.org.apache.velocity.version>1.7.0.wso2v1</org.wso2.orbit.org.apache.velocity.version>
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
@@ -2321,7 +2321,7 @@
         <!--ws-trust-client-->
         <org.apache.velocity.version>1.7</org.apache.velocity.version>
         <org.xmlunit.version>2.6.3</org.xmlunit.version>
-        <org.apache.logging.log4j.version>2.13.2</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.17.1</org.apache.logging.log4j.version>
 
         <project.scm.id>my-scm-server</project.scm.id>
 


### PR DESCRIPTION
Need to bump respective **Kernel, forgetMe tool** versions. Will remove SNAPSHOT versions once those respective components are released

Dependent PRs
https://github.com/wso2/carbon-kernel/pull/3151
https://github.com/wso2/carbon-commons/pull/436
https://github.com/wso2/identity-anonymization-tool/pull/146