### PR TITLE
Add scripts to enable and disable FIPS compliance

### DIFF
--- a/modules/distribution/src/bin/fips.bat
+++ b/modules/distribution/src/bin/fips.bat
@@ -1,0 +1,122 @@
+@echo off
+rem ----------------------------------------------------------------------------
+rem Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+rem
+rem WSO2 LLC. licenses this file to you under the Apache License,
+rem Version 2.0 (the "License"); you may not use this file except
+rem in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing,
+rem software distributed under the License is distributed on an
+rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+rem KIND, either express or implied.  See the License for the
+rem specific language governing permissions and limitations
+rem under the License.
+
+set BC_FIPS_VERSION=1.0.2.3
+set BCPKIX_FIPS_VERSION=1.0.7
+set BCPROV_JDK15ON_VERSION=1.70.0.wso2v1
+set BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+echo  "%CARBON_HOME%"
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\version.txt" goto noServerHome
+
+set DISABLE=%1
+set bundles_info=%CARBON_HOME%\repository\components\default\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set bcprov_text=bcprov-jdk15on,%BCPKIX_JDK15ON_VERSION%,../plugins/bcprov-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar,4,true
+set bcpkix_text=bcpkix-jdk15on,%BCPROV_JDK15ON_VERSION%,../plugins/bcpkix-jdk15on_%BCPROV_JDK15ON_VERSION%.jar,4,true
+echo %bundles_info%
+
+rem commandline arguement 'DISABLE' or 'disable' is passed
+if "%DISABLE%"=="DISABLE" goto disableFipsMode
+if "%DISABLE%"=="disable" goto disableFipsMode
+rem no commandline arguements are passed
+goto enableFipsMode
+
+:disableFipsMode
+if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
+  echo Remove existing bc-fips_%BC_FIPS_VERSION% jar from lib folder.
+  DEL /F "%CARBON_HOME%\repository\components\lib\bc-fips*.jar"
+  echo Bc-fips jar Removed from components\lib.
+)
+if exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
+  echo Remove existing bcPKIX-fips_%BC_FIPS_VERSION% jar from lib folder.
+  DEL /F "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar"
+  echo Bcpkix-fips jar Removed from components\lib.
+)
+if exist "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar" (
+  echo Remove existing bc_fips_%BC_FIPS_VERSION% jar from dropins folder.
+  DEL /F "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar"
+  echo Bc-fips jar Removed from components\dropins.
+)
+if exist "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar" (
+  echo Remove existing bc_fips_%BC_FIPS_VERSION% jar from dropins folder.
+  DEL /F "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar"
+  echo Bc-fips jar Removed from components\dropins.
+)
+if not exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" (
+	echo Downloading required bcprov-jdk15on jar : bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%
+	curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/%BCPROV_JDK15ON_VERSION%/bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar -o %CARBON_HOME%/repository/components/plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar
+)
+if not exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" (
+	echo Downloading required bcpkix-jdk15on jar : bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%
+	curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/%BCPKIX_JDK15ON_VERSION%/bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar -o %CARBON_HOME%/repository/components/plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar
+)
+findstr /c:%bcprov_text% %bundles_info% > nul
+if %errorlevel%==1 (
+    echo %bcprov_text% >>  %bundles_info%
+)
+findstr /c:%bcpkix_text% %bundles_info% > nul
+if %errorlevel%==1 (
+    echo %bcpkix_text% >>  %bundles_info%
+)
+goto printRestartMsg
+
+: enableFipsMode
+
+if exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*" (
+  echo Remove existing bcprov-jdk15on jar from plugins folder.
+  DEL /F "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*"
+  echo bcprov-jdk15on jar Removed from components\plugins.
+)
+if exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*" (
+  echo Remove existing bcpkix-jdk15on jar from plugins folder.
+  DEL /F "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*"
+  echo bcpkix-jdk15on jar Removed from components\plugins.
+)
+if not exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
+	echo Downloading required bc-fips jar : bc-fips-%BC_FIPS_VERSION%
+	curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/%BC_FIPS_VERSION%/bc-fips-%BC_FIPS_VERSION%.jar -o %CARBON_HOME%/repository/components/lib/bc-fips-%BC_FIPS_VERSION%.jar
+)
+if not exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
+	echo Downloading required bcpkix-fips jar : bcpkix-fips-%BCPKIX_FIPS_VERSION%
+	curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/%BCPKIX_FIPS_VERSION%/bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar -o %CARBON_HOME%/repository/components/lib/bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar
+)
+set temp_file=%CARBON_HOME%\repository\components\default\configuration\org.eclipse.equinox.simpleconfigurator\temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% !bundles_info! > !temp_file!
+move /y !temp_file! !bundles_info!
+goto printRestartMsg
+
+:printRestartMsg
+echo Please restart the server.
+goto end
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:end
+endlocal

--- a/modules/distribution/src/bin/fips.bat
+++ b/modules/distribution/src/bin/fips.bat
@@ -1,5 +1,3 @@
-
-
 @echo off
 rem ----------------------------------------------------------------------------
 rem Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
@@ -20,11 +18,7 @@ rem under the License.
 
 set BC_FIPS_VERSION=1.0.2.3
 set BCPKIX_FIPS_VERSION=1.0.7
-set BCPROV_JDK15ON_VERSION=1.70.0.wso2v1
-set BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1
 
-set EXPECTED_BCPROV_CHECKSUM=261f41c52b6a664a5e9011ba829e78eb314c0ed8
-set EXPECTED_BCPKIX_CHECKSUM=17db4aba24861e306427bdeff03b1c2fac57760f
 set EXPECTED_BC_FIPS_CHECKSUM=da62b32cb72591f5b4d322e6ab0ce7de3247b534
 set EXPECTED_BCPKIX_FIPS_CHECKSUM=fe07959721cfa2156be9722ba20fdfee2b5441b0
 
@@ -43,8 +37,6 @@ if not exist "%CARBON_HOME%\bin\version.txt" goto noServerHome
 
 set ARGUEMENT=%1
 set bundles_info=%CARBON_HOME%\repository\components\default\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
-set bcprov_text=bcprov-jdk15on,%BCPROV_JDK15ON_VERSION%,../plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar,4,true
-set bcpkix_text=bcpkix-jdk15on,%BCPKIX_JDK15ON_VERSION%,../plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar,4,true
 set "homeDir=%userprofile%"
 set server_restart_required=false
 
@@ -61,13 +53,13 @@ if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
     set server_restart_required=true
     echo Remove existing bc-fips jar from lib folder.
     DEL /F "%CARBON_HOME%\repository\components\lib\bc-fips*.jar"
-    echo Successfully removed bc-fips__%BC_FIPS_VERSION%.jar from components\lib.
+    echo Successfully removed bc-fips_%BC_FIPS_VERSION%.jar from components\lib.
 )
 if exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
     set server_restart_required=true
     echo Remove existing bcpkix-fips jar from lib folder.
     DEL /F "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar"
-    echo Successfully removed bcpkix-fips_%BC_FIPS_VERSION%.jar from components\lib.
+    echo Successfully removed bcpkix-fips_%BCPKIX_FIPS_VERSION%.jar from components\lib.
 )
 if exist "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar" (
     set server_restart_required=true
@@ -81,38 +73,44 @@ if exist "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar" (
     DEL /F "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar"
     echo Successfully removed bcpkix-fips_%BCPKIX_FIPS_VERSION%.jar from components\dropins.
 )
+
 if not exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" (
     set server_restart_required=true
-    if exist "%homeDir%\.wso2-bc\backup\bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar" (
-        move "%homeDir%\.wso2-bc\backup\bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar" "%CARBON_HOME%\repository\components\plugins"
-        echo Moved bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar from %homeDir%\.wso2-bc\backup to components/plugins.
-    ) else (
-        echo Downloading required bcprov-jdk15on jar : bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%
-	    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/%BCPROV_JDK15ON_VERSION%/bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar -o %CARBON_HOME%/repository/components/plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar
-        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%/repository/components/plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BCPROVE=%%G"
-        if "%ACTUAL_CHECKSUM_BCPROVE%"=="%EXPECTED_BCPROV_CHECKSUM%" (
-            echo Checksum verified: The downloaded bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar is valid.
-        ) else (
-            echo Checksum verification failed: The downloaded bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar may be corrupted.
-        )
+    if exist "%homeDir%\.wso2-bc\backup\bcprov-jdk15on*.jar" (
+        for /r %homeDir%\.wso2-bc\backup\ %%G in (bcprov-jdk15on*.jar) do (
+        set bcprov_location=%%G
+        set file_name=%%~nG
+	    goto checkbcprovVersion
     )
+    :checkbcprovVersion
+    for /f "tokens=2 delims=_" %%v in ("%bcprov_file_name%") do set "bcprov_version=%%v"
+    goto bbb
+
+    :bbb
+    move "%bcprov_location%" "%CARBON_HOME%\repository\components\plugins"
+    echo Moved %bcprov_file_name% from %homeDir%\.wso2-bc\backup to components/plugins.
+    ) else ( echo "Required bcprov-jdk15on jar is not available in %homeDir%/.wso2-bc/backup. Download the jar from maven central repository." )
 )
+
 if not exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" (
     set server_restart_required=true
-    if exist "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar" (
-        move "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar" "%CARBON_HOME%\repository\components\plugins"
-        echo Moved bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar from %homeDir%\.wso2-bc\backup to components/plugins.
-    ) else (
-	    echo Downloading required bcpkix-jdk15on jar : bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%
-	    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/%BCPKIX_JDK15ON_VERSION%/bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar -o %CARBON_HOME%/repository/components/plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar
-        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%/repository/components/plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BCPKIX=%%G"
-        if "%ACTUAL_CHECKSUM_BCPKIX%"=="%EXPECTED_BCPKIX_CHECKSUM%" (
-            echo Checksum verified: The downloaded bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar is valid.
-        ) else (
-            echo Checksum verification failed: The downloaded bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar may be corrupted.
+    if exist "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on*.jar" (
+        for /r %homeDir%\.wso2-bc\backup\ %%G in (bcpkix-jdk15on*.jar) do (
+        set bcpkix_location=%%G
+        set bcpkix_file_name=%%~nG
+        set verify=false
+	    goto foundBcPkix1
         )
-    )
+    :foundBcPkix1
+    for /f "tokens=2 delims=_" %%v in ("%bcpkix_file_name%") do set "bcpkix_version=%%v"
+    goto bbb
+
+    :bbb
+    move "%bcpkix_location%" "%CARBON_HOME%\repository\components\plugins"
+    echo Moved %bcpkix_file_name% from %homeDir%\.wso2-bc\backup to components/plugins.
+    ) else ( echo "Required bcpkix-jdk15on jar is not available in %homeDir%/.wso2-bc/backup. Download the jar from maven central repository." )
 )
+
 findstr /c:%bcprov_text% %bundles_info% > nul
 if %errorlevel%==1 (
     set server_restart_required=true
@@ -125,7 +123,7 @@ if %errorlevel%==1 (
 )
 goto printRestartMsg
 
-: enableFipsMode
+:enableFipsMode
 set arg1=
 set arg2=
 :parse_args
@@ -142,28 +140,45 @@ if not exist "%homeDir%\.wso2-bc" (
 if not exist "%homeDir%\.wso2-bc\backup" (
     mkdir "%homeDir%\.wso2-bc\backup"
 )
-if exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*" (
-    set server_restart_required=true
-    echo Remove existing bcprov-jdk15on jar from plugins folder.
-    for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on_*.jar"') do (
-        set bcprov_location=%%a
-        goto check_bcprov_location
-    )
-   :check_bcprov_location
-    move "%bcprov_location%" "%homeDir%\.wso2-bc\backup"
-    echo Successfully removed bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar from components\plugins.
-)
-if exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*" (
-    set server_restart_required=true
-    echo Remove existing bcpkix-jdk15on jar from plugins folder.
-    for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on_*.jar"') do (
-        set bcpkix_location=%%a
-        goto check_bcpkix_location
 
+if exist %CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar (
+    set server_restart_required=true
+    for /r %CARBON_HOME%\repository\components\plugins\ %%G in (bcprov-jdk15on*.jar) do (
+        set bcprov_location=%%G
+        set bcprov_file_name=%%~nG
+	goto checkBcVersion
     )
-   :check_bcpkix_location
+    :checkBcVersion
+    for /f "tokens=2 delims=_" %%v in ("%bcprov_file_name%") do set "bcprov_version=%%v"
+    goto removeBcProv
+
+    :removeBcProv
+    echo Remove existing bcprov-jdk15on jar from plugins folder.
+    if exist "%homeDir%\.wso2-bc\backup\bcprov-jdk15on*.jar" (
+        DEL /F "%homeDir%\.wso2-bc\backup\bcprov-jdk15on*.jar"
+    )
+    move "%bcprov_location%" "%homeDir%\.wso2-bc\backup"
+    echo Successfully removed %bcprov_file_name% from components\plugins.
+)
+
+if exist %CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar (
+    set server_restart_required=true
+    for /r %CARBON_HOME%\repository\components\plugins\ %%G in (bcpkix-jdk15on*.jar) do (
+        set bcpkix_location=%%G
+        set bcpkix_file_name=%%~nG
+	goto checkBcpkixVersion
+    )
+    :checkBcpkixVersion
+    for /f "tokens=2 delims=_" %%v in ("%bcpkix_file_name%") do set "bcpkix_version=%%v"
+    goto removeBcPkix
+
+    :removeBcPkix
+   	echo Remove existing bcpkix-jdk15on jar from plugins folder.
+   	if exist "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on*.jar" (
+        DEL /F "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on*.jar"
+    )
     move "%bcpkix_location%" "%homeDir%\.wso2-bc\backup"
-    echo Successfully removed bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar Removed from components\plugins.
+    echo Successfully removed %bcpkix_file_name% from components\plugins.
 )
 if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
     for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\lib\bc-fips*.jar"') do (
@@ -278,6 +293,9 @@ if not exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
         )
     )
 )
+set bcprov_text=bcprov-jdk15on,%bcprov_version%,../plugins/bcprov-jdk15on_%bcprov_version%.jar,4,true
+set bcpkix_text=bcpkix-jdk15on,%bcpkix_version%,../plugins/bcpkix-jdk15on_%bcpkix_version%.jar,4,true
+
 set temp_file=%CARBON_HOME%\repository\components\default\configuration\org.eclipse.equinox.simpleconfigurator\temp.info
 findstr /v /c:%bcprov_text% /c:%bcpkix_text% %bundles_info% > !temp_file!
 move /y !temp_file! %bundles_info% > nul
@@ -285,30 +303,28 @@ goto printRestartMsg
 
 :verifyFipsMode
 set verify=true
-if exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" (
-	set location=
-	for /f "delims=" %%i in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" ^| findstr /i /c:".jar"') do (
-		set "location=%%i"
-		goto :verifyBcFipsLocation
-	)
-	:verifyBcFipsLocation
-	if not "%location%"=="" (
-		set verify=false
-		echo Found bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar in plugins folder. This jar should be removed.
-	)
+if exist %CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar (
+    for /r %CARBON_HOME%\repository\components\plugins\ %%G in (bcprov-jdk15on*.jar) do (
+        set bc_location=%%G
+        set file_name=%%~nG
+        set verify=false
+	goto foundBcProv
+    )
+    :foundBcProv
+    echo Found %file_name% in plugins folder. This jar should be removed.
 )
-if exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" (
-	set location=
-	for /f "delims=" %%i in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" ^| findstr /i /c:".jar"') do (
-		set "location=%%i"
-		goto :verifyBcPkixFipsLocation
-	)
-	:verifyBcPkixFipsLocation
-	if not "%location%"=="" (
-		set verify=false
-		echo Found bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar in plugins folder. This jar should be removed.
-	)
+
+if exist %CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar (
+    for /r %CARBON_HOME%\repository\components\plugins\ %%G in (bcpkix-jdk15on*.jar) do (
+        set bcpkix_location=%%G
+        set file_name=%%~nG
+        set verify=false
+	goto foundBcPkix
+    )
+    :foundBcPkix
+    echo Found %file_name% in plugins folder. This jar should be removed.
 )
+
 if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
 	if not exist "%CARBON_HOME%\repository\components\lib\bc-fips-%BC_FIPS_VERSION%.jar" (
 		set verify=false
@@ -329,16 +345,16 @@ if exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
     echo can not be found bc-fips_%BC_FIPS_VERSION%.jar in components/lib folder. This jar should be added.
 )
 
-findstr /i /c:"%bcprov_text%" "%bundles_info%" >nul
+findstr /i /c:"bcprov-jdk15on" "%bundles_info%" >nul
 if %errorlevel%==0 (
 	set verify=false
-	echo Found text "%bcprov_text%" in bundles.info. This should be removed.
+  	echo Found bcprov-jdk15on entry in bundles.info. This should be removed.
 )
 
-findstr /i /c:"%bcpkix_text%" "%bundles_info%" >nul
+findstr /i /c:"bcpkix-jdk15on" "%bundles_info%" >nul
 if %errorlevel%==0 (
 	set verify=false
-	echo Found text "%bcpkix_text%" in bundles.info. This should be removed.
+  	echo Found bcpkix-jdk15on entry in bundles.info. This should be removed.
 )
 if "%verify%"=="true" (
 	echo Verified : Product is FIPS compliant.

--- a/modules/distribution/src/bin/fips.sh
+++ b/modules/distribution/src/bin/fips.sh
@@ -1,0 +1,97 @@
+#! /bin/bash
+# ----------------------------------------------------------------------------
+#  Copyright 2023 WSO2, LLC. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+BC_FIPS_VERSION=1.0.2.3;
+BCPKIX_FIPS_VERSION=1.0.7;
+BCPROV_JDK15ON_VERSION=1.70.0.wso2v1;
+BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1;
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+echo $CARBON_HOME
+
+DISABLE=$1;
+bundles_info="$CARBON_HOME/repository/components/default/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+
+if [ "$DISABLE" = "DISABLE" ] || [ "$DISABLE" = "disable" ]; then
+	if [ ! -e $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+		echo "Downloading required bcprov-jdk15on jar : bcprov-jdk15on-$BCPROV_JDK15ON_VERSION"
+		curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/$BCPROV_JDK15ON_VERSION/bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar
+	fi
+	if [ ! -e $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
+		echo "Downloading required bcpkix-jdk15on jar : bcprov-jdk15on-$BCPKIX_JDK15ON_VERSION"
+		curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/$BCPKIX_JDK15ON_VERSION/bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar
+	fi
+	bcprov_text="bcprov-jdk15on1,$BCPKIX_JDK15ON_VERSION,../plugins/bcprov-jdk15on_$BCPKIX_JDK15ON_VERSION.jar,4,true";
+	bcpkix_text="bcpkix-jdk15on1,$BCPROV_JDK15ON_VERSION,../plugins/bcpkix-jdk15on_$BCPROV_JDK15ON_VERSION.jar,4,true";
+	if ! grep -q "$bcprov_text" "$bundles_info" ; then
+		echo  $bcprov_text >> $bundles_info;
+	fi
+	if ! grep -q "$bcpkix_text" "$bundles_info" ; then
+		echo  $bcpkix_text >> $bundles_info;
+	fi
+	if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+   		echo "Remove existing bc-fips_$BC_FIPS_VERSION jar from lib folder."
+   		rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
+		echo "bc-fips_$BC_FIPS_VERSION Removed from component/plugin."
+   	fi
+   	if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+   		echo "Remove existing bcpkix-fips_$BCPKIX_JDK15ON_VERSION jar from lib folder."
+   		rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
+   		echo "bcpkix-fips_$BCPKIX_JDK15ON_VERSION Removed from component/lib."
+   	fi
+   	if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
+   		echo "Remove existing bc-fips_$BC_FIPS_VERSION jar from dropins folder."
+   		rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
+   		echo "bc-fips_$BC_FIPS_VERSION Removed from component/plugin."
+   	fi
+   	if [ -f $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar ]; then
+   		echo "Remove existing bcpkix_fips_$BCPKIX_JDK15ON_VERSION jar from dropins folder."
+   		rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
+		echo "bcpkix_fips_$BCPKIX_JDK15ON_VERSION Removed from component/dropins."
+   	fi
+
+else
+	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+   		echo "Remove existing bcprov-jdk15on_$BCPROV_JDK15ON_VERSION jar from plugins folder."
+   		rm rm $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar 2> /dev/null
+   		echo "bcprov-jdk15on Removed from component/plugin."
+	fi
+	if [ -f $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
+   		echo "Remove existing bcpkix-jdk15on_BCPKIX_JDK15ON_VERSION jar from plugins folder."
+   		rm rm $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar 2> /dev/null
+   		echo "bcpkix-jdk15on Removed from component/plugin."
+	fi
+
+	sed -i '/bcprov-jdk15on/d' $CARBON_HOME/repository/components/default/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info
+	sed -i '/bcpkix-jdk15on/d' $CARBON_HOME/repository/components/default/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info
+
+	if [ ! -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+		echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
+		curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
+	fi
+
+	if [ ! -e $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+		echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
+		curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
+	fi
+
+fi
+
+echo "Please restart the server."

--- a/modules/distribution/src/bin/fips.sh
+++ b/modules/distribution/src/bin/fips.sh
@@ -16,11 +16,7 @@
 
 BC_FIPS_VERSION=1.0.2.3;
 BCPKIX_FIPS_VERSION=1.0.7;
-BCPROV_JDK15ON_VERSION=1.70.0.wso2v1;
-BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1;
 
-EXPECTED_BCPROV_CHECKSUM="261f41c52b6a664a5e9011ba829e78eb314c0ed8"
-EXPECTED_BCPKIX_CHECKSUM="17db4aba24861e306427bdeff03b1c2fac57760f"
 EXPECTED_BC_FIPS_CHECKSUM="da62b32cb72591f5b4d322e6ab0ce7de3247b534"
 EXPECTED_BCPKIX_FIPS_CHECKSUM="fe07959721cfa2156be9722ba20fdfee2b5441b0"
 
@@ -32,8 +28,6 @@ PRGDIR=`dirname "$PRG"`
 
 ARGUMENT=$1;
 bundles_info="$CARBON_HOME/repository/components/default/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
-bcprov_text="bcprov-jdk15on1,$BCPKIX_JDK15ON_VERSION,../plugins/bcprov-jdk15on_$BCPKIX_JDK15ON_VERSION.jar,4,true";
-bcpkix_text="bcpkix-jdk15on1,$BCPROV_JDK15ON_VERSION,../plugins/bcpkix-jdk15on_$BCPROV_JDK15ON_VERSION.jar,4,true";
 homeDir="$HOME"
 sever_restart_required=false
 
@@ -42,13 +36,13 @@ if [ "$ARGUMENT" = "DISABLE" ] || [ "$ARGUMENT" = "disable" ]; then
 	    sever_restart_required=true
    		echo "Remove existing bc-fips jar from lib folder."
    		rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
-		echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar Removed from component/lib."
+		echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/lib."
    	fi
    	if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
    	    sever_restart_required=true
    		echo "Remove existing bcpkix-fips jar from lib folder."
    		rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
-   		echo "Successfully removed bcpkix-fips_$BCPKIX_JDK15ON_VERSION.jar  from component/lib."
+   		echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar  from component/lib."
    	fi
    	if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
    	    sever_restart_required=true
@@ -60,42 +54,37 @@ if [ "$ARGUMENT" = "DISABLE" ] || [ "$ARGUMENT" = "disable" ]; then
    	    sever_restart_required=true
    		echo "Remove existing bcpkix_fips jar from dropins folder."
    		rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
-		echo "Successfully removed bcpkix_fips_$BCPKIX_JDK15ON_VERSION.jar from component/dropins."
+		echo "Successfully removed bcpkix_fips_$BCPKIX_FIPS_VERSION.jar from component/dropins."
    	fi
 	if [ ! -e $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 	    sever_restart_required=true
-	    if [ -f "$homeDir/.wso2-bc/backup/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar" ]; then
-		    mv "$homeDir/.wso2-bc/backup/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar" "$CARBON_HOME/repository/components/plugins"
-		    echo "Moved bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar from $homeDir/.wso2-bc/backup to components/plugins"
+	    if [ -e $homeDir/.wso2-bc/backup/bcprov-jdk15on*.jar ]; then
+	      location=$(find "$homeDir/.wso2-bc/backup/" -type f -name "bcprov-jdk15on*.jar" | head -1)
+        bcprov_file_name=$(basename "$location")
+        bcprov_version=${bcprov_file_name#*_}
+        bcprov_version=${bcprov_version%.jar}
+		    mv "$location" "$CARBON_HOME/repository/components/plugins"
+		    echo "Moved $bcprov_file_name from $homeDir/.wso2-bc/backup to components/plugins."
 	    else
-		    echo "Downloading required bcprov-jdk15on jar : bcprov-jdk15on-$BCPROV_JDK15ON_VERSION"
-		    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/$BCPROV_JDK15ON_VERSION/bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar
-	        ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar | cut -d' ' -f1)
-	        if [ "$EXPECTED_BCPROV_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		        echo "Checksum verified: The downloaded bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar is valid."
-	        else
-  		        echo "Checksum verification failed: The downloaded bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar may be corrupted."
-	        fi
+		    echo "Required bcprov-jdk15on jar is not available in $homeDir/.wso2-bc/backup. Download the jar from maven central repository."
 	    fi
 	fi
 	if [ ! -e $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
 	    sever_restart_required=true
-	    if [ -f "$homeDir/.wso2-bc/backup/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar" ]; then
-		    mv "$homeDir/.wso2-bc/backup/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar" "$CARBON_HOME/repository/components/plugins"
-		    echo "Moved bcpkix-jdk15on_$BCKIX_JDK15ON_VERSION.jar from $homeDir/.wso2-bc/backup to components/plugins"
-
+	    if [ -e $homeDir/.wso2-bc/backup/bcpkix-jdk15on*.jar ]; then
+	      location=$(find "$homeDir/.wso2-bc/backup/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+        bcpkix_file_name=$(basename "$location")
+        bcpkix_version=${bcpkix_file_name#*_}
+        bcpkix_version=${bcpkix_version%.jar}
+		    mv "$location" "$CARBON_HOME/repository/components/plugins"
+		    echo "Moved $bcpkix_file_name from $homeDir/.wso2-bc/backup to components/plugins."
 	    else
-		    echo "Downloading required bcpkix-jdk15on jar : bcplix-jdk15on-$BCPKIX_JDK15ON_VERSION"
-		    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/$BCPKIX_JDK15ON_VERSION/bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar
-	        ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar | cut -d' ' -f1)
-	        if [ "$EXPECTED_BCPKIX_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		        echo "Checksum verified: The downloaded bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar is valid."
-	        else
-  		        echo "Checksum verification failed: The downloaded bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar may be corrupted."
-	        fi
+		    echo "Required bcpkix-jdk15on jar is not available in $homeDir/.wso2-bc/backup. Download the jar from maven central repository."
 	    fi
 	fi
 
+  bcprov_text="bcprov-jdk15on,$bcprov_version,../plugins/$bcprov_file_name,4,true";
+  bcpkix_text="bcpkix-jdk15on,$bcpkix_version,../plugins/$bcpkix_file_name,4,true";
 	if ! grep -q "$bcprov_text" "$bundles_info" ; then
 		echo  $bcprov_text >> $bundles_info;
 		sever_restart_required=true
@@ -109,13 +98,15 @@ elif [ "$ARGUMENT" = "VERIFY" ] || [ "$ARGUMENT" = "verify" ]; then
 	verify=true;
 	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcprov-jdk15on*.jar" | head -1)
+		file_name=$(basename "$location")
 		verify=false
-		echo "Found bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar in plugins folder. This jar should be removed."
+		echo "Found $file_name in plugins folder. This jar should be removed."
 	fi
 	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+		file_name=$(basename "$location")
 		verify=false
-		echo "Found bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar in plugins folder. This jar should be removed."
+		echo "Found $file_name in plugins folder. This jar should be removed."
 	fi
 	if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
 	    if [ ! -f $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar ]; then
@@ -137,15 +128,15 @@ elif [ "$ARGUMENT" = "VERIFY" ] || [ "$ARGUMENT" = "verify" ]; then
 		echo "Can not be found bcpkix-fips_$BCPKIX_FIPS_VERSION.jar in components/lib folder. This jar should be added."
 
 	fi
-	if grep -q "$bcprov_text" "$bundles_info" ; then
-		verify=false
-		echo  "Found $bcprov_text in bundles.info. This should be removed";
+	if grep -q "bcprov-jdk15on" "$bundles_info" ; then
+    verify=false
+  	echo  "Found bcprov-jdk15on entry in bundles.info. This should be removed.";
 
-	fi
-	if grep -q "$bcpkix_text" "$bundles_info" ; then
-		verify=false
-		echo  "Found $bcpkix_text in bundles.info. This should be removed";
-	fi
+  	fi
+  	if grep -q "bcpkix-jdk15on" "$bundles_info" ; then
+  		verify=false
+  		echo  "Found bcpkix-jdk15on entry in bundles.info. This should be removed.";
+  	fi
 
 	if [ $verify = true ]; then
 		echo "Verified : Product is FIPS compliant."
@@ -159,7 +150,7 @@ while getopts "f:m:" opt; do
     		arg1=$OPTARG
       		;;
     	m)
-      		arg2=$OPTARG
+      	arg2=$OPTARG
       		;;
     	\?)
       	echo "Invalid option: -$OPTARG" >&2
@@ -167,9 +158,6 @@ while getopts "f:m:" opt; do
       	;;
   	esac
 	done
-	echo "arg1: $arg1"
-	echo "arg2: $arg2"
-
 
 	if [ ! -d "$homeDir/.wso2-bc" ]; then
     		mkdir "$homeDir/.wso2-bc"
@@ -180,23 +168,33 @@ while getopts "f:m:" opt; do
 	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 	    sever_restart_required=true
 	    location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcprov-jdk15on*.jar" | head -1)
-	    echo "Remove existing bcpkix-jdk15on jar from plugins folder."
+	    echo "Remove existing bcprov-jdk15on jar from plugins folder."
+	    if [ -f $homeDir/.wso2-bc/backup/bcprov-jdk15on*.jar ]; then
+	      rm $homeDir/.wso2-bc/backup/bcprov-jdk15on*.jar
+	    fi
 	    mv "$location" "$homeDir/.wso2-bc/backup"
-   	    echo "Successfully removed bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar from component/plugins."
+	    bcprov_file_name=$(basename "$location")
+	    bcprov_version=${file_name#*_}
+      bcprov_version=${bcprov_version%.jar}
+   	  echo "Successfully removed $bcprov_file_name from component/plugins."
 	fi
 	if [ -f $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
 	   	sever_restart_required=true
    		echo "Remove existing bcpkix-jdk15on jar from plugins folder."
    		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+   		if [ -f $homeDir/.wso2-bc/backup/bcpkix-jdk15on*.jar ]; then
+        rm $homeDir/.wso2-bc/backup/bcpkix-jdk15on*.jar
+      fi
    		mv "$location" "$homeDir/.wso2-bc/backup"
-   		echo "Successfully removed bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar from component/plugins."
+   		bcpkix_file_name=$(basename "$location")
+   		echo "Successfully removed $bcpkix_file_name from component/plugins."
 	fi
 
-	if grep -q "$bcprov_text" "$bundles_info"; then
+	if grep -q "bcprov-jdk15on" "$bundles_info"; then
 		sever_restart_required=true
 		sed -i '/bcprov-jdk15on/d' $bundles_info
 	fi
-	if grep -q "$bcpkix_text" "$bundles_info"; then
+	if grep -q "bcpkix-jdk15on" "$bundles_info"; then
 		sever_restart_required=true
 		sed -i '/bcpkix-jdk15on/d' $bundles_info
 	fi
@@ -220,7 +218,6 @@ while getopts "f:m:" opt; do
 	if [ ! -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
 		sever_restart_required=true
 		if [ -z "$arg1" ] && [ -z "$arg2" ]; then
-		    echo "both empty"
 		    echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
 		    curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
 		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
@@ -242,7 +239,6 @@ while getopts "f:m:" opt; do
 			    fi
 			fi
 		else
-		    echo "1 empty"
 		    echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
 		    curl $arg2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
 		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
@@ -260,7 +256,7 @@ while getopts "f:m:" opt; do
 		    sever_restart_required=true
    	    	echo "There is an update for bcpkix-fips. Therefore Remove existing bcpkix-fips jar from lib folder."
    		    rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
-		    echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar Removed from component/lib."
+		    echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar from component/lib."
 		    if [ -f $CARBON_HOME/repository/components/dropins/bcpkix-fips*.jar ]; then
    		        echo "Remove existing bcpkix-fips jar from dropins folder."
    		        rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
@@ -281,7 +277,6 @@ while getopts "f:m:" opt; do
   			    echo "Checksum verification failed: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar may be corrupted."
 	    	fi
 	    elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
-	   	    echo "2 empty"
 	   	    if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
 	   	    	echo "Can not be found required bcpkix-fips-$BCPKIX_FIPS_VERSION.jar in given file path : $arg1."
 	   	    else
@@ -293,7 +288,6 @@ while getopts "f:m:" opt; do
 			    fi
 		    fi
 		else
-			echo "1 empty"
 			echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
 		    curl $arg2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
 			ACTUAL_CHECKSUM=$(sha1sucam $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)


### PR DESCRIPTION
$subject

Related issue - https://github.com/wso2/product-is/issues/15428

**To enable fips compliant  mode need to  proceed with following instructions.**
1.Stop the server if running
2.Run fips.sh (fips.bat for Windows) (eg: sh fips.sh)
3.Add the following config to the deployment.toml file.
```
[jce_provider]
provider_name = "BCFIPS" 
```
4.Restart the server

**To disable fips compliance mode need to proceed with following instructions.**
1.Stop the server if running
2.Run fips.sh (fips.bat for Windows) with DISABLE parameter (eg: sh fips.sh DISABLE)
3. Remove the config from the deployment.toml or change the config as follows.
``` 
[jce_provider]
provider_name = "BC" 
```
4.Restart the server

**Script supports the following functionalities**

1. Running script without parameters : **sh fips.sh**
    From this we can make the product pack fips compliant. This has 3 types.
            
            1.1. Without arguments : sh fips.sh
             bc-fips and bcpkix-fips jars will be downloaded from the public maven repository.

            1.2. With -f argument : sh fips.sh -f file_path_to_fips_jars
            Users can give the local folder path with bc-fips and bcpkix-fips jars. Then the script get the jars from the given paths.
 
            1.3. With -f argument : sh fips.sh -m base_path_to_local_maven
            Users can give the base path of their local maven repositories to download the bc-fips and bcpkix-fips jars. Then the script download the jars from following paths
             - $file_path_to_fips_jars/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
             - $file_path_to_fips_jars/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar

2. Running script with  **VERIFY** parameters : **sh fips.sh VERIFY**
    Using the verify parameter we can check that whether the product pack is fips compliant or not.
3. Running script with  **DISABLE** parameters : **sh fips.sh DISABLE**
    Using the disable parameter we can check that disable the fips compliant mode.





