### PR TITLE
Set [multi_tenancy.stratos] public_cloud_setup = false

### DIFF
--- a/modules/distribution/src/repository/resources/conf/deployment.toml
+++ b/modules/distribution/src/repository/resources/conf/deployment.toml
@@ -38,6 +38,9 @@ hash= "66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"
 [identity.auth_framework.endpoint]
 app_password= "dashboard"
 
+[multi_tenancy.stratos]
+public_cloud_setup=false
+
 # The KeyStore which is used for encrypting/decrypting internal data. By default the primary keystore is used as the internal keystore.
 
 #[keystore.internal]

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_enabled.toml
@@ -40,3 +40,6 @@ app_password= "dashboard"
 
 [application_mgt]
 enable_role_validation = true
+
+[multi_tenancy.stratos]
+public_cloud_setup=false


### PR DESCRIPTION
$Subject
Part of fix: https://github.com/wso2/product-is/issues/14219
By default, organization mgt is enabled in IS-6.0.0. In order to support organization management, the following config should be changed as follows.
If public_cloud_setup = false, the created tenant's domain name doesn't need to end with an extension like (.com)
```
[multi_tenancy.stratos]
public_cloud_setup=false
```