### PR TITLE
Bump carbon-consent-mgt version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2200,7 +2200,7 @@
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!--Carbon Consent Version-->
-        <carbon.consent.mgt.version>2.5.0</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.5.1</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
         <identity.governance.version>1.8.14</identity.governance.version>


### PR DESCRIPTION
### Purpose

This PR bumps the `carbon-consent-management` version to fix the Null Pointer Exception that occurs when invoking the List Consents endpoint [1] without the `piiPrincipalId` parameter. 

[1] https://docs.wso2.com/display/IS510/apidocs/Consent-management-apis/#!/operations#Consent#consentsGet

### Related Issue 
https://github.com/wso2/product-is/issues/15419

### Related PR
https://github.com/wso2/carbon-consent-management/pull/221