### PR TITLE
Deprecate the tests which are relavant to deprecated services

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/mgt/AccountCredentialMgtConfigServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/mgt/AccountCredentialMgtConfigServiceClient.java
@@ -30,6 +30,7 @@ import java.rmi.RemoteException;
 /**
  * Service client for AccountCredentialMgtConfigService
  */
+@Deprecated
 public class AccountCredentialMgtConfigServiceClient {
 
     private AccountCredentialMgtConfigServiceStub accCredentialMgtConfigStub;

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/mgt/UserIdentityManagementAdminServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/mgt/UserIdentityManagementAdminServiceClient.java
@@ -26,6 +26,7 @@ import org.wso2.identity.integration.common.clients.AuthenticateStub;
 
 import java.rmi.RemoteException;
 
+@Deprecated
 public class UserIdentityManagementAdminServiceClient {
 
     private UserIdentityManagementAdminServiceStub userIdentityManagementAdminServicestub;

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/mgt/UserInformationRecoveryServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/identity/integration/common/clients/mgt/UserInformationRecoveryServiceClient.java
@@ -32,7 +32,7 @@ import org.wso2.carbon.identity.mgt.stub.UserInformationRecoveryServiceIdentityM
 import org.wso2.carbon.identity.mgt.stub.UserInformationRecoveryServiceStub;
 import org.wso2.identity.integration.common.clients.AuthenticateStub;
 
-
+@Deprecated
 public class UserInformationRecoveryServiceClient {
 
 	private UserInformationRecoveryServiceStub infoRecoveryStub;

--- a/pom.xml
+++ b/pom.xml
@@ -2075,7 +2075,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.367</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.368</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Related to https://github.com/wso2/carbon-identity-framework/pull/3990
Deprecate the test cases which have been written to use the deprecated services.