### PR TITLE
Update pr-builder.sh to support binary diffs

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -33,7 +33,7 @@ if [ "$REPO" = "product-is" ]; then
   echo ""
   echo "Applying PR $PULL_NUMBER as a diff..."
   echo "=========================================================="
-  wget -q --output-document=diff.diff $PR_LINK.diff
+  wget -q --output-document=diff.diff $PR_LINK.patch
   cat diff.diff
   echo "=========================================================="
   git apply diff.diff || {


### PR DESCRIPTION
Purpose:
pr-builder script is failing to apply the diff from the PR, if a binary file changes are there. Updating the diff URL from `.diff` to `.patch` required binary data including the diff will be returned.