### PR TITLE
Revert "Bump framework version to v6.0.15"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2156,7 +2156,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>6.0.15</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.13</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
### Purpose
* Reverting the framework version from `v6.0.15` to `v6.0.13` since `v6.0.15` release has some issues. 