### PR TITLE
Update the application patch test to add externalConsentManagement to the patch request

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationPatchTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationPatchTest.java
@@ -116,6 +116,7 @@ public class ApplicationPatchTest extends ApplicationManagementBaseTest {
                 .body("advancedConfigurations.find{ it.key == 'discoverableByEndUsers' }.value", equalTo(false))
                 .body("advancedConfigurations.find{ it.key == 'skipLoginConsent' }.value", equalTo(false))
                 .body("advancedConfigurations.find{ it.key == 'skipLogoutConsent' }.value", equalTo(false))
+                .body("advancedConfigurations.externalConsentManagement.find{ it.key == 'enabled' }.value", equalTo(false))
                 .body("advancedConfigurations.find{ it.key == 'returnAuthenticatedIdpList' }.value", equalTo(false))
                 .body("advancedConfigurations.find{ it.key == 'enableAuthorization' }.value", equalTo(false));
 
@@ -131,7 +132,8 @@ public class ApplicationPatchTest extends ApplicationManagementBaseTest {
                 .body("advancedConfigurations.find{ it.key == 'saas' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'discoverableByEndUsers' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'skipLoginConsent' }.value", equalTo(true))
-                .body("advancedConfigurations.find{ it.key == 'skipLogoutConsent' }.value", equalTo(true))
+                .body("advancedConfigurations.externalConsentManagement.find{ it.key == 'enabled' }.value", equalTo(true))
+                .body("advancedConfigurations.externalConsentManagement.find{ it.key == 'consentUrl' }.value", equalTo("https://example.com/consent"))
                 .body("advancedConfigurations.find{ it.key == 'returnAuthenticatedIdpList' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'enableAuthorization' }.value", equalTo(true));
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationPatchTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationPatchTest.java
@@ -132,6 +132,7 @@ public class ApplicationPatchTest extends ApplicationManagementBaseTest {
                 .body("advancedConfigurations.find{ it.key == 'saas' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'discoverableByEndUsers' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'skipLoginConsent' }.value", equalTo(true))
+                .body("advancedConfigurations.find{ it.key == 'skipLogoutConsent' }.value", equalTo(true))
                 .body("advancedConfigurations.externalConsentManagement.find{ it.key == 'enabled' }.value", equalTo(true))
                 .body("advancedConfigurations.externalConsentManagement.find{ it.key == 'consentUrl' }.value", equalTo("https://example.com/consent"))
                 .body("advancedConfigurations.find{ it.key == 'returnAuthenticatedIdpList' }.value", equalTo(true))

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/AdvancedApplicationConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/AdvancedApplicationConfiguration.java
@@ -30,6 +30,7 @@ public class AdvancedApplicationConfiguration  {
     private Boolean skipLogoutConsent;
     private Boolean returnAuthenticatedIdpList;
     private Boolean enableAuthorization;
+    private ExternalConsentManagementConfiguration externalConsentManagement;
 
     /**
     * Decide whether this application is allowed to be accessed across tenants.
@@ -103,6 +104,25 @@ public class AdvancedApplicationConfiguration  {
     }
 
     /**
+     **/
+    public AdvancedApplicationConfiguration externalConsentManagement(ExternalConsentManagementConfiguration
+                                                                              externalConsentManagement) {
+
+        this.externalConsentManagement = externalConsentManagement;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("externalConsentManagement")
+    @Valid
+    public ExternalConsentManagementConfiguration getExternalConsentManagement() {
+        return externalConsentManagement;
+    }
+    public void setExternalConsentManagement(ExternalConsentManagementConfiguration externalConsentManagement) {
+        this.externalConsentManagement = externalConsentManagement;
+    }
+
+    /**
     * Decide whether authenticated identity provider list needs to returned in the authentication response.
     **/
     public AdvancedApplicationConfiguration returnAuthenticatedIdpList(Boolean returnAuthenticatedIdpList) {
@@ -155,13 +175,14 @@ public class AdvancedApplicationConfiguration  {
             Objects.equals(this.certificate, advancedApplicationConfiguration.certificate) &&
                 Objects.equals(this.skipLoginConsent, advancedApplicationConfiguration.skipLoginConsent) &&
                 Objects.equals(this.skipLogoutConsent, advancedApplicationConfiguration.skipLogoutConsent) &&
+                Objects.equals(this.externalConsentManagement, advancedApplicationConfiguration.externalConsentManagement) &&
                 Objects.equals(this.returnAuthenticatedIdpList, advancedApplicationConfiguration.returnAuthenticatedIdpList) &&
             Objects.equals(this.enableAuthorization, advancedApplicationConfiguration.enableAuthorization);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(saas, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization);
+        return Objects.hash(saas, certificate, skipLoginConsent, skipLogoutConsent, externalConsentManagement, returnAuthenticatedIdpList, enableAuthorization);
     }
 
     @Override
@@ -174,6 +195,7 @@ public class AdvancedApplicationConfiguration  {
         sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
         sb.append("    skipLoginConsent: ").append(toIndentedString(skipLoginConsent)).append("\n");
         sb.append("    skipLogoutConsent: ").append(toIndentedString(skipLogoutConsent)).append("\n");
+        sb.append("    externalConsentManagement: ").append(toIndentedString(externalConsentManagement)).append("\n");
         sb.append("    returnAuthenticatedIdpList: ").append(toIndentedString(returnAuthenticatedIdpList)).append("\n");
         sb.append("    enableAuthorization: ").append(toIndentedString(enableAuthorization)).append("\n");
         sb.append("}");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ExternalConsentManagementConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ExternalConsentManagementConfiguration.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.Objects;
+
+public class ExternalConsentManagementConfiguration {
+
+    private boolean enabled;
+    private String consentUrl;
+
+    /**
+     * Decide whether external consent management is enabled.
+     **/
+    public ExternalConsentManagementConfiguration enabled(boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Decide whether external consent management is enabled.")
+    @JsonProperty("enabled")
+    @Valid
+    public boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Consent URL.
+     **/
+    public ExternalConsentManagementConfiguration consentUrl(String consentUrl) {
+
+        this.consentUrl = consentUrl;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Consent URL.")
+    @JsonProperty("consentUrl")
+    @Valid
+    public String getConsentUrl() {
+        return consentUrl;
+    }
+    public void setConsentUrl(String consentUrl) {
+        this.consentUrl = consentUrl;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExternalConsentManagementConfiguration externalConsentManagement = (ExternalConsentManagementConfiguration) o;
+        return Objects.equals(this.enabled, externalConsentManagement.enabled) &&
+                Objects.equals(this.consentUrl, externalConsentManagement.consentUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, consentUrl);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ExternalConsentManagementConfiguration {\n");
+
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    consentUrl: ").append(toIndentedString(consentUrl)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-application-advanced-configuration.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-application-advanced-configuration.json
@@ -4,6 +4,10 @@
     "discoverableByEndUsers": true,
     "skipLoginConsent": true,
     "skipLogoutConsent": true,
+    "externalConsentManagement" : {
+      "enabled" : true,
+      "consentUrl" : "https://example.com/consent"
+    },
     "returnAuthenticatedIdpList": true,
     "enableAuthorization": true
   }


### PR DESCRIPTION
## Purpose
$subjetc

## Changes
- The below configuration is added to the advance configurations of the application API request. 
```json
{
    "advancedConfigurations": {
        "externalConsentManagement": {
            "enabled": true,
            "consentUrl": "https://example.com/consent"
        }
    }
}
```

- From this PR, this configuration is added to the patch test case of application. 