### PR TITLE
Extend export/import file formats for Identity tool cli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2197,7 +2197,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.135</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.138</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2313,7 +2313,7 @@
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.13</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.9</identity.user.api.version>
-        <identity.server.api.version>1.2.39</identity.server.api.version>
+        <identity.server.api.version>1.2.40</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.2</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15461

Add support for SP configurations export/import in XML, YAML, and JSON file formats.

## Goals
When the required file type is given, this API will export or import Service Providers in either XML, YAML, or JSON file formats.

## Approach
This endpoint in application management server API is added to accept and export a file in a given file type.

**GET  /applications/{applicationId}/exportFile**

This endpoint in application management server API is updated to import a SP with the given file type.

**POST  /applications/import**

## Related PRs

https://github.com/wso2/identity-api-server/pull/426
https://github.com/wso2/carbon-identity-framework/pull/4451