### PR TITLE
Bump carbon.identity.framework.version to the latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2197,7 +2197,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.150</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.157</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15683

Bump identity framework version to 5.25.157

## Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4505
https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/391
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2047