### PR TITLE
upgrade carbon registry version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2154,7 +2154,7 @@
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.10.6</carbon.deployment.version>
         <carbon.commons.version>4.7.45</carbon.commons.version>
-        <carbon.registry.version>4.7.48</carbon.registry.version>
+        <carbon.registry.version>4.8.2-SNAPSHOT</carbon.registry.version>
         <carbon.multitenancy.version>4.9.8</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.10</carbon.metrics.version>
         <carbon.business-process.version>4.5.50</carbon.business-process.version>


### PR DESCRIPTION
The upgraded carbon registry uses the log4j1 vulnerability fixed version of apache solr