### PR TITLE
Add missing provider bean for JsonProcessingExceptionMapper

### DIFF
--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
@@ -254,6 +254,7 @@
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+            <bean class="org.wso2.carbon.identity.oauth2.dcr.endpoint.exmapper.JsonProcessingExceptionMapper"/>
             <bean class="com.fasterxml.jackson.jaxrs.base.JsonMappingExceptionMapper"/>
             <bean class="com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper"/>
         </jaxrs:providers>


### PR DESCRIPTION
**Purpose**:
$Subject. The fix was done with https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1699. Due to some later migrations, configuration for implemented exception mapper was missing.. Added the missing configuration to the relevant place.  

**Issue resolved:**
https://github.com/wso2-enterprise/wso2-iam-internal/issues/398
