### PR TITLE
Bump framework and event-handler-notification versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2172,7 +2172,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.13</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.16</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2220,7 +2220,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.5.0</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.4.7</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.4.8</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
This PR will bump the `carbon-identity-framework` and `identity-event-handler-notification` versions to get the changes related to adding magic link to IS [[1]](https://github.com/wso2/product-is/issues/14227).

[1] https://github.com/wso2/product-is/issues/14227