### PR TITLE
Remove IS Analytics related integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -286,18 +286,6 @@
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>
         </classes>
     </test>
-    <test name="is-analytics-tests-deprecated-config" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.analytics.base.AnalyticsBaseTestCase"/>
-            <class name="org.wso2.identity.integration.test.analytics.authentication.AnalyticsLoginTestCase"/>
-            <class name="org.wso2.identity.integration.test.analytics.oauth.OAuth2TokenIssuance"/>
-        </classes>
-    </test>
-    <test name="is-analytics-tests-new-config" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.analytics.authentication.AnalyticsLoginDataPublishHandlingTestCase"/>
-        </classes>
-    </test>
     <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
             <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>


### PR DESCRIPTION
From IS 5.12 onwards, ELK-based analytics will be the recommended on-premise analytics for IS. Added ELK configuration as defualt configurations into the product with https://github.com/wso2/carbon-identity-framework/pull/4000 and https://github.com/wso2-extensions/identity-data-publisher-authentication/pull/98. Hence removing integration tests related to the IS analytics. 