### PR TITLE
Add test to assert openid scope is not issued for client credential grant type

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -124,7 +124,6 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
 
         consumerSecret = appDto.getOauthConsumerSecret();
         Assert.assertNotNull(consumerSecret, "Application creation failed.");
-
     }
 
     @Test(groups = "wso2.is", description = "Send client credentials token request.", dependsOnMethods = "testRegisterApplication")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -1,28 +1,37 @@
 /*
-* Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* WSO2 Inc. licenses this file to you under the Apache License,
-* Version 2.0 (the "License"); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.identity.integration.test.oauth2;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
+import com.nimbusds.oauth2.sdk.ClientCredentialsGrant;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -31,139 +40,133 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.automation.engine.context.beans.ContextUrls;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
-import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
 import org.wso2.identity.integration.common.clients.application.mgt.ApplicationManagementServiceClient;
 import org.wso2.identity.integration.common.clients.oauth.OauthAdminClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
-import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.net.URI;
 
-import static org.wso2.identity.integration.test.utils.DataExtractUtil.KeyValue;
-
+/**
+ * Tests for OAuth2 client credentials grant type.
+ */
 public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstractIntegrationTest {
-	private AuthenticatorClient logManger;
-	private String accessToken;
-	private String consumerKey;
-	private String consumerSecret;
-	private String username;
-	private String userPassword;
-	private final AutomationContext context;
-	private String backendURL;
-	private String sessionCookie;
-	private Tenant tenantInfo;
-	private User userInfo;
-	private LoginLogoutClient loginLogoutClient;
-	private ContextUrls identityContextUrls;
-	private RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
 
-	private CloseableHttpClient client;
+    private AuthenticatorClient logManger;
+    private String accessToken;
+    private String consumerKey;
+    private String consumerSecret;
+    private final String username;
+    private final String userPassword;
+    private final AutomationContext context;
+    private Tenant tenantInfo;
 
-	@DataProvider(name = "configProvider")
-	public static Object[][] configProvider() {
-		return new Object[][]{{TestUserMode.SUPER_TENANT_ADMIN}, {TestUserMode.TENANT_ADMIN}};
-	}
+    private CloseableHttpClient client;
 
-	@Factory(dataProvider = "configProvider")
-	public OAuth2ServiceClientCredentialTestCase(TestUserMode userMode) throws Exception {
+    @DataProvider(name = "configProvider")
+    public static Object[][] configProvider() {
 
-		context = new AutomationContext("IDENTITY", userMode);
-		this.username = context.getContextTenant().getTenantAdmin().getUserName();
-		this.userPassword = context.getContextTenant().getTenantAdmin().getPassword();
-	}
+        return new Object[][]{{TestUserMode.SUPER_TENANT_ADMIN}, {TestUserMode.TENANT_ADMIN}};
+    }
 
-	@BeforeClass(alwaysRun = true)
-	public void testInit() throws Exception {
+    @Factory(dataProvider = "configProvider")
+    public OAuth2ServiceClientCredentialTestCase(TestUserMode userMode) throws Exception {
 
-		backendURL = context.getContextUrls().getBackEndUrl();
-		loginLogoutClient = new LoginLogoutClient(context);
-		logManger = new AuthenticatorClient(backendURL);
-		sessionCookie = logManger.login(username, userPassword, context.getInstance().getHosts().get("default"));
-		identityContextUrls = context.getContextUrls();
-		tenantInfo = context.getContextTenant();
-		userInfo = tenantInfo.getContextUser();
-		appMgtclient = new ApplicationManagementServiceClient(sessionCookie, backendURL, null);
-		adminClient = new OauthAdminClient(backendURL, sessionCookie);
-		remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
+        context = new AutomationContext("IDENTITY", userMode);
+        this.username = context.getContextTenant().getTenantAdmin().getUserName();
+        this.userPassword = context.getContextTenant().getTenantAdmin().getPassword();
+    }
 
-		setSystemproperties();
-		client = HttpClientBuilder.create().build();
-	}
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
 
-	@AfterClass(alwaysRun = true)
-	public void atEnd() throws Exception {
+        String backendURL = context.getContextUrls().getBackEndUrl();
+        loginLogoutClient = new LoginLogoutClient(context);
+        logManger = new AuthenticatorClient(backendURL);
+        identityContextUrls = context.getContextUrls();
+        tenantInfo = context.getContextTenant();
+        userInfo = tenantInfo.getContextUser();
 
-		appMgtclient.deleteApplication(SERVICE_PROVIDER_NAME);
-		adminClient.removeOAuthApplicationData(consumerKey);
-		client.close();
-		logManger = null;
-		consumerKey = null;
-		accessToken = null;
-	}
+        String sessionCookie = logManger.login(username, userPassword, context.getInstance().getHosts().get("default"));
+        appMgtclient = new ApplicationManagementServiceClient(sessionCookie, backendURL, null);
+        adminClient = new OauthAdminClient(backendURL, sessionCookie);
+        remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
 
-	@Test(groups = "wso2.is", description = "Check Oauth2 application registration")
-	public void testRegisterApplication() throws Exception {
+        setSystemproperties();
+        client = HttpClientBuilder.create().build();
+    }
 
-		OAuthConsumerAppDTO appDto = createApplication();
-		Assert.assertNotNull(appDto, "Application creation failed.");
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
 
-		consumerKey = appDto.getOauthConsumerKey();
-		Assert.assertNotNull(consumerKey, "Application creation failed.");
+        appMgtclient.deleteApplication(SERVICE_PROVIDER_NAME);
+        adminClient.removeOAuthApplicationData(consumerKey);
+        client.close();
+        logManger = null;
+        consumerKey = null;
+        accessToken = null;
+    }
 
-		consumerSecret = appDto.getOauthConsumerSecret();
-		Assert.assertNotNull(consumerSecret, "Application creation failed.");
+    @Test(groups = "wso2.is", description = "Check Oauth2 application registration")
+    public void testRegisterApplication() throws Exception {
 
-	}
+        OAuthConsumerAppDTO appDto = createApplication();
+        Assert.assertNotNull(appDto, "Application creation failed.");
 
-	@Test(groups = "wso2.is", description = "Send authorize user request", dependsOnMethods = "testRegisterApplication")
-	public void testSendAuthorozedPost() throws Exception {
-		List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
-		urlParameters.add(new BasicNameValuePair(
-		                                         "grantType",
-		                                         OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
-		urlParameters.add(new BasicNameValuePair("consumerKey", consumerKey));
-		urlParameters.add(new BasicNameValuePair("consumerSecret", consumerSecret));
-		urlParameters.add(new BasicNameValuePair("accessEndpoint",
-		                                         OAuth2Constant.ACCESS_TOKEN_ENDPOINT));
-		urlParameters.add(new BasicNameValuePair("authorize", OAuth2Constant.AUTHORIZE_PARAM));
-		HttpResponse response =
-		                        sendPostRequestWithParameters(client, urlParameters,
-		                                                      OAuth2Constant.AUTHORIZED_USER_URL);
-		Assert.assertNotNull(response, "Authorization request failed. Authorized response is null");
-		EntityUtils.consume(response.getEntity());
+        consumerKey = appDto.getOauthConsumerKey();
+        Assert.assertNotNull(consumerKey, "Application creation failed.");
 
-		response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
+        consumerSecret = appDto.getOauthConsumerSecret();
+        Assert.assertNotNull(consumerSecret, "Application creation failed.");
 
-		Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
-		keyPositionMap.put("name=\"accessToken\"", 1);
+    }
 
-		List<KeyValue> keyValues =
-		                           DataExtractUtil.extractInputValueFromResponse(response,
-		                                                                         keyPositionMap);
-		Assert.assertNotNull(keyValues, "Access token Key value is null.");
-		accessToken = keyValues.get(0).getValue();
+    @Test(groups = "wso2.is", description = "Send client credentials token request.", dependsOnMethods = "testRegisterApplication")
+    public void testGetTokenUsingClientCredentialsGrant() throws Exception {
 
-		EntityUtils.consume(response.getEntity());
-		Assert.assertNotNull(accessToken, "Access token is null.");
-	}
+        AuthorizationGrant clientCredentialsGrant = new ClientCredentialsGrant();
+        ClientID clientID = new ClientID(consumerKey);
+        Secret clientSecret = new Secret(consumerSecret);
+        ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
+        Scope scope = new Scope(OAuth2Constant.OAUTH2_SCOPE_OPENID, "xyz");
 
-	@Test(groups = "wso2.is", description = "Validate access token", dependsOnMethods = "testSendAuthorozedPost")
-	public void testValidateAccessToken() throws Exception {
+        URI tokenEndpoint = new URI(OAuth2Constant.ACCESS_TOKEN_ENDPOINT);
+        TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, clientCredentialsGrant, scope);
+        HTTPResponse tokenHTTPResp = request.toHTTPRequest().send();
+        Assert.assertNotNull(tokenHTTPResp, "Access token http response is null.");
 
-		String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
-				OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
-		org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
-				username, userPassword);
-		Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
-		Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
-	}
+        TokenResponse tokenResponse = TokenResponse.parse(tokenHTTPResp);
+        Assert.assertTrue(tokenResponse.indicatesSuccess(),
+                "Token response did not indicate success. Token request has failed.");
+
+        AccessTokenResponse accessTokenResponse = tokenResponse.toSuccessResponse();
+        Assert.assertNotNull(accessTokenResponse.getTokens().getAccessToken(), "Access Token is null in response.");
+
+        accessToken = accessTokenResponse.getTokens().getAccessToken().getValue();
+        Assert.assertNotNull(accessToken, "Access Token is null in the token response.");
+
+        Scope scopesInResponse = accessTokenResponse.getTokens().getAccessToken().getScope();
+        Assert.assertTrue(scopesInResponse.contains("xyz"), "Requested scope is missing in the token response");
+
+        // This ensures that openid scopes are not issued for client credential grant type.
+        Assert.assertFalse(accessTokenResponse instanceof OIDCTokenResponse, "Client credential grant type cannot " +
+                "get a OIDC Token Response.");
+        Assert.assertFalse(scopesInResponse.contains("openid"), "Client credentials cannot get openid scope.");
+    }
+
+    @Test(groups = "wso2.is", description = "Validate access token",
+            dependsOnMethods = "testGetTokenUsingClientCredentialsGrant")
+    public void testValidateAccessToken() throws Exception {
+
+        String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+                OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+        org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
+                username, userPassword);
+        Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
+        Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -51,6 +51,8 @@ import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
 import java.net.URI;
 
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_SCOPE_OPENID;
+
 /**
  * Tests for OAuth2 client credentials grant type.
  */
@@ -132,7 +134,7 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
         ClientID clientID = new ClientID(consumerKey);
         Secret clientSecret = new Secret(consumerSecret);
         ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
-        Scope scope = new Scope(OAuth2Constant.OAUTH2_SCOPE_OPENID, "xyz");
+        Scope scope = new Scope(OAUTH2_SCOPE_OPENID, "xyz");
 
         URI tokenEndpoint = new URI(OAuth2Constant.ACCESS_TOKEN_ENDPOINT);
         TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, clientCredentialsGrant, scope);
@@ -155,7 +157,7 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
         // This ensures that openid scopes are not issued for client credential grant type.
         Assert.assertFalse(accessTokenResponse instanceof OIDCTokenResponse, "Client credential grant type cannot " +
                 "get a OIDC Token Response.");
-        Assert.assertFalse(scopesInResponse.contains("openid"), "Client credentials cannot get openid scope.");
+        Assert.assertFalse(scopesInResponse.contains(OAUTH2_SCOPE_OPENID), "Client credentials cannot get openid scope.");
     }
 
     @Test(groups = "wso2.is", description = "Validate access token",


### PR DESCRIPTION
$subject + rewrite to test to use nimbusds SDK instead of oauth2 playground app