### PR TITLE
updated DCR register request body in OIDC conformance test script

### DIFF
--- a/oidc-conformance-tests/constants.py
+++ b/oidc-conformance-tests/constants.py
@@ -36,7 +36,8 @@ DCR_BODY = {
     'client_name': 'python_script',
     "grant_types": ["password"],
     "ext_param_client_id": DCR_CLIENT_ID,
-    "ext_param_client_secret": DCR_CLIENT_SECRET
+    "ext_param_client_secret": DCR_CLIENT_SECRET,
+    "is_management_app": True
 }
 
 SMTP_SERVER = "smtp.gmail.com"


### PR DESCRIPTION
Updated DCR register request body to include `is_management_app` property as per the changes made by [1]

[1] - [https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1845](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1845)