### PR TITLE
Bump the latest carbon identity framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2182,7 +2182,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.56</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.62</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Bump carbon identity framework version after fixing [#14501](https://github.com/wso2/product-is/issues/14501)