### PR TITLE
Added admin advisory banner as a feature

### DIFF
--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -479,6 +479,10 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.governance:org.wso2.carbon.identity.multi.attribute.login.service.server.feature:${identity.governance.version}
                                 </featureArtifactDef>
+                                <!-- Admin session advisory banner feature -->
+                                <featureArtifactDef>
+                                    org.wso2.carbon.identity.governance:org.wso2.carbon.identity.admin.session.advisory.banner.control.server.feature:${identity.governance.version}
+                                </featureArtifactDef>
                                 <!-- PBKDF2 feature -->
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.hash.provider.pbkdf2:org.wso2.carbon.identity.hash.provider.pbkdf2.server.feature:${hashprovider.pbkdf2.version}
@@ -531,6 +535,10 @@
                             </destination>
                             <deleteOldProfileFiles>true</deleteOldProfileFiles>
                             <features>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.admin.session.advisory.banner.control.server.feature.group</id>
+                                    <version>${identity.governance.version}</version>
+                                </feature>
                                 <feature>
                                     <id>org.wso2.carbon.as.runtimes.cxf3.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
@@ -788,6 +796,11 @@
                                     <id>org.wso2.carbon.identity.multi.attribute.login.service.server.feature.group</id>
                                     <version>${identity.governance.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.admin.session.advisory.banner.control.server.feature.group</id>
+                                    <version>${identity.governance.version}</version>
+                                </feature>
+
                                 <feature>
                                     <id>org.wso2.carbon.identity.central.log.mgt.server.feature.group</id>
                                     <version>${carbon.identity.framework.version}</version>
@@ -1343,6 +1356,10 @@
                                     <version>${identity.governance.version}</version>
                                 </feature>
                                 <feature>
+                                    <id>org.wso2.carbon.identity.admin.session.advisory.banner.control.server.feature.group</id>
+                                    <version>${identity.governance.version}</version>
+                                </feature>
+                                <feature>
                                     <id>org.wso2.carbon.identity.central.log.mgt.server.feature.group</id>
                                     <version>${carbon.identity.framework.version}</version>
                                 </feature>
@@ -1799,6 +1816,10 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.multi.attribute.login.service.server.feature.group</id>
+                                    <version>${identity.governance.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.admin.session.advisory.banner.control.server.feature.group</id>
                                     <version>${identity.governance.version}</version>
                                 </feature>
                                 <feature>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -536,10 +536,6 @@
                             <deleteOldProfileFiles>true</deleteOldProfileFiles>
                             <features>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.admin.session.advisory.banner.control.server.feature.group</id>
-                                    <version>${identity.governance.version}</version>
-                                </feature>
-                                <feature>
                                     <id>org.wso2.carbon.as.runtimes.cxf3.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>


### PR DESCRIPTION
This PR adds the feature Admin advisory banner displayed in the login page of the admin login. The following PRs needed to be merged before merging this PR.

- identity-governance PR 667
- https://github.com/wso2/identity-apps/pull/3822
- https://github.com/wso2/carbon-identity-framework/pull/4480

### Related Issues
- https://github.com/wso2/product-is/issues/15521
