### PR TITLE
Reduce complexity in adding debug logs

### DIFF
--- a/modules/distribution/src/repository/resources/conf/log4j2.properties
+++ b/modules/distribution/src/repository/resources/conf/log4j2.properties
@@ -147,7 +147,7 @@ appender.osgi.type = PaxOsgi
 appender.osgi.name = PaxOsgi
 appender.osgi.filter = *
 
-loggers = AUDIT_LOG, trace-messages, diagnostics, org-apache-coyote, com-hazelcast, javax-mail, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-apache-axis2-description, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml
+loggers = AUDIT_LOG, trace-messages, diagnostics, org-apache-coyote, com-hazelcast, javax-mail, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-apache-axis2-description, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml, org-wso2-carbon-identity-application, org-wso2-carbon-identity-application-authentication-framework, org-wso2-carbon-identity-oauth2, org-wso2-carbon-identity-oauth, org-wso2-carbon-identity-application-authenticator, org-wso2-carbon-identity-scim, org-wso2-carbon-identity-scim2, org-wso2-charon-core, org-wso2-charon3-core
 
 logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO
@@ -381,20 +381,38 @@ logger.org-wso2-carbon-identity.level=INFO
 logger.org-wso2-carbon-identity-sso-saml.name=org.wso2.carbon.identity.sso.saml
 logger.org-wso2-carbon-identity-sso-saml.level=INFO
 
-#logger.org-wso2-carbon-identity-application.name=org.wso2.carbon.identity.application
-#logger.org-wso2-carbon-identity-application.level=DEBUG
+logger.org-wso2-carbon-identity-application.name=org.wso2.carbon.identity.application
+logger.org-wso2-carbon-identity-application.level=INFO
 
-#logger.org-wso2-carbon-identity-application-authentication-framework.name=org.wso2.carbon.identity.application.authentication.framework
-#logger.org-wso2-carbon-identity-application-authentication-framework.level=DEBUG
+logger.org-wso2-carbon-identity-application-authentication-framework.name=org.wso2.carbon.identity.application.authentication.framework
+logger.org-wso2-carbon-identity-application-authentication-framework.level=INFO
 
 #logger.org-wso2-carbon-identity-mgt.name=org.wso2.carbon.identity.mgt
 #logger.org-wso2-carbon-identity-mgt.level=DEBUG
 
-#logger.org-wso2-carbon-identity-oauth2.name=org.wso2.carbon.identity.oauth2
-#logger.org-wso2-carbon-identity-oauth2.level=DEBUG
+logger.org-wso2-carbon-identity-oauth2.name=org.wso2.carbon.identity.oauth2
+logger.org-wso2-carbon-identity-oauth2.level=INFO
 
-#logger.org-wso2-carbon-identity-scim.name=org.wso2.carbon.identity.scim
-#logger.org-wso2-carbon-identity-scim.level=DEBUG
+logger.org-wso2-carbon-identity-oauth.name=org.wso2.carbon.identity.oauth
+logger.org-wso2-carbon-identity-oauth.level=INFO
+
+logger.org-wso2-carbon-identity-oidc.name=org.wso2.carbon.identity.oidc
+logger.org-wso2-carbon-identity-oidc.level=INFO
+
+logger.org-wso2-carbon-identity-application-authenticator.name=org.wso2.carbon.identity.application.authenticator
+logger.org-wso2-carbon-identity-application-authenticator.level=INFO
+
+logger.org-wso2-carbon-identity-scim.name=org.wso2.carbon.identity.scim
+logger.org-wso2-carbon-identity-scim.level=INFO
+
+logger.org-wso2-carbon-identity-scim2.name=org.wso2.carbon.identity.scim2
+logger.org-wso2-carbon-identity-scim2.level=INFO
+
+logger.org-wso2-charon-core.name=org.wso2.charon.core
+logger.org-wso2-charon-core.level=INFO
+
+logger.org-wso2-charon3-core.name=org.wso2.charon3.core
+logger.org-wso2-charon3-core.level=INFO
 
 #logger.org-wso2-carbon-identity-mgt.name=org.wso2.carbon.identity.mgt
 #logger.org-wso2-carbon-identity-mgt.level=DEBUG


### PR DESCRIPTION
- Reduce the complexity in adding debug logs by adding the commonly used packages to the loggers variable and making it `INFO` level.
- With this change, the process of enabling debug logs is reduced to just changing the logger level to `DEBUG`.