### PR TITLE
Bump identity event handler notification version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2230,7 +2230,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.6.1</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.5.1</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.5.2</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
Need to bump the `identity-event-handler-notification` version to add the branding changes in email notifications