### PR TITLE
update pax-logging

### DIFF
--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -54,6 +54,7 @@
                             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
                     </systemProperties>
                     <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging:pax-logging-api</classpathDependencyExclude>
                         <classpathDependencyExclude>org.ops4j.pax.logging:pax-logging-api</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                     <workingDirectory>${basedir}/target</workingDirectory>

--- a/modules/integration/tests-cypress-integration/tests-cypress-common/pom.xml
+++ b/modules/integration/tests-cypress-integration/tests-cypress-common/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -56,6 +56,8 @@
                             </suiteXmlFiles>
 
                             <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging:pax-logging-api
+                                </classpathDependencyExclude>
                                 <classpathDependencyExclude>org.ops4j.pax.logging:pax-logging-api
                                 </classpathDependencyExclude>
                             </classpathDependencyExcludes>
@@ -143,6 +145,8 @@
                             </suiteXmlFiles>
 
                             <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging:pax-logging-api
+                                </classpathDependencyExclude>
                                 <classpathDependencyExclude>org.ops4j.pax.logging:pax-logging-api
                                 </classpathDependencyExclude>
                             </classpathDependencyExcludes>

--- a/modules/tests-utils/admin-services/pom.xml
+++ b/modules/tests-utils/admin-services/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1983,7 +1983,7 @@
             </dependency>
             <!-- Pax Logging -->
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
@@ -2294,7 +2294,7 @@
         <wsdl4j.version>1.6.2.wso2v2</wsdl4j.version>
         <commons.pool.wso2.version>1.5.6.wso2v1</commons.pool.wso2.version>
         <liberty.maven.plugin.version>2.2</liberty.maven.plugin.version>
-        <pax.logging.api.version>1.11.13</pax.logging.api.version>
+        <pax.logging.api.version>2.1.0-wso2v4</pax.logging.api.version>
         <org.wso2.orbit.org.apache.velocity.version>1.7.0.wso2v1</org.wso2.orbit.org.apache.velocity.version>
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose
 
- update pax logging
- exclude WSO2 managed pax logging from maven surfier plugin to resolve test failures.