### PR TITLE
Add integration tests for user-registrants retrieval endpoint

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementUserRegistrantSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementUserRegistrantSuccessTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1;
+
+import io.restassured.response.Response;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.assertNotBlank;
+import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.extractApplicationIdFromLocationHeader;
+
+import java.io.IOException;
+
+/**
+ * Test class for Application Management User Registrant Success Test.
+ */
+public class ApplicationManagementUserRegistrantSuccessTest extends ApplicationManagementBaseTest {
+
+    private String createdAppId;
+    static final String APPLICATION_USER_REGISTRANT_CONTEXT = "/user-registrants";
+    static final String RESPONSE_ELEMENT_TOTAL_RESULTS = "totalResults";
+    static final String RESPONSE_ELEMENT_USER_REGISTRANTS = "userRegistrants";
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public ApplicationManagementUserRegistrantSuccessTest(TestUserMode userMode) throws Exception {
+
+        super(userMode);
+    }
+
+    @BeforeTest(alwaysRun = true)
+    public void initTestClass() throws IOException {
+
+        super.init();
+    }
+
+    @AfterTest(alwaysRun = true)
+    public void testFinish() {
+
+        super.testFinish();
+    }
+
+    @Test
+    public void testRetrieveUserRegistrantsOfInvalidApp() {
+
+        Response response = getResponseOfGet(APPLICATION_MANAGEMENT_API_BASE_PATH + PATH_SEPARATOR + "some-wrong-id" +
+                APPLICATION_USER_REGISTRANT_CONTEXT);
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(RESPONSE_ELEMENT_TOTAL_RESULTS, equalTo(0))
+                .body(RESPONSE_ELEMENT_USER_REGISTRANTS + ".size()", equalTo(0));
+    }
+
+    @Test
+    public void testCreateAppWithNoAuthenticationOptions() throws Exception {
+
+        String body = readResource("create-app-with-no-authenticators.json");
+
+        Response response = getResponseOfPost(APPLICATION_MANAGEMENT_API_BASE_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        createdAppId = extractApplicationIdFromLocationHeader(location);
+        assertNotBlank(createdAppId);
+    }
+
+    @Test(dependsOnMethods = "testCreateAppWithNoAuthenticationOptions")
+    public void testRetrieveUserRegistrantsDefault() {
+
+        Response response = getResponseOfGet(APPLICATION_MANAGEMENT_API_BASE_PATH + PATH_SEPARATOR + createdAppId +
+                APPLICATION_USER_REGISTRANT_CONTEXT);
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(RESPONSE_ELEMENT_TOTAL_RESULTS, equalTo(1))
+                .body(RESPONSE_ELEMENT_USER_REGISTRANTS + ".size()", equalTo(1));
+    }
+
+    @Test(dependsOnMethods = "testRetrieveUserRegistrantsDefault")
+    public void testRetrieveUserRegistrantUsernamePassword() throws IOException {
+
+        String authenticatorsPutPayload = readResource("patch-app-with-username-password-authenticator.json");
+        doPutAuthenticatorsAndVerify(authenticatorsPutPayload);
+
+        Response response = getResponseOfGet(APPLICATION_MANAGEMENT_API_BASE_PATH + PATH_SEPARATOR + createdAppId +
+                APPLICATION_USER_REGISTRANT_CONTEXT);
+
+        String baseIdentifier =
+                RESPONSE_ELEMENT_USER_REGISTRANTS + ".find{ it.id == 'QmFzaWNBdXRoQXV0aEF0dHJpYnV0ZUhhbmRsZXI' }.";
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(RESPONSE_ELEMENT_TOTAL_RESULTS, equalTo(1))
+                .body(RESPONSE_ELEMENT_USER_REGISTRANTS + ".size()", equalTo(1))
+                .body(baseIdentifier + "name", equalTo("BasicAuthAuthAttributeHandler"))
+                .body(baseIdentifier + "authAttributes.size()", equalTo(2))
+                .body(baseIdentifier + "authAttributes[0].attribute", equalTo("username"))
+                .body(baseIdentifier + "authAttributes[1].attribute", equalTo("password"));
+    }
+
+    @Test(dependsOnMethods = "testRetrieveUserRegistrantUsernamePassword")
+    public void testRetrieveTwoConfiguredUserRegistrants() throws IOException {
+
+        String authenticatorsPutPayload = readResource("patch-app-with-two-auth-options.json");
+        doPutAuthenticatorsAndVerify(authenticatorsPutPayload);
+
+        Response response = getResponseOfGet(APPLICATION_MANAGEMENT_API_BASE_PATH + PATH_SEPARATOR + createdAppId +
+                APPLICATION_USER_REGISTRANT_CONTEXT);
+
+        String encodedIdForBasicAuth = "QmFzaWNBdXRoQXV0aEF0dHJpYnV0ZUhhbmRsZXI";
+        String encodedIdForMagicLink = "TWFnaWNMaW5rQXV0aEF0dHJpYnV0ZUhhbmRsZXI";
+        String basicAuthBaseIdentifier =
+                RESPONSE_ELEMENT_USER_REGISTRANTS + ".find{ it.id == '" + encodedIdForBasicAuth + "' }.";
+        String magicLinkBaseIdentifier =
+                RESPONSE_ELEMENT_USER_REGISTRANTS + ".find{ it.id == '" + encodedIdForMagicLink + "' }.";
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(RESPONSE_ELEMENT_TOTAL_RESULTS, equalTo(2))
+                .body(RESPONSE_ELEMENT_USER_REGISTRANTS + ".size()", equalTo(2))
+                .body(basicAuthBaseIdentifier + "name", equalTo("BasicAuthAuthAttributeHandler"))
+                .body(basicAuthBaseIdentifier + "authAttributes.size()", equalTo(2))
+                .body(basicAuthBaseIdentifier + "authAttributes[0].attribute", equalTo("username"))
+                .body(basicAuthBaseIdentifier + "authAttributes[1].attribute", equalTo("password"))
+                .body(magicLinkBaseIdentifier + "name", equalTo("MagicLinkAuthAttributeHandler"))
+                .body(magicLinkBaseIdentifier + "authAttributes.size()", equalTo(2))
+                .body(magicLinkBaseIdentifier + "authAttributes[0].attribute", equalTo("username"))
+                .body(magicLinkBaseIdentifier + "authAttributes[1].attribute", equalTo("http://wso2.org/claims/emailaddress"));
+    }
+
+    private void doPutAuthenticatorsAndVerify(String authenticatorsPutPayload) {
+
+        String path = APPLICATION_MANAGEMENT_API_BASE_PATH + PATH_SEPARATOR + createdAppId;
+        Response responseOfPatch = getResponseOfPatch(path, authenticatorsPutPayload);
+
+        // Validate PATCH response.
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/create-app-with-no-authenticators.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/create-app-with-no-authenticators.json
@@ -1,0 +1,6 @@
+{
+  "name": "user-registrant-test-app",
+  "description": "App for retrieving user registrants endpoint",
+  "imageUrl": "https://localhost/image",
+  "accessUrl": "https://localhost/accessUrl"
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-app-with-two-auth-options.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-app-with-two-auth-options.json
@@ -1,0 +1,20 @@
+{
+  "authenticationSequence": {
+    "attributeStepId":1,
+    "steps":[{
+      "id":1,
+      "options":[
+        {
+        "idp":"LOCAL",
+        "authenticator":"BasicAuthenticator"
+        },
+        {
+          "idp": "LOCAL",
+          "authenticator": "MagicLinkAuthenticator"
+        }
+      ]
+    }],
+    "subjectStepId":1,
+    "type":"USER_DEFINED"
+  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-app-with-username-password-authenticator.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-app-with-username-password-authenticator.json
@@ -1,0 +1,14 @@
+{
+  "authenticationSequence": {
+    "attributeStepId":1,
+    "steps":[{
+      "id":1,
+      "options":[{
+        "idp":"LOCAL",
+        "authenticator":"BasicAuthenticator"
+      }]
+    }],
+    "subjectStepId":1,
+    "type":"USER_DEFINED"
+  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -202,6 +202,7 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementUserRegistrantSuccessTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
This PR adds integration tests for the user-registrants retrieval endpoint in the application management API. 

The API layer changes were introduced with https://github.com/wso2/identity-api-server/pull/417
The BE improvements were introduced with https://github.com/wso2-extensions/identity-governance/pull/663