### PR TITLE
Bump versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2159,7 +2159,7 @@
         <identity.inbound.auth.openid.version>5.7.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.7.4</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.0</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>1.6.16</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>1.6.17</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity workflow Versions -->
         <identity.user.workflow.version>5.5.2</identity.user.workflow.version>
@@ -2234,7 +2234,7 @@
         <authenticator.x509.version>3.1.2</authenticator.x509.version>
         <identity.extension.utils>1.0.8</identity.extension.utils>
 
-        <identity.org.mgt.version>1.0.23</identity.org.mgt.version>
+        <identity.org.mgt.version>1.0.28</identity.org.mgt.version>
 
         <!-- Hash Provider Versions-->
         <hashprovider.pbkdf2.version>0.1.4</hashprovider.pbkdf2.version>


### PR DESCRIPTION
Bump identity.inbound.provisioning.scim2.version 1.6.16 -> 1.6.17
identity.org.mgt.version 1.0.23 ->1.0.28