### PR TITLE
fixed chat message not sending when triggered automatically

### DIFF
--- a/.github/workflows/oidc-conformance-test.yml
+++ b/.github/workflows/oidc-conformance-test.yml
@@ -155,8 +155,12 @@ jobs:
       if: always()
       run: |
         INPUT=${{github.event.inputs.send-chat}}
+        TAG=${{github.event.inputs.tag}}
         if [[ -z "${INPUT}" ]]; then
-          INPUT="no"
+          INPUT="yes"
+        fi
+        if [[ -z "${TAG}" ]]; then
+          TAG=${GITHUB_REF:10}
         fi
         SEND_CHAT=${INPUT^^}
         if [ $SEND_CHAT == "YES" ]; then
@@ -164,7 +168,7 @@ jobs:
           echo "Sending Google Chat Message"
           echo "==========================="
           CONFORMANCE_SUITE_URL=https://localhost:8443
-          python3 ./product-is/oidc-conformance-tests/send_chat.py "$CONFORMANCE_SUITE_URL" "$GITHUB_RUN_NUMBER" "${{job.status}}" "${{github.repository}}" "${{github.run_id}}" "${{secrets.GOOGLE_CHAT_WEBHOOK_OIDC_TEST}}" "${{github.event.inputs.tag}}"
+          python3 ./product-is/oidc-conformance-tests/send_chat.py "$CONFORMANCE_SUITE_URL" "$GITHUB_RUN_NUMBER" "${{job.status}}" "${{github.repository}}" "${{github.run_id}}" "${{secrets.GOOGLE_CHAT_WEBHOOK_OIDC_TEST}}" "$TAG"
         elif [ $SEND_CHAT == "NO" ]; then
           echo "========================================"
           echo "Skipped Sending Google Chat Message"


### PR DESCRIPTION
Fixed an issue where auto triggers of the OIDC conformance test workflow will not send the test summary to the google chat space