### PR TITLE
Add session.nonce.cookies.whitelist.authenticators config

### DIFF
--- a/modules/distribution/src/repository/resources/conf/deployment.toml
+++ b/modules/distribution/src/repository/resources/conf/deployment.toml
@@ -38,6 +38,9 @@ hash= "66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"
 [identity.auth_framework.endpoint]
 app_password= "dashboard"
 
+[[session.nonce.cookies.whitelist.authenticators]]
+name="MagicLinkAuthenticator"
+
 # The KeyStore which is used for encrypting/decrypting internal data. By default the primary keystore is used as the internal keystore.
 
 #[keystore.internal]


### PR DESCRIPTION
### Purpose
* Add MagicLink Authenticator as one of the session nonce cookie whitelisted authenticators

#### Related PR(s)
https://github.com/wso2/carbon-identity-framework/pull/4587
