### PR TITLE
Remove organization_switch from oidc-metadata

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
@@ -42,10 +42,6 @@
         "displayName": "account_switch"
       },
       {
-        "name": "organization_switch",
-        "displayName": "organization_switch"
-      },
-      {
         "name": "urn:ietf:params:oauth:grant-type:jwt-bearer",
         "displayName": "urn:ietf:params:oauth:grant-type:jwt-bearer"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -2182,7 +2182,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.37</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.42</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -2285,7 +2285,7 @@
         <authenticator.x509.version>3.1.5</authenticator.x509.version>
         <identity.extension.utils>1.0.8</identity.extension.utils>
 
-        <identity.org.mgt.version>1.0.64</identity.org.mgt.version>
+        <identity.org.mgt.version>1.0.65</identity.org.mgt.version>
 
         <!-- Hash Provider Versions-->
         <hashprovider.pbkdf2.version>0.1.4</hashprovider.pbkdf2.version>


### PR DESCRIPTION
$Subject

Removing due to changes in https://github.com/wso2/carbon-identity-framework/pull/4164

- [x] Bump framework version