### PR TITLE
Fix default syslog configurations

### DIFF
--- a/modules/distribution/src/repository/resources/conf/log4j2.properties
+++ b/modules/distribution/src/repository/resources/conf/log4j2.properties
@@ -138,6 +138,7 @@ appender.DIAGNOSTICS.filter.threshold.level = INFO
 #appender.syslog.name = Syslog
 #appender.syslog.host = localhost
 #appender.syslog.port = 514
+#appender.syslog.protocol = UDP
 #appender.syslog.layout.type = PatternLayout
 #appender.syslog.layout.pattern = [%d] [%tenantId] %5p {%c} - %mm%ex%n
 #appender.syslog.filter.threshold.type = ThresholdFilter
@@ -360,7 +361,7 @@ rootLogger.level = INFO
 rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
 rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
-#rootLogger.appenderRef.syslog.ref = syslog
+#rootLogger.appenderRef.syslog.ref = Syslog
 
 
 logger.org-apache-directory-api.name=org.apache.directory.api


### PR DESCRIPTION
Related to 
- https://github.com/wso2/product-is/issues/15661

Update the commented syslog configurations that are available in the log4j2.properties file by default.