### PR TITLE
Fix XSS integration test issue to fail if the scripted content included in the response

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/entitlement/EntitlementSecurityTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/entitlement/EntitlementSecurityTestCase.java
@@ -75,7 +75,7 @@ public class EntitlementSecurityTestCase extends ISIntegrationTest {
 
             rd.close();
 
-            if(!success) {
+            if(success) {
                 Assert.fail("Content is not encoded");
             }
         }


### PR DESCRIPTION
> Previously the mentioned test case gives `405` method not found client error and proceed while not executing the `if` https://github.com/wso2/product-is/pull/15819/files#diff-dbbef157bb60deedf6f06270e3836b5d04f48ac0e324a00a80dbd9d4a6e0e483R65 condition logic which expects `200` response. But with the fix sent by this PR https://github.com/wso2/carbon-kernel/pull/3571, for authenticated sessions, the response is redirected to the login page and it includes `200` response. Then the above mentioned `if` condition is being executed and there is an improvement to be made to that if block. This PR is initiated for that.