### PR TITLE
Add async to the WSO2_CARBON_DB URL

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/wso2_com.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/wso2_com.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <UserStoreManager class="org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager">
     <Property name="driverName">org.h2.Driver</Property>
-    <Property name="url">jdbc:h2:./repository/database/WSO2CARBON_DB</Property>
+    <Property name="url">jdbc:h2:async:./repository/database/WSO2CARBON_DB</Property>
     <Property name="userName">wso2carbon</Property>
     <Property name="password">wso2carbon</Property>
     <Property name="Disabled">false</Property>

--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.7.0.m10" useFeatures="true" includeLaunchers="true">
+version="4.7.0.m11" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.7.0.m10" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.7.0.m10"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.7.0.m11"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2194,7 +2194,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.7.0-m10</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-m11</carbon.kernel.version>
 
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.8</carbon.deployment.version>

--- a/usecases/uc2/master-datasources.xml
+++ b/usecases/uc2/master-datasources.xml
@@ -14,7 +14,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+                    <url>jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>


### PR DESCRIPTION
Related to:
- https://github.com/wso2-enterprise/asgardeo-product/issues/9247
Public Issue:
- https://github.com/wso2/product-is/issues/13138

The embedded local H2 in prod env have broken at a multi-threaded application.
This is already reported H2-issue. As per it `In a multi-threaded application, it is sufficient that one client thread tries to access the database in the interrupted state to completely crash the database.`

According to this H2 issue, adding `async` to the URL is the solution.

Related PR:
- https://github.com/wso2/carbon-kernel/pull/3204