### PR TITLE
Modify `catalina-server.xml.j2` to add custom remoteIpValve properties

### DIFF
--- a/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -85,6 +85,9 @@
                     protocolHeader="{{catalinaValves.remoteIpValve.protocolHeader}}"
                     proxiesHeader="{{catalinaValves.remoteIpValve.proxiesHeader}}"
                     trustedProxies="{{catalinaValves.remoteIpValve.trustedProxies}}"
+                    {% for property,value in catalinaValves.remoteIpValve.properties.items() %}
+                        {{property}}="{{value}}"
+                    {% endfor %}
                 />
                 {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"


### PR DESCRIPTION
### Purpose

Please refer the $subject

### Notes

Users can add custom properties to `RemoteIpValve` config by adding the following configuration in the `deployment.toml`

```
[ catalinaValves.remoteIpValve.properties]
customProperty1 = "customVal1"
customProperty2 = "customVal2"
```

`catalina-server.xml` preview

```
<Valve
    className="org.apache.catalina.valves.RemoteIpValve"
    internalProxies=""
    remoteIpHeader=""
    protocolHeader=""
    proxiesHeader=""
    trustedProxies=""
    customProperty1="customVal1"
    customProperty2="customVal2"
/>
```
Resolves : [wso2/product-is#13350](https://github.com/wso2/product-is/issues/13350)
