### PR TITLE
Replace organization attr with country in validateUserExtensionSchemaElement

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2SchemasTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2SchemasTest.java
@@ -136,13 +136,13 @@ public class SCIM2SchemasTest extends SCIM2BaseTest {
     @Test(dependsOnMethods = "getSchemas")
     public void validateUserExtensionSchemaElement() {
 
-        String baseIdentifier = "find{ it.name == 'EnterpriseUser' }.attributes.find {it.name == 'organization'}.";
+        String baseIdentifier = "find{ it.name == 'EnterpriseUser' }.attributes.find {it.name == 'country'}.";
         this.response.then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(baseIdentifier + "type", is("STRING"))
-                .body(baseIdentifier + "displayName", is("Organization"));
+                .body(baseIdentifier + "displayName", is("Country"));
 
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
This PR will replace `Organization` attribute with `Country` in `validateUserExtensionSchemaElement` test.

### Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4091

### Related Issues
https://github.com/wso2/product-is/issues/14015