### PR TITLE
Remove obsolete sms otp module references

### DIFF
--- a/modules/connectors/pom.xml
+++ b/modules/connectors/pom.xml
@@ -146,29 +146,6 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!-- Download smsOTP endpoint war from nexus and copy to the authenticatorCopied/war folder-->
-                    <execution>
-                        <id>download_smsotp_war</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.wso2.identity.apps</groupId>
-                                    <artifactId>sms-otp-authentication-portal</artifactId>
-                                    <version>${identity.apps.version}</version>
-                                    <type>war</type>
-                                    <overWrite>true</overWrite>
-                                    <destFileName>smsotpauthenticationendpoint.war</destFileName>
-                                    <outputDirectory>${basedir}/target/authenticatorCopied/war
-                                    </outputDirectory>
-                                    <includes>**/*.war</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>download_x509certificateauthenticationendpoint_war</id>
                         <phase>compile</phase>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -542,14 +542,6 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/console.war" />
 
-                                <!-- Explode the smsotpauthenticationendpoint.war -->
-                                <unzip dest="../connectors/target/authenticatorCopied/war/smsotpauthenticationendpoint">
-                                    <fileset dir="../connectors/target/authenticatorCopied/war">
-                                        <include name="smsotpauthenticationendpoint.war" />
-                                    </fileset>
-                                </unzip>
-                                <delete file="../connectors/target/authenticatorCopied/war/smsotpauthenticationendpoint.war" />
-
                                 <!-- Explode the x509certificateauthenticationendpoint.war -->
                                 <unzip dest="../connectors/target/authenticatorCopied/war/x509certificateauthenticationendpoint">
                                     <fileset dir="../connectors/target/authenticatorCopied/war">

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -332,15 +332,6 @@
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/components/dropins</outputDirectory>
         </fileSet>
 
-        <!--Copy web apps for for smsotp authenticators-->
-        <fileSet>
-            <directory>../connectors/target/authenticatorCopied/war</directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
-            <includes>
-                <include>smsotpauthenticationendpoint.war</include>
-            </includes>
-        </fileSet>
-
         <!--Copy web apps for for x509 certificate authenticators-->
         <fileSet>
             <directory>../connectors/target/authenticatorCopied/war</directory>
@@ -542,7 +533,6 @@
             <directory>../connectors/target/authenticatorCopied/war</directory>
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
             <includes>
-                <include>smsotpauthenticationendpoint/</include>
                 <include>x509certificateauthenticationendpoint/</include>
             </includes>
         </fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -2084,7 +2084,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.437</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.440</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2180,7 +2180,7 @@
         <authenticator.totp.version>3.0.26</authenticator.totp.version>
         <authenticator.backupcode.version>0.0.3</authenticator.backupcode.version>
         <authenticator.office365.version>2.1.1</authenticator.office365.version>
-        <authenticator.smsotp.version>3.1.9</authenticator.smsotp.version>
+        <authenticator.smsotp.version>3.1.10</authenticator.smsotp.version>
         <authenticator.emailotp.version>4.0.8</authenticator.emailotp.version>
         <authenticator.twitter.version>1.1.0</authenticator.twitter.version>
         <authenticator.x509.version>3.1.2</authenticator.x509.version>
@@ -2208,7 +2208,7 @@
         <carbon.identity.oauth.uma.version>1.3.9</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.version>1.2.1009</identity.apps.version>
+        <identity.apps.version>1.2.1011</identity.apps.version>
 
         <!-- Charon -->
         <charon.version>3.4.1</charon.version>


### PR DESCRIPTION
This removes obsolete SMS OTP module references. 

Fixes https://github.com/wso2/product-is/issues/14046