### PR TITLE
PR Builder fix for carbon kernel 4.9.0.mx

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -1,6 +1,4 @@
 #!/bin/bash +x
-MULTITENANCY_REPO=carbon-multitenancy
-MULTITENANCY_REPO_CLONE_LINK=https://github.com/wso2/carbon-multitenancy.git
 OUTBOUND_AUTH_OIDC_REPO=identity-outbound-auth-oidc
 OUTBOUND_AUTH_OIDC_REPO_CLONE_LINK=https://github.com/wso2-extensions/identity-outbound-auth-oidc.git
 SCIM2_REPO=identity-inbound-provisioning-scim2
@@ -192,62 +190,9 @@ else
   fi
   cd ..
 
-  MULTITENANCY_VERSION_PROPERTY_KEY=""
-  MULTITENANCY_DEPENDENCY_VERSION=""
   OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY=""
   OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION=""
   if [ "$REPO" = "carbon-kernel" ]; then
-    echo ""
-    echo "Building Multitenancy repo..."
-    echo "=========================================================="
-    git clone $MULTITENANCY_REPO_CLONE_LINK
-    MULTITENANCY_VERSION_PROPERTY=$(python version_property_finder.py $MULTITENANCY_REPO product-is 2>&1)
-    if [ "$MULTITENANCY_VERSION_PROPERTY" != "invalid" ]; then
-      echo "Version property key for the $MULTITENANCY_REPO is $MULTITENANCY_VERSION_PROPERTY"
-      MULTITENANCY_VERSION_PROPERTY_KEY=$MULTITENANCY_VERSION_PROPERTY
-    else
-      echo ""
-      echo "=========================================================="
-      echo "Unable to find the version property for $MULTITENANCY_REPO..."
-      echo "=========================================================="
-      echo ""
-      echo "::error::Unable to find the version property for $MULTITENANCY_REPO..."
-      exit 1
-    fi
-    cd $MULTITENANCY_REPO
-    MULTITENANCY_DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-    echo "Multitenancy Dependency Version: $MULTITENANCY_DEPENDENCY_VERSION"
-    echo ""
-
-    KERNEL_VERSION_PROPERTY_KEY=carbon.kernel.version
-    echo "Updating carbon-kernel dependency version in carbon-multitenancy repo..."
-    echo "=========================================================="
-    echo ""
-    sed -i "s/<$KERNEL_VERSION_PROPERTY_KEY>.*<\/$KERNEL_VERSION_PROPERTY_KEY>/<$KERNEL_VERSION_PROPERTY_KEY>$DEPENDENCY_VERSION<\/$KERNEL_VERSION_PROPERTY_KEY>/" pom.xml
-
-    echo ""
-    echo "Building repo $MULTITENANCY_REPO..."
-    echo "=========================================================="
-
-
-    export JAVA_HOME=$JAVA_11_HOME
-    mvn clean install -Dmaven.test.skip=true --batch-mode | tee mvn-build.log
-
-    echo "Repo $MULTITENANCY_REPO build complete."
-    SUB_REPO_BUILD_STATUS=$(cat mvn-build.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
-
-    if [ "$SUB_REPO_BUILD_STATUS" != "SUCCESS" ]; then
-      echo "$MULTITENANCY_REPO repo build not successfull. Aborting."
-      echo "::error::$MULTITENANCY_REPO repo build not successfull. Aborting."
-      exit 1
-    fi
-
-    echo ""
-    echo "Built version: $MULTITENANCY_DEPENDENCY_VERSION"
-    echo "=========================================================="
-    echo ""
-    cd ..
-
     echo ""
     echo "Building Outbound Auth OIDC repo..."
     echo "=========================================================="
@@ -367,16 +312,10 @@ else
   else
     sed -i "s/<$VERSION_PROPERTY_KEY>.*<\/$VERSION_PROPERTY_KEY>/<$VERSION_PROPERTY_KEY>$DEPENDENCY_VERSION<\/$VERSION_PROPERTY_KEY>/" pom.xml
     if [ "$REPO" = "carbon-kernel" ]; then
-      echo "Updating Multitenancy version in product-is..."
-      echo "=========================================================="
-      echo ""
-      sed -i "s/<$MULTITENANCY_VERSION_PROPERTY_KEY>.*<\/$MULTITENANCY_VERSION_PROPERTY_KEY>/<$MULTITENANCY_VERSION_PROPERTY_KEY>$MULTITENANCY_DEPENDENCY_VERSION<\/$MULTITENANCY_VERSION_PROPERTY_KEY>/" pom.xml
-
       echo "Updating Outbound Auth OIDC version in product-is..."
       echo "=========================================================="
       echo ""
       sed -i "s/<$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>.*<\/$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>/<$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>$OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION<\/$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>/" pom.xml
-
       echo "Updating caron-kernel version in carbon.product..."
       echo "=========================================================="
       echo ""

--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -1,6 +1,8 @@
 #!/bin/bash +x
 MULTITENANCY_REPO=carbon-multitenancy
 MULTITENANCY_REPO_CLONE_LINK=https://github.com/wso2/carbon-multitenancy.git
+OUTBOUND_AUTH_OIDC_REPO=identity-outbound-auth-oidc
+OUTBOUND_AUTH_OIDC_REPO_CLONE_LINK=https://github.com/wso2-extensions/identity-outbound-auth-oidc.git
 SCIM2_REPO=identity-inbound-provisioning-scim2
 SCIM2_REPO_CLONE_LINK=https://github.com/wso2-extensions/identity-inbound-provisioning-scim2.git
 
@@ -192,6 +194,8 @@ else
 
   MULTITENANCY_VERSION_PROPERTY_KEY=""
   MULTITENANCY_DEPENDENCY_VERSION=""
+  OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY=""
+  OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION=""
   if [ "$REPO" = "carbon-kernel" ]; then
     echo ""
     echo "Building Multitenancy repo..."
@@ -240,6 +244,57 @@ else
 
     echo ""
     echo "Built version: $MULTITENANCY_DEPENDENCY_VERSION"
+    echo "=========================================================="
+    echo ""
+    cd ..
+
+    echo ""
+    echo "Building Outbound Auth OIDC repo..."
+    echo "=========================================================="
+    git clone $OUTBOUND_AUTH_OIDC_REPO_CLONE_LINK
+    OUTBOUND_AUTH_OIDC_VERSION_PROPERTY=$(python version_property_finder.py $OUTBOUND_AUTH_OIDC_REPO product-is 2>&1)
+    if [ "$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY" != "invalid" ]; then
+      echo "Version property key for the $OUTBOUND_AUTH_OIDC_REPO is $OUTBOUND_AUTH_OIDC_VERSION_PROPERTY"
+      OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY=$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY
+    else
+      echo ""
+      echo "=========================================================="
+      echo "Unable to find the version property for $OUTBOUND_AUTH_OIDC_REPO..."
+      echo "=========================================================="
+      echo ""
+      echo "::error::Unable to find the version property for $OUTBOUND_AUTH_OIDC_REPO..."
+      exit 1
+    fi
+    cd $OUTBOUND_AUTH_OIDC_REPO
+    OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+    echo "Outbound Auth OIDC Dependency Version: $OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION"
+    echo ""
+
+    KERNEL_VERSION_PROPERTY_KEY=carbon.kernel.version
+    echo "Updating carbon-kernel dependency version in identity-outbound-auth-oidc repo..."
+    echo "=========================================================="
+    echo ""
+    sed -i "s/<$KERNEL_VERSION_PROPERTY_KEY>.*<\/$KERNEL_VERSION_PROPERTY_KEY>/<$KERNEL_VERSION_PROPERTY_KEY>$DEPENDENCY_VERSION<\/$KERNEL_VERSION_PROPERTY_KEY>/" pom.xml
+
+    echo ""
+    echo "Building repo $OUTBOUND_AUTH_OIDC_REPO..."
+    echo "=========================================================="
+
+
+    export JAVA_HOME=$JAVA_11_HOME
+    mvn clean install -Dmaven.test.skip=true --batch-mode | tee mvn-build.log
+
+    echo "Repo $OUTBOUND_AUTH_OIDC_REPO build complete."
+    SUB_REPO_BUILD_STATUS=$(cat mvn-build.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
+
+    if [ "$SUB_REPO_BUILD_STATUS" != "SUCCESS" ]; then
+      echo "$OUTBOUND_AUTH_OIDC_REPO repo build not successfull. Aborting."
+      echo "::error::$OUTBOUND_AUTH_OIDC_REPO repo build not successfull. Aborting."
+      exit 1
+    fi
+
+    echo ""
+    echo "Built version: $OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION"
     echo "=========================================================="
     echo ""
     cd ..
@@ -316,6 +371,12 @@ else
       echo "=========================================================="
       echo ""
       sed -i "s/<$MULTITENANCY_VERSION_PROPERTY_KEY>.*<\/$MULTITENANCY_VERSION_PROPERTY_KEY>/<$MULTITENANCY_VERSION_PROPERTY_KEY>$MULTITENANCY_DEPENDENCY_VERSION<\/$MULTITENANCY_VERSION_PROPERTY_KEY>/" pom.xml
+
+      echo "Updating Outbound Auth OIDC version in product-is..."
+      echo "=========================================================="
+      echo ""
+      sed -i "s/<$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>.*<\/$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>/<$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>$OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION<\/$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY_KEY>/" pom.xml
+
       echo "Updating caron-kernel version in carbon.product..."
       echo "=========================================================="
       echo ""


### PR DESCRIPTION
## Description
PR builder failure occurs for `OpenID Connect Application Authenticator Server Feature` version `5.11.2` due to carbon kernel version `4.9.0.m1`. This happens due to carbon kernel being kept as `4.9.0.SNAPSHOT`. Similar approach was taken for multi-tenancy repository as well and it will be reverted from this update since not required anymore. 

Following is the error that occurs with the [PR build failure](https://github.com/wso2/product-is/actions/runs/3265033674/jobs/5366604658#step:11:23881).
```
Missing requirement: OpenID Connect Application Authenticator Server Feature 5.11.2
(org.wso2.carbon.identity.application.authenticator.oidc.server.feature.group 5.11.2) requires
'org.wso2.carbon.core.feature.group [4.9.0.m1,5.0.0)' but it could not be found
```