### PR TITLE
Fix error response for unsupported grant type error

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceErrorResponseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceErrorResponseTest.java
@@ -86,8 +86,7 @@ public class OAuth2ServiceErrorResponseTest extends OAuth2ServiceAbstractIntegra
         String locationURI = locationHeader.getValue();
 
         Assert.assertTrue(locationURI.contains(OAuth2Constant.UNAUTHORIZED_CLIENT));
-        Assert.assertTrue(locationURI.contains("The+authenticated+client+is+not+authorized+to+use+this+authorization+" +
-                "grant+type"));
+        Assert.assertTrue(locationURI.contains("not.authorized.for.requested.grant.type"));
     }
 
     public OAuthConsumerAppDTO createApplication() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceErrorResponseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceErrorResponseTest.java
@@ -86,7 +86,7 @@ public class OAuth2ServiceErrorResponseTest extends OAuth2ServiceAbstractIntegra
         String locationURI = locationHeader.getValue();
 
         Assert.assertTrue(locationURI.contains(OAuth2Constant.UNAUTHORIZED_CLIENT));
-        Assert.assertTrue(locationURI.contains("not.authorized.for.requested.grant.type"));
+        Assert.assertTrue(locationURI.contains("not.authorized.to.use.requested.grant.type"));
     }
 
     public OAuthConsumerAppDTO createApplication() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -2182,7 +2182,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.23.28</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.32</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2204,7 +2204,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.10.1</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.8.3</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.8.4</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.7.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.8.0</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.0</identity.inbound.provisioning.scim.version>
@@ -2307,7 +2307,7 @@
         <carbon.identity.oauth.uma.version>1.3.9</carbon.identity.oauth.uma.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.version>1.4.63</identity.apps.version>
+        <identity.apps.version>1.4.70</identity.apps.version>
 
         <!-- Charon -->
         <charon.version>3.4.1</charon.version>


### PR DESCRIPTION
This PR updates integration test for unsupported grant type error response. oauthErrorMsg for unsupported grant type has been changed to `not.authorized.for.requested.grant.type` with https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1901. 