### PR TITLE
Update pr-builder script to support binary diffs.

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -113,7 +113,7 @@ else
   echo ""
   echo "Applying PR $PULL_NUMBER as a diff..."
   echo "=========================================================="
-  wget -q --output-document=diff.diff $PR_LINK.diff
+  wget -q --output-document=diff.diff $PR_LINK.patch
   cat diff.diff
   echo "=========================================================="
   git apply diff.diff || {


### PR DESCRIPTION
Purpose:
pr-builder script is failing to apply the diff from the PR, if a binary file changes are there. Updating the diff URL from .diff to .patch required binary data including the diff will be returned. Change for product-is done in https://github.com/wso2/product-is/pull/13265, this PR is to fix the same for other supported repositories.