### PR TITLE
Update PR builder for carbon-analytics-common 5.2.x branch

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -112,6 +112,11 @@ else
     echo "Checking out for 4.x.x branch in carbon-deployment..."
     echo "=========================================================="
     git checkout 4.x.x
+  elif [ "$REPO" = "carbon-analytics-common" ]; then
+      echo ""
+      echo "Checking out for 5.2.x branch in carbon-analytics-common..."
+      echo "=========================================================="
+      git checkout 5.2.x
   fi
   DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
   echo "Dependency Version: $DEPENDENCY_VERSION"


### PR DESCRIPTION
### Purpose
The 5.2.x branch of carbon-common-analytics repository is used in the product master. Therefore it is needed to explicitly configure the PR builder to apply the diffs on 5.2.x branch of the carbon-commons-analytics instead of the master branch.