### PR TITLE
Add oauth-scope-bindings.xml.j2 to wso2-is

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -994,6 +994,13 @@
         </file>
         <file>
             <source>
+                ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/conf/templates/repository/conf/identity/oauth-scope-bindings.xml.j2
+            </source>
+            <outputDirectory>wso2is-${pom.version}/repository/resources/conf/templates/repository/conf/identity</outputDirectory>
+            <fileMode>644</fileMode>
+        </file>
+        <file>
+            <source>
                 ../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/consent-mgt-config.xml
             </source>
             <outputDirectory>wso2is-${pom.version}/repository/conf/</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -2209,7 +2209,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.10.2</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.10.1</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.10.2-SNAPSHOT</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.9.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.10.0</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.0</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
Add oauth-scope-bindings.xml.j2 file, which gives the capability to add new scope bindings
Fix: https://github.com/wso2/product-is/issues/14971
Sample deployment.toml config 
```
[[scope.binding]]
name="internal_organization_view"
display_name="View Organization"
permission="/permission/admin/manage/identity/organizationmgt/view"
```

Depends on:

- [ ] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1920
- [ ] Bump identity.inbound.auth.oauth.version