### PR TITLE
Introduce backup code authenticator

### DIFF
--- a/modules/api-resources/api-resources-full/pom.xml
+++ b/modules/api-resources/api-resources-full/pom.xml
@@ -158,6 +158,14 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.rest.api.user.backupcode.v1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.rest.api.user.backupcode.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
             <artifactId>org.wso2.carbon.identity.rest.api.user.session.v1</artifactId>
         </dependency>
         <dependency>

--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
@@ -27,6 +27,7 @@
     <import resource="classpath:META-INF/cxf/session-user-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/user-fido2-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/user-totp-v1-cxf.xml"/>
+    <import resource="classpath:META-INF/cxf/user-backupcode-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/permission-management-v1-cxf.xml"/>
     <!--<import resource="classpath:META-INF/cxf/workflow-engine-server-v1-cxf.xml"/>-->
     <import resource="classpath:META-INF/cxf/claim-management-server-v1-cxf.xml"/>
@@ -126,6 +127,7 @@
             <bean class="org.wso2.carbon.identity.rest.api.user.session.v1.MeApi"/>
             <bean class="org.wso2.carbon.identity.rest.api.user.fido2.v1.MeApi"/>
             <bean class="org.wso2.carbon.identity.rest.api.user.totp.v1.MeApi"/>
+            <bean class="org.wso2.carbon.identity.rest.api.user.backupcode.v1.MeApi"/>
             <bean class="org.wso2.carbon.identity.rest.api.user.application.v1.MeApi"/>
             <bean class="org.wso2.carbon.identity.rest.api.user.recovery.v1.RecoveryApi"/>
             <bean class="org.wso2.carbon.identity.rest.api.user.challenge.v1.UserIdApi"/>

--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -186,6 +186,16 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.rest.api.user.backupcode.common</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.rest.api.user.backupcode.v1</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
                 <artifactId>org.wso2.carbon.identity.rest.api.user.recovery.v1</artifactId>
                 <version>${identity.user.api.version}</version>
             </dependency>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -255,6 +255,9 @@
                                     org.wso2.carbon.extension.identity.authenticator.outbound.totp:org.wso2.carbon.extension.identity.authenticator.totp.feature:${authenticator.totp.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
+                                    org.wso2.carbon.extension.identity.authenticator.outbound.backupcode:org.wso2.carbon.extension.identity.authenticator.backupcode.feature:${authenticator.backupcode.version}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.extension.identity.authenticator.outbound.emailotp:org.wso2.carbon.identity.authenticator.emailotp.feature:${authenticator.emailotp.version}
                                 </featureArtifactDef>
 
@@ -1003,6 +1006,10 @@
                                     <version>${authenticator.totp.version}</version>
                                 </feature>
                                 <feature>
+                                    <id>org.wso2.carbon.extension.identity.authenticator.backupcode.connector.feature.group</id>
+                                    <version>${authenticator.backupcode.version}</version>
+                                </feature>
+                                <feature>
                                     <id>org.wso2.carbon.identity.authenticator.emailotp.feature.group</id>
                                     <version>${authenticator.emailotp.version}</version>
                                 </feature>
@@ -1515,6 +1522,10 @@
                                     <version>${authenticator.totp.version}</version>
                                 </feature>
                                 <feature>
+                                    <id>org.wso2.carbon.extension.identity.authenticator.backupcode.connector.feature.group</id>
+                                    <version>${authenticator.backupcode.version}</version>
+                                </feature>
+                                <feature>
                                     <id>org.wso2.carbon.identity.authenticator.emailotp.feature.group</id>
                                     <version>${authenticator.emailotp.version}</version>
                                 </feature>
@@ -1958,6 +1969,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.extension.identity.authenticator.totp.connector.feature.group</id>
                                     <version>${authenticator.totp.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.extension.identity.authenticator.backupcode.connector.feature.group</id>
+                                    <version>${authenticator.backupcode.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.authenticator.emailotp.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1672,6 +1672,11 @@
                 <version>${authenticator.totp.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.backupcode</groupId>
+                <artifactId>org.wso2.carbon.extension.identity.authenticator.backupcode.connector</artifactId>
+                <version>${authenticator.backupcode.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.x509Certificate</groupId>
                 <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>
                 <version>${authenticator.x509.version}</version>
@@ -2080,7 +2085,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.392</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.393</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2106,7 +2111,7 @@
         <identity.inbound.auth.openid.version>5.7.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.7.2</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.0</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>1.6.9</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>1.6.10</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity workflow Versions -->
         <identity.user.workflow.version>5.5.2</identity.user.workflow.version>
@@ -2174,6 +2179,7 @@
 
         <!-- Connector Versions -->
         <authenticator.totp.version>3.0.23</authenticator.totp.version>
+        <authenticator.backupcode.version>0.0.1</authenticator.backupcode.version>
         <authenticator.office365.version>2.1.0</authenticator.office365.version>
         <authenticator.smsotp.version>3.1.5</authenticator.smsotp.version>
         <authenticator.emailotp.version>4.0.7</authenticator.emailotp.version>
@@ -2189,7 +2195,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.9</identity.api.dispatcher.version>
-        <identity.user.api.version>1.2.4</identity.user.api.version>
+        <identity.user.api.version>1.2.5</identity.user.api.version>
         <identity.server.api.version>1.1.13</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
@@ -2201,7 +2207,7 @@
         <carbon.identity.oauth.uma.version>1.3.9</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.version>1.2.923</identity.apps.version>
+        <identity.apps.version>1.2.929</identity.apps.version>
 
         <!-- Charon -->
         <charon.version>3.4.1</charon.version>


### PR DESCRIPTION
## Purpose
Introduce backup code authenticator to IS server. 

## Related PRs
Merge this PR after merging follwoing PRs
- https://github.com/wso2-extensions/identity-outbound-auth-backup-code/pull/1
- https://github.com/wso2/carbon-identity-framework/pull/4009
- https://github.com/wso2/carbon-identity-framework/pull/4010
- https://github.com/wso2/identity-api-user/pull/146
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/416