### PR TITLE
Add integration tests for different credential signup

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
@@ -28,6 +28,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+
 public class SelfRegisterTestCase extends SelfRegisterTestBase {
 
     public static final String ENABLE_SELF_SIGN_UP = "SelfRegistration.Enable";
@@ -113,5 +115,86 @@ public class SelfRegisterTestCase extends SelfRegisterTestBase {
                 getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfoWithInvalidPassword);
         Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_BAD_REQUEST,
                 "Self register user password invalid");
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user with basic auth as option")
+    public void testSelfRegisterWithBasicAuth() throws Exception {
+
+        String selfRegisterUserInfo = readResource("self-register-success-basicauth-option.json");
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        Response responseOfPost = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
+        Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_CREATED, "User successfully registered with " +
+                "basic auth.");
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", description = "Create self registered user with magic link as option")
+    public void testSelfRegisterWithMagicLink() throws Exception {
+
+        String selfRegisterUserInfo = readResource("self-register-success-magiclink-option.json");
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        Response responseOfPost = getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo);
+        Assert.assertEquals(responseOfPost.statusCode(), HttpStatus.SC_CREATED, "User successfully registered with " +
+                "magic link.");
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is", description = "Self registration request with multiple options")
+    public void testSelfRegisterMultipleOptions() throws Exception {
+
+        String selfRegisterUserInfo = readResource("self-register-failure-multiple-options.json");
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("code", equalTo("USR-10008"));
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is",
+            description = "Self registration request to basic auth with missing attributes")
+    public void testSelfRegisterMissingAttributesWithBasicAuth() throws Exception {
+
+        String selfRegisterUserInfo = readResource("self-register-failure-basicauth-option.json");
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("code", equalTo("USR-10006"));
+    }
+
+    @Test(alwaysRun = true, groups = "wso2.is",
+            description = "Self registration request to magic link with missing attributes")
+    public void testSelfRegisterMissingAttributesWithMagicLink() throws Exception {
+
+        String selfRegisterUserInfo = readResource("self-register-failure-magiclink-option.json");
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("code", equalTo("USR-10006"));
+    }
+
+
+    @Test(alwaysRun = true, groups = "wso2.is", description = "Self registration request with an invalid option")
+    public void testSelfRegisterInvalidRegistrationOption() throws Exception {
+
+        String selfRegisterUserInfo = readResource("self-register-failure-invalid-option.json");
+
+        updateResidentIDPProperty(ENABLE_SELF_SIGN_UP, "true", true);
+        getResponseOfPost(SELF_REGISTRATION_ENDPOINT, selfRegisterUserInfo)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("code", equalTo("USR-10007"));
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-basicauth-option.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-basicauth-option.json
@@ -1,0 +1,26 @@
+{
+  "user": {
+    "username": "basicauthuser",
+    "realm": "PRIMARY",
+    "claims": [
+      {
+        "uri": "http://wso2.org/claims/givenname",
+        "value": "kim"
+      },
+      {
+        "uri": "http://wso2.org/claims/emailaddress",
+        "value": "kim.anderson@gmail.com"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "key": "callback",
+      "value": "https://localhost:9443/myaccount/login"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "BasicAuthAuthAttributeHandler"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-invalid-option.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-invalid-option.json
@@ -1,0 +1,27 @@
+{
+  "user": {
+    "username": "basicauthuser",
+    "realm": "PRIMARY",
+    "password": "Passowrd@321",
+    "claims": [
+      {
+        "uri": "http://wso2.org/claims/givenname",
+        "value": "kim"
+      },
+      {
+        "uri": "http://wso2.org/claims/emailaddress",
+        "value": "kim.anderson@gmail.com"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "key": "callback",
+      "value": "https://localhost:9443/myaccount/login"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "some-invalid-registration-option"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-magiclink-option.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-magiclink-option.json
@@ -1,0 +1,22 @@
+{
+  "user": {
+    "username": "magiclinkuser",
+    "realm": "PRIMARY",
+    "claims": [
+      {
+        "uri": "http://wso2.org/claims/givenname",
+        "value": "kim"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "key": "callback",
+      "value": "https://localhost:9443/myaccount/login"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "MagicLinkAuthAttributeHandler"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-multiple-options.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-failure-multiple-options.json
@@ -1,0 +1,31 @@
+{
+  "user": {
+    "username": "basicauthuser",
+    "realm": "PRIMARY",
+    "password": "Passowrd@321",
+    "claims": [
+      {
+        "uri": "http://wso2.org/claims/givenname",
+        "value": "kim"
+      },
+      {
+        "uri": "http://wso2.org/claims/emailaddress",
+        "value": "kim.anderson@gmail.com"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "key": "callback",
+      "value": "https://localhost:9443/myaccount/login"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "BasicAuthAuthAttributeHandler"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "MagicLinkAuthAttributeHandler"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-success-basicauth-option.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-success-basicauth-option.json
@@ -1,0 +1,27 @@
+{
+  "user": {
+    "username": "basicauthuser",
+    "realm": "PRIMARY",
+    "password": "Passowrd@321",
+    "claims": [
+      {
+        "uri": "http://wso2.org/claims/givenname",
+        "value": "kim"
+      },
+      {
+        "uri": "http://wso2.org/claims/emailaddress",
+        "value": "kim.anderson@gmail.com"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "key": "callback",
+      "value": "https://localhost:9443/myaccount/login"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "BasicAuthAuthAttributeHandler"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-success-magiclink-option.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-success-magiclink-option.json
@@ -1,0 +1,26 @@
+{
+  "user": {
+    "username": "magiclinkuser",
+    "realm": "PRIMARY",
+    "claims": [
+      {
+        "uri": "http://wso2.org/claims/givenname",
+        "value": "kim"
+      },
+      {
+        "uri": "http://wso2.org/claims/emailaddress",
+        "value": "kim.anderson@gmail.com"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "key": "callback",
+      "value": "https://localhost:9443/myaccount/login"
+    },
+    {
+      "key" : "registrationOption",
+      "value": "MagicLinkAuthAttributeHandler"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2208,7 +2208,7 @@
         <carbon.consent.mgt.version>2.5.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.8.23</identity.governance.version>
+        <identity.governance.version>1.8.24</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.8.4</identity.carbon.auth.saml2.version>


### PR DESCRIPTION
This PR adds the integration tests for the BE changes introduced with the PR, https://github.com/wso2-extensions/identity-governance/pull/669 as discussed in the issue https://github.com/wso2/product-is/issues/15573