### PR TITLE
EnableRemoteShutdownAndRestart for integration test runs

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/automation.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/automation.xml
@@ -222,6 +222,7 @@
                     <name>org.wso2.identity.integration.common.extension.server.IdentityServerExtension</name>
                     <parameter name="-DportOffset" value="410" />
                     <parameter name="-Dsetup" value="true"/>
+                    <parameter name="-DenableRemoteShutdownAndRestart" value="true"/>
                     <!--<parameter name="backup-test-pack" value="true"/>-->
                     <!--<parameter name="backup-location" value="<Absolute path for backup location with trailing foreword slash>"/>-->
                     <!--<parameter name="cmdArg" value="debug 5005" />-->


### PR DESCRIPTION
- Set system property "enableRemoteShutdownAndRestart" to true when executing integration tests.
- With https://github.com/wso2/carbon-kernel/pull/3233 change, server restart and shutdown via admin service is disabled by default.
- But server restarts and shutdown via admin service requires for integration test runs.
- Therefore system property enableRemoteShutdownAndRestart setting to true will enable the remote shutdown/restart. (System property has high priority than the carbon configs)