### PR TITLE
Add system property for ignore line breaks in xml sec encode

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -31,6 +31,7 @@
   "transport.https.enabled" : true,
 
   "system.parameter.\u0027org.wso2.CipherTransformation\u0027": "AES/GCM/NoPadding",
+  "system.parameter.\u0027org.apache.xml.security.ignoreLineBreaks\u0027": "true",
 
   "encryption.internal_crypto_provider": "org.wso2.carbon.crypto.provider.SymmetricKeyInternalCryptoProvider",
   "encryption.key": "03BAFEB27A8E871CAD83C5CD4E771DAB",


### PR DESCRIPTION
## Changes in this PR
* Fixes https://github.com/wso2/product-is/issues/13094
* Added the `org.apache.xml.security.ignoreLineBreaks` system property with the value `true`.
* By adding this property when a XML is encoded from the base64 encoder in XML security will not consider the line breaks and that XML will be encoded as a single line.