### PR TITLE
Bump inbound auth oauth version to v6.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2204,7 +2204,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.10.0</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.8.0</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.8.2</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.7.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.8.0</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.0</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
Bump inbound auth oauth version from v6.8.0 to v6.8.2