### PR TITLE
Remove carbon ui dependency from server features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2334,7 +2334,7 @@
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.20</carbon.deployment.version>
         <carbon.commons.version>4.10.0</carbon.commons.version>
-        <carbon.registry.version>4.8.12</carbon.registry.version>
+        <carbon.registry.version>4.8.14</carbon.registry.version>
         <carbon.multitenancy.version>4.11.0</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.business-process.version>4.5.60</carbon.business-process.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2197,7 +2197,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.118</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.120</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2214,12 +2214,12 @@
         <identity.carbon.auth.saml2.version>5.8.4</identity.carbon.auth.saml2.version>
         <identity.carbon.auth.mutual.ssl.version>5.5.0</identity.carbon.auth.mutual.ssl.version>
         <identity.carbon.auth.iwa.version>5.5.0</identity.carbon.auth.iwa.version>
-        <identity.carbon.auth.rest.version>1.8.12</identity.carbon.auth.rest.version>
+        <identity.carbon.auth.rest.version>1.8.13</identity.carbon.auth.rest.version>
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.saml.version>5.11.6</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.11.31</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.saml.version>5.11.7</identity.inbound.auth.saml.version>
+        <identity.inbound.auth.oauth.version>6.11.32</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.9.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.10.4</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.2</identity.inbound.provisioning.scim.version>
@@ -2239,9 +2239,9 @@
         <identity.userstore.remote.version>5.2.5</identity.userstore.remote.version>
 
         <!-- Identity Data Publisher Versions -->
-        <identity.data.publisher.authentication.version>5.6.3</identity.data.publisher.authentication.version>
-        <identity.data.publisher.oauth.version>1.6.3</identity.data.publisher.oauth.version>
-        <identity.data.publisher.audit.version>1.4.1</identity.data.publisher.audit.version>
+        <identity.data.publisher.authentication.version>5.6.4</identity.data.publisher.authentication.version>
+        <identity.data.publisher.oauth.version>1.6.4</identity.data.publisher.oauth.version>
+        <identity.data.publisher.audit.version>1.4.2</identity.data.publisher.audit.version>
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.8.7</identity.event.handler.account.lock.version>
@@ -2288,7 +2288,7 @@
         <identity.oauth2.jwt.bearer.grant.version>2.2.0</identity.oauth2.jwt.bearer.grant.version>
 
         <!--SAML Metadata-->
-        <identity.metadata.saml.version>1.7.2</identity.metadata.saml.version>
+        <identity.metadata.saml.version>1.7.3</identity.metadata.saml.version>
 
         <!-- Connector Versions -->
         <authenticator.totp.version>3.3.6</authenticator.totp.version>


### PR DESCRIPTION
### About this PR
Remove identity.core.ui.feature dependency
From following repos
- identity-inbound-auth-oauth
- identity-data-publisher-audit
- identity-data-publisher-oauth
- identity-data-publisher-authentication
- identity-metadata-saml2
- identity-carbon-auth-rest
- identity-inbound-auth-saml

Remove identity.registry.core.ui.feature dependency from carbon-registry repo

### Related PRS
- https://github.com/wso2/carbon-identity-framework/pull/4462
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2019
- https://github.com/wso2-extensions/identity-data-publisher-audit/pull/28
- https://github.com/wso2-extensions/identity-data-publisher-oauth/pull/98
- https://github.com/wso2-extensions/identity-data-publisher-authentication/pull/113
- https://github.com/wso2-extensions/identity-metadata-saml2/pull/83 
- https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/231
- https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/389 