### PR TITLE
Revert temporarily update pr-builder.sh to support binary diffs

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -33,7 +33,7 @@ if [ "$REPO" = "product-is" ]; then
   echo ""
   echo "Applying PR $PULL_NUMBER as a diff..."
   echo "=========================================================="
-  wget -q --output-document=diff.diff $PR_LINK.patch
+  wget -q --output-document=diff.diff $PR_LINK.diff
   cat diff.diff
   echo "=========================================================="
   git apply diff.diff || {
@@ -118,7 +118,7 @@ else
   echo ""
   echo "Applying PR $PULL_NUMBER as a diff..."
   echo "=========================================================="
-  wget -q --output-document=diff.diff $PR_LINK.patch
+  wget -q --output-document=diff.diff $PR_LINK.diff
   cat diff.diff
   echo "=========================================================="
   git apply diff.diff || {


### PR DESCRIPTION
Revert below PRs 
https://github.com/wso2/product-is/pull/13265  
https://github.com/wso2/product-is/pull/13274

This is a temporary reversal due to failure in PR builder test when multiple commits are available in the PR for which the pr-builder-test action is run. When there are multiple commits, the diffs of the commits are taken separately and when there is a conflict, the buider currently fails. 

The initial fix from above PRs will be applied with a new approach to resolve the issue and linked here. 

