### PR TITLE
Bump identity.inbound.auth.openid version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2093,7 +2093,7 @@
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.8.53</identity.inbound.auth.saml.version>
         <identity.inbound.auth.oauth.version>6.7.101</identity.inbound.auth.oauth.version>
-        <identity.inbound.auth.openid.version>5.6.9</identity.inbound.auth.openid.version>
+        <identity.inbound.auth.openid.version>5.6.10</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.6.14</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.6.8</identity.inbound.provisioning.scim.version>
         <identity.inbound.provisioning.scim2.version>1.5.126</identity.inbound.provisioning.scim2.version>


### PR DESCRIPTION
Bump identity.inbound.auth.openid version from 5.6.9 to 5.6.10