### PR TITLE
Add integration test to validate the application count

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/application/mgt/ApplicationManagementServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/application/mgt/ApplicationManagementServiceClient.java
@@ -153,6 +153,39 @@ public class ApplicationManagementServiceClient {
     }
 
     /**
+     * Get count of all basic applications.
+     *
+     * @return Count of applications.
+     * @throws Exception if there is an error while retrieve the application count.
+     */
+    public int getCountOfAllApplications() throws Exception {
+
+        try {
+            return stub.getCountOfAllApplications();
+        } catch (RemoteException | IdentityApplicationManagementServiceIdentityApplicationManagementException e) {
+            handleException(e);
+        }
+        return 0;
+    }
+
+    /**
+     * Get count of all basic applications for a matching filter.
+     *
+     * @param filter Application name filter.
+     * @return Count of applications match the filter.
+     * @throws Exception if there is an error while retrieve the application count.
+     */
+    public int getCountOfApplications(String filter) throws Exception {
+
+        try {
+            return stub.getCountOfApplications(filter);
+        } catch (RemoteException | IdentityApplicationManagementServiceIdentityApplicationManagementException e) {
+            handleException(e);
+        }
+        return 0;
+    }
+
+    /**
      *
      * @param applicationName
      * @return

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ServiceProviderUserRoleValidationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ServiceProviderUserRoleValidationTestCase.java
@@ -1,0 +1,151 @@
+package org.wso2.identity.integration.test.application.mgt;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
+import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.clients.application.mgt.ApplicationManagementServiceClient;
+import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.util.Utils;
+
+import javax.xml.xpath.XPathExpressionException;
+import java.io.File;
+import java.io.IOException;
+
+public class ServiceProviderUserRoleValidationTestCase extends ISIntegrationTest {
+
+    private static final String ROLE_VALIDATION_ENABLED_TOML = "role_validation_enabled.toml";
+    private static final String APPLICATION_PREFIX = "app";
+    private static final String SERVICE_PROVIDER_DESCRIPTION = "This is a test Service Provider for AZ test.";
+    private static final String ROLE_PREFIX = "Application/role";
+    private static final String USERNAME = "admin";
+    private static final String[] ROLES = new String[]{"Application/role1", "Application/role2", "Application/role3"};
+    private static final String APPLICATION_FILTER = "role*";
+    private static final int APPLICATION_COUNT_WITHOUT_FILTER = 9;
+    private static final int APPLICATION_COUNT_WITH_FILTER = 0;
+
+    protected Log log = LogFactory.getLog(getClass());
+    protected ApplicationManagementServiceClient applicationManagementServiceClient;
+    protected RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(TestUserMode.SUPER_TENANT_ADMIN);
+        changeISConfiguration();
+        super.init(TestUserMode.SUPER_TENANT_ADMIN);
+        ConfigurationContext configContext = ConfigurationContextFactory
+                .createConfigurationContextFromFileSystem(null, null);
+        applicationManagementServiceClient =
+                new ApplicationManagementServiceClient(sessionCookie, backendURL, configContext);
+        remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
+        createApplications();
+        createApplicationRoles();
+        updateAdminUser();
+    }
+
+    private void changeISConfiguration() throws IOException,
+            XPathExpressionException, AutomationUtilException {
+
+        log.info("Replacing the deployment.toml file to reduce items per page and to enable role validation.");
+        String carbonHome = Utils.getResidentCarbonHome();
+        File defaultTomlFile = getDeploymentTomlFile(carbonHome);
+        File configuredTomlFile = new File
+                (getISResourceLocation() + File.separator + "application" + File.separator + "mgt" +
+                        File.separator + ROLE_VALIDATION_ENABLED_TOML);
+        ServerConfigurationManager serverConfigurationManager = new ServerConfigurationManager(isServer);
+        serverConfigurationManager.applyConfigurationWithoutRestart(configuredTomlFile, defaultTomlFile, true);
+        serverConfigurationManager.restartForcefully();
+    }
+
+    private void createApplications() throws Exception {
+
+        log.info("Creating the service providers required for the testcase.");
+        for (int i = 1; i < 10; i++) {
+            ServiceProvider serviceProvider = new ServiceProvider();
+            serviceProvider.setApplicationName(APPLICATION_PREFIX + i);
+            serviceProvider.setDescription(SERVICE_PROVIDER_DESCRIPTION);
+            applicationManagementServiceClient.createApplication(serviceProvider);
+        }
+    }
+
+    private void deleteApplications() throws Exception {
+
+        log.info("Deleting the service providers used during the testcase.");
+        for (int i = 1; i < 10; i++) {
+            applicationManagementServiceClient.deleteApplication(APPLICATION_PREFIX + i);
+        }
+    }
+
+    private void createApplicationRoles() throws Exception {
+
+        log.info("Creating the application roles required for the testcase.");
+        for (int i = 1; i <= 5; i++) {
+            remoteUSMServiceClient.addRole(ROLE_PREFIX + i, new String[0], null);
+        }
+    }
+
+    private void deleteApplicationRoles() throws Exception {
+
+        log.info("Deleting the application roles used during the testcase.");
+        for (int i = 1; i <= 5; i++) {
+            remoteUSMServiceClient.deleteRole(ROLE_PREFIX + i);
+        }
+    }
+
+    private void updateAdminUser() throws Exception {
+
+        log.info("Updating the role list of the user : " + USERNAME + ".");
+        remoteUSMServiceClient.updateRoleListOfUser(USERNAME, null, ROLES);
+    }
+
+    @Test(description = "Retrieve application count for the admin user without filter.")
+    public void testApplicationCountForUserWithoutFilter() throws Exception {
+
+        int count = applicationManagementServiceClient.getCountOfAllApplications();
+        Assert.assertEquals(count, APPLICATION_COUNT_WITHOUT_FILTER,
+                String.format("The expected application count without a filter does not match the actual application " +
+                                "count: Expected Application Count: %d Actual Application Count: %d.",
+                        APPLICATION_COUNT_WITHOUT_FILTER, count)
+        );
+    }
+
+    @Test(description = "Retrieve application count for the admin user with filter.")
+    public void testApplicationCountForUserWithFilter() throws Exception {
+
+        int count = applicationManagementServiceClient.getCountOfApplications(APPLICATION_FILTER);
+        Assert.assertEquals(count, APPLICATION_COUNT_WITH_FILTER,
+                String.format("The expected application count with a filter does not match the actual application " +
+                                "count: Expected Application Count: %d Actual Application Count: %d.",
+                        APPLICATION_COUNT_WITH_FILTER, count)
+        );
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void clearObjects() throws Exception {
+
+        deleteObjects();
+        clear();
+    }
+
+    private void deleteObjects() throws Exception {
+
+        deleteApplications();
+        deleteApplicationRoles();
+    }
+
+    private void clear() {
+
+        applicationManagementServiceClient = null;
+        remoteUSMServiceClient = null;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_enabled.toml
@@ -1,0 +1,46 @@
+[server]
+hostname = "localhost"
+node_ip = "127.0.0.1"
+base_path = "https://$ref{server.hostname}:${carbon.management.port}"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[user_store]
+type = "read_write_ldap_unique_id"
+connection_url = "ldap://localhost:${Ports.EmbeddedLDAP.LDAPServerPort}"
+connection_name = "uid=admin,ou=system"
+connection_password = "admin"
+base_dn = "dc=wso2,dc=org"      #refers the base dn on which the user and group search bases will be generated
+
+[database.identity_db]
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
+
+[database.shared_db]
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
+
+[keystore.primary]
+file_name = "wso2carbon.jks"
+password = "wso2carbon"
+
+[truststore]
+file_name="client-truststore.jks"
+password="wso2carbon"
+type="JKS"
+
+[account_recovery.endpoint.auth]
+hash= "66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"
+
+[identity.auth_framework.endpoint]
+app_password= "dashboard"
+
+[application_mgt]
+enable_role_validation = true

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -45,6 +45,7 @@
             <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>
             <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
             <!--<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>
             <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
             <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
             <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>
@@ -76,17 +77,11 @@
             <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>
             <!--TODO End of openid tests-->
 
-            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
-            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
-            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>
-            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />
+<!--            &lt;!&ndash;TODO Remove following open id tests since deprecated&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>-->
+<!--            &lt;!&ndash;TODO End of openid tests&ndash;&gt;-->
 
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>


### PR DESCRIPTION
- Add integration test to validate the application count when role validation is enabled (both with and without filter).
- This integration test makes sure that https://github.com/wso2/product-is/issues/13292 does not happen.