### PR TITLE
Bump basicauth dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2271,7 +2271,7 @@
         <provisioning.connector.scim2.version>2.0.1</provisioning.connector.scim2.version>
 
         <!-- Local Authenticator Versions -->
-        <identity.local.auth.basicauth.version>6.7.2</identity.local.auth.basicauth.version>
+        <identity.local.auth.basicauth.version>6.7.3</identity.local.auth.basicauth.version>
         <identity.local.auth.fido.version>5.3.30</identity.local.auth.fido.version>
         <identity.local.auth.iwa.version>5.4.0</identity.local.auth.iwa.version>
 


### PR DESCRIPTION
Bump basicauth dependency version from `6.7.2` -> `6.7.3`