### PR TITLE
Add Default Values for Axis2 Transport Properties

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -30,6 +30,11 @@
   "transport.http.enabled" : true,
   "transport.https.enabled" : true,
 
+  "axis2_transport.receiver.http.enabled": true,
+  "axis2_transport.receiver.https.enabled": true,
+  "axis2_transport.sender.http.enabled": true,
+  "axis2_transport.sender.https.enabled": true,
+
   "system.parameter.\u0027org.wso2.CipherTransformation\u0027": "AES/GCM/NoPadding",
   "system.parameter.\u0027org.apache.xml.security.ignoreLineBreaks\u0027": "true",
 


### PR DESCRIPTION
This PR adds the default values for Axis2 transport properties.  
By default, both http and https properties are enabled for axis2 transportSender and transportReceiver.

These properties can be changed through the deployment.toml file.

For ex: if the http/https transportReceiver property should be disabled, following configs can be added to the deployment.toml file.
```
[axis2_transport.receiver.http]
enabled = false
```
```
[axis2_transport.receiver.https]
enabled = false
```
If the http/https transportSender property should be disabled, following configs can be added to the deployment.toml file.
```
[axis2_transport.sender.http]
enabled = false
```
```
[axis2_transport.sender.https]
enabled = false
```

Related Issue: https://github.com/wso2/product-is/issues/8364

