### PR TITLE
Modify Integration Tests after Disabling Cross Tenant Token Introspection

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -464,12 +464,12 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 	 * @return JSON object of the response.
 	 * @throws Exception
 	 */
-	public JSONObject introspectTokenWithTenant(HttpClient client, String accessToken, String endpoint)
-			throws Exception {
+	public JSONObject introspectTokenWithTenant(HttpClient client, String accessToken, String endpoint, String key,
+												String secret) throws Exception {
 
 		List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
 		urlParameters.add(new BasicNameValuePair("token", accessToken));
-		return responseObject(client, endpoint, urlParameters, userInfo.getUserName(), userInfo.getPassword());
+		return responseObject(client, endpoint, urlParameters, "Basic " + getBase64EncodedString(key, secret));
 	}
 
 	/**
@@ -663,10 +663,10 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 	 * @throws Exception
 	 */
 	private JSONObject responseObject(HttpClient client, String endpoint, List<NameValuePair> postParameters,
-									  String key, String secret) throws Exception {
+									  String authorizationHeader) throws Exception {
 
 		HttpPost httpPost = new HttpPost(endpoint);
-		httpPost.setHeader("Authorization", "Basic " + getBase64EncodedString(key, secret));
+		httpPost.setHeader("Authorization", authorizationHeader);
 		httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded");
 		httpPost.setEntity(new UrlEncodedFormEntity(postParameters));
 		HttpResponse response = client.execute(httpPost);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -457,6 +457,22 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 	}
 
 	/**
+	 * Send token introspection post request according to the tenant domain.
+	 * @param client - http client
+	 * @param accessToken - access token
+	 * @param endpoint - Introspection URL of the tenant domain.
+	 * @return JSON object of the response.
+	 * @throws Exception
+	 */
+	public JSONObject introspectTokenWithTenant(HttpClient client, String accessToken, String endpoint)
+			throws Exception {
+
+		List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+		urlParameters.add(new BasicNameValuePair("token", accessToken));
+		return responseObject(client, endpoint, urlParameters, userInfo.getUserName(), userInfo.getPassword());
+	}
+
+	/**
 	 * Delete Application
 	 *
 	 * @throws Exception
@@ -634,5 +650,33 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 			}
 			authRequestList.add(opicAuthenticationRequest);
 		}
+	}
+
+	/**
+	 * Build post request and return json response object.
+	 *
+	 * @param endpoint       Endpoint.
+	 * @param postParameters postParameters.
+	 * @param key            Basic authentication key.
+	 * @param secret         Basic authentication secret.
+	 * @return JSON object of the response.
+	 * @throws Exception
+	 */
+	private JSONObject responseObject(HttpClient client, String endpoint, List<NameValuePair> postParameters,
+									  String key, String secret) throws Exception {
+
+		HttpPost httpPost = new HttpPost(endpoint);
+		httpPost.setHeader("Authorization", "Basic " + getBase64EncodedString(key, secret));
+		httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded");
+		httpPost.setEntity(new UrlEncodedFormEntity(postParameters));
+		HttpResponse response = client.execute(httpPost);
+		String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+		EntityUtils.consume(response.getEntity());
+		JSONParser parser = new JSONParser();
+		JSONObject json = (JSONObject) parser.parse(responseString);
+		if (json == null) {
+			throw new Exception("Error occurred while getting the response.");
+		}
+		return json;
 	}
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
@@ -266,24 +266,20 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
 
     @Test(groups = "wso2.is", description = "Validate access token", dependsOnMethods = "testGetAccessToken")
     public void testValidateAccessToken() throws Exception {
-        HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
-        Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
-        keyPositionMap.put("name=\"valid\"", 1);
-
-        List<KeyValue> keyValues =
-                DataExtractUtil.extractInputValueFromResponse(response,
-                        keyPositionMap);
-        Assert.assertNotNull(keyValues, "Access token Key value is null.");
-        String valid = keyValues.get(0).getValue();
-        Assert.assertEquals(valid, "true", "Token Validation failed");
-        EntityUtils.consume(response.getEntity());
+        String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+                OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+        org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl);
+        Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
+        Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
     }
 
     @Test(groups = "wso2.is", description = "Validate the user claim values", dependsOnMethods = "testGetAccessToken")
     public void testClaims() throws Exception {
-        HttpGet request = new HttpGet(OAuth2Constant.USER_INFO_ENDPOINT);
+
+        String userInfoUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+                OAuth2Constant.USER_INFO_ENDPOINT : OAuth2Constant.TENANT_USER_INFO_ENDPOINT;
+        HttpGet request = new HttpGet(userInfoUrl);
 
         request.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
         request.setHeader("Authorization", "Bearer " + accessToken);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
@@ -269,7 +269,8 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
 
         String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
                 OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
-        org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl);
+        org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
+                username, userPassword);
         Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
         Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -161,7 +161,8 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
 
 		String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
 				OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
-		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl);
+		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
+				username, userPassword);
 		Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
 		Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
 	}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -158,17 +158,11 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
 
 	@Test(groups = "wso2.is", description = "Validate access token", dependsOnMethods = "testSendAuthorozedPost")
 	public void testValidateAccessToken() throws Exception {
-		HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
-		Assert.assertNotNull(response, "Validate access token failed. response is invalid.");
 
-		Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
-		keyPositionMap.put("name=\"valid\"", 1);
-
-		List<KeyValue> keyValues = DataExtractUtil.extractInputValueFromResponse(response, keyPositionMap);
-		Assert.assertNotNull(keyValues, "Access token Key value is null.");
-		String valid = keyValues.get(0).getValue();
-		EntityUtils.consume(response.getEntity());
-		Assert.assertEquals(valid, "true", "Token Validation failed");
-		EntityUtils.consume(response.getEntity());
+		String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+				OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl);
+		Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
+		Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
 	}
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceImplicitGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceImplicitGrantTestCase.java
@@ -226,20 +226,12 @@ public class OAuth2ServiceImplicitGrantTestCase extends OAuth2ServiceAbstractInt
 
 	@Test(groups = "wso2.is", description = "Validate access token", dependsOnMethods = "testSendApprovalPost")
 	public void testValidateAccessToken() throws Exception {
-		HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
-		Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-		Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
-		keyPositionMap.put("name=\"valid\"", 1);
-
-		List<KeyValue> keyValues =
-		                           DataExtractUtil.extractInputValueFromResponse(response,
-		                                                                         keyPositionMap);
-		Assert.assertNotNull(keyValues, "Access token Key value is null.");
-		String valid = keyValues.get(0).getValue();
-		EntityUtils.consume(response.getEntity());
-		Assert.assertEquals(valid, "true", "Token Validation failed");
-		EntityUtils.consume(response.getEntity());
+		String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+				OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
+				username, userPassword);
+		Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
+		Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
 	}
-
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
@@ -184,19 +184,12 @@ public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractInt
 
 	@Test(groups = "wso2.is", description = "Validate access token", dependsOnMethods = "testSendAuthorozedPost")
 	public void testValidateAccessToken() throws Exception {
-		HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
-		Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-		Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
-		keyPositionMap.put("name=\"valid\"", 1);
-
-		List<KeyValue> keyValues =
-		                           DataExtractUtil.extractInputValueFromResponse(response,
-		                                                                         keyPositionMap);
-		Assert.assertNotNull(keyValues, "Access token Key value is null.");
-		String valid = keyValues.get(0).getValue();
-		EntityUtils.consume(response.getEntity());
-		Assert.assertEquals(valid, "true", "Token Validation failed");
+		String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+				OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl);
+		Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
+		Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
 	}
 
     @Test(groups = "wso2.is", description = "Send authorize user request without having colan separated client it and" +

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
@@ -187,7 +187,8 @@ public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractInt
 
 		String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
 				OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
-		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl);
+		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
+				username, userPassword);
 		Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
 		Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
 	}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithRevokedAccessToken.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithRevokedAccessToken.java
@@ -201,7 +201,9 @@ public class OAuth2TokenRevocationWithRevokedAccessToken extends OAuth2ServiceAb
     private HTTPResponse revokeAccessToken(AccessToken accessToken) throws Exception {
 
         ClientAuthentication clientAuth = new ClientSecretBasic(consumerKey, consumerSecret);
-        URI tokenRevokeEndpoint = new URI(OAuth2Constant.TOKEN_REVOKE_ENDPOINT);
+        String tokenRevokeUrl = activeTenant.equalsIgnoreCase("carbon.super") ?
+                OAuth2Constant.TOKEN_REVOKE_ENDPOINT : OAuth2Constant.TENANT_TOKEN_REVOKE_ENDPOINT;
+        URI tokenRevokeEndpoint = new URI(tokenRevokeUrl);
 
         TokenRevocationRequest revocationRequest =
                 new TokenRevocationRequest(tokenRevokeEndpoint, clientAuth, accessToken);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
@@ -103,6 +103,7 @@ public final class OAuth2Constant {
     public static final String INTRO_SPEC_ENDPOINT = "https://localhost:9853/oauth2/introspect";
     public static final String TENANT_INTRO_SPEC_ENDPOINT = "https://localhost:9853/t/wso2.com/oauth2/introspect";
     public static final String TENANT_USER_INFO_ENDPOINT = "https://localhost:9853/t/wso2.com/oauth2/userinfo?schema=openid";
+    public final static String TENANT_TOKEN_REVOKE_ENDPOINT = "https://localhost:9853/t/wso2.com/oauth2/revoke";
 
     public static final class PlaygroundAppPaths {
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/OAuth2Constant.java
@@ -102,6 +102,7 @@ public final class OAuth2Constant {
     public static final String OAUTH2_NONCE = "nonce";
     public static final String INTRO_SPEC_ENDPOINT = "https://localhost:9853/oauth2/introspect";
     public static final String TENANT_INTRO_SPEC_ENDPOINT = "https://localhost:9853/t/wso2.com/oauth2/introspect";
+    public static final String TENANT_USER_INFO_ENDPOINT = "https://localhost:9853/t/wso2.com/oauth2/userinfo?schema=openid";
 
     public static final class PlaygroundAppPaths {
 

--- a/pom.xml
+++ b/pom.xml
@@ -2182,7 +2182,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.57</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.56</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2204,7 +2204,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.9.11</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.7.185</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.7.187</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.7.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.7.5</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.0</identity.inbound.provisioning.scim.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2182,7 +2182,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.51</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.57</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
This PR modifies the product-is integration tests after the cross tenant token introspection is disabled. With this config disabled, an access token of a tenant cannot be introspected using the supertenant introspection endpoint. The tenanted introspection endpoint should be used instead.

Related issue: https://github.com/wso2/product-is/issues/14270 