### PR TITLE
Set -DenableRemoteShutdownAndRestart param true for secondary IS startup

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/SecondaryCarbonServerInitializerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/SecondaryCarbonServerInitializerTestCase.java
@@ -56,6 +56,7 @@ public class SecondaryCarbonServerInitializerTestCase extends AbstractIdentityFe
         TestDataHolder testDataHolder = TestDataHolder.getInstance();
         Map<String, String> startupParameters = new HashMap<>();
         startupParameters.put("-DportOffset", String.valueOf(PORT_OFFSET_1 + CommonConstants.IS_DEFAULT_OFFSET));
+        startupParameters.put("-DenableRemoteShutdownAndRestart", String.valueOf(true));
         testDataHolder.setAutomationContext(new AutomationContext("IDENTITY", "identity002", TestUserMode
                 .SUPER_TENANT_ADMIN));
         startCarbonServer(PORT_OFFSET_1, testDataHolder.getAutomationContext(), startupParameters);


### PR DESCRIPTION
- Set the system property "enableRemoteShutdownAndRestart" to true when starting secondary IS in integration tests.
- With https://github.com/wso2/carbon-kernel/pull/3233 change, server restart and shutdown via admin service is disabled by default.
- But server restarts and shutdown via admin service requires for integration test runs.
- Therefore system property enableRemoteShutdownAndRestart setting to true will enable the remote shutdown/restart. (System property has high priority than the carbon configs)