### PR TITLE
Use dependsOn to resolve a test case execution order issue

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
@@ -73,19 +73,25 @@ public class SelfRegisterTestCase extends SelfRegisterTestBase {
         Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_BAD_REQUEST, "Self register user not enabled");
     }
 
-    @Test(
-            alwaysRun = true,
-            groups = "wso2.is",
-            description = "Create self registered user with new and existing usernames"
-    )
+    @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user")
     public void testSelfRegister() throws Exception {
 
         updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
         Response responseOfPost = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
         Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_CREATED, "Self register user successful");
+    }
 
-        Response responseOfPostConflict = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
-        Assert.assertEquals(responseOfPostConflict.statusCode(), HttpStatus.SC_CONFLICT, "Username already exist");
+    @Test(
+            alwaysRun = true,
+            groups = "wso2.is",
+            dependsOnMethods = {"testSelfRegister"},
+            description = "Create self registered user with existing username"
+    )
+    public void testSelfRegisterWithExistingUsername() throws Exception {
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        Response responseOfPost = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
+        Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_CONFLICT, "Self register user already exists");
     }
 
     @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user with invalid username")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
@@ -73,20 +73,19 @@ public class SelfRegisterTestCase extends SelfRegisterTestBase {
         Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_BAD_REQUEST, "Self register user not enabled");
     }
 
-    @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user")
+    @Test(
+            alwaysRun = true,
+            groups = "wso2.is",
+            description = "Create self registered user with new and existing usernames"
+    )
     public void testSelfRegister() throws Exception {
 
         updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
         Response responseOfPost = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
         Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_CREATED, "Self register user successful");
-    }
 
-    @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user with existing username")
-    public void testSelfRegisterWithExistingUsername() throws Exception {
-
-        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
-        Response responseOfPost = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
-        Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_CONFLICT, "Self register user already exists");
+        Response responseOfPostConflict = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
+        Assert.assertEquals(responseOfPostConflict.statusCode(), HttpStatus.SC_CONFLICT, "Username already exist");
     }
 
     @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user with invalid username")


### PR DESCRIPTION
Merge two test cases related to self register user to resolve an intermittent test failure.