### PR TITLE
Bump carbon identity framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2197,7 +2197,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.115</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.118</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Bumping the carbon-identity-framework version.

Related PR:
- https://github.com/wso2/carbon-identity-framework/pull/4430