### PR TITLE
Bump carbon registry version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2334,7 +2334,7 @@
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.20</carbon.deployment.version>
         <carbon.commons.version>4.10.0</carbon.commons.version>
-        <carbon.registry.version>4.8.14</carbon.registry.version>
+        <carbon.registry.version>4.8.15</carbon.registry.version>
         <carbon.multitenancy.version>4.11.0</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.business-process.version>4.5.60</carbon.business-process.version>


### PR DESCRIPTION
**Purpose**

This PR bumps carbon-registry version to include the UI permission check added to the Registry > Search page in the management console application.

**Related PRs**
- https://github.com/wso2/carbon-registry/pull/407