### PR TITLE
Update callback URL regex and fix callback url invalid port.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
@@ -36,7 +36,7 @@
       },
       {
         "name": "SelfRegistration.CallbackRegex",
-        "value": "[https://localhost:9853].*[/authenticationendpoint/login.do]*"
+        "value": "^https:\\/\\/localhost:9853.*(?:\\/authenticationendpoint\\/login\\.do)?$"
       },
       {
         "name": "_url_listPurposeSelfSignUp",

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-request-body.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/user/selfRegister/self-register-request-body.json
@@ -25,7 +25,7 @@
   "properties": [
     {
       "key": "callback",
-      "value": "https://localhost:9443/myaccount/login"
+      "value": "https://localhost:9853/myaccount/login"
     }
   ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request

After fixing the issue https://github.com/wso2/product-is/issues/15658 the integration tests related to the self registration has been failing due to the provided test properties needed to be changed. 

1. The regex for callback URL needed to be updated.
2. The value given for the callback URL contained a invalid port(9443), needed to be changed(9853). (Earlier because of the invalid regex provided as mentioned in this [issue](https://github.com/wso2/product-is/issues/15658), though the callback url port was invalid, the test case had been passing.)

### When should this PR be merged
- After merging the https://github.com/wso2/carbon-identity-framework/pull/4496 PR 

### Related Isuues
- https://github.com/wso2/product-is/issues/15658

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4496