### PR TITLE
Integrate Admin Advisory Management component

### DIFF
--- a/modules/api-resources/api-resources-full/pom.xml
+++ b/modules/api-resources/api-resources-full/pom.xml
@@ -143,6 +143,14 @@
             <artifactId>org.wso2.carbon.identity.api.server.identity.governance.common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.admin.advisory.management.v1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.admin.advisory.management.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.user.api</groupId>
             <artifactId>org.wso2.carbon.identity.rest.api.user.totp.v1</artifactId>
         </dependency>

--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
@@ -48,6 +48,7 @@
     <import resource="classpath:META-INF/cxf/input-validation-server-v1-cxf.xml"/>
 
     <import resource="classpath:META-INF/cxf/identity-governance-server-v1-cxf.xml"/>
+    <import resource="classpath:META-INF/cxf/admin-advisory-management-server-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/user-store-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/tenant-management-server-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/cors-server-v1-cxf.xml"/>
@@ -80,6 +81,7 @@
             <bean class="org.wso2.carbon.identity.rest.api.server.claim.management.v1.ClaimManagementApi"/>
             <bean class="org.wso2.carbon.identity.rest.api.server.email.template.v1.EmailApi"/>
             <bean class="org.wso2.carbon.identity.api.server.identity.governance.v1.IdentityGovernanceApi"/>
+            <bean class="org.wso2.carbon.identity.api.server.admin.advisory.management.v1.AdminAdvisoryManagementApi"/>
             <bean class="org.wso2.carbon.identity.api.server.application.management.v1.ApplicationsApi"/>
             <bean class="org.wso2.carbon.identity.api.server.userstore.v1.UserstoresApi"/>
             <bean class="org.wso2.carbon.identity.api.server.permission.management.v1.PermissionManagementApi"/>

--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -133,6 +133,16 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.admin.advisory.management.v1</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.admin.advisory.management.common</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.challenge.common</artifactId>
                 <version>${identity.server.api.version}</version>
             </dependency>

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/admin/advisory/management/v1/AdminAdvisoryManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/admin/advisory/management/v1/AdminAdvisoryManagementSuccessTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ * Test class for the Admin Advisory Management REST API success path.
+ */
+public class AdminAdvisoryManagementSuccessTest extends AdminAdvisoryManagementTestBase {
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public AdminAdvisoryManagementSuccessTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws IOException {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void testFinish() {
+
+        RestAssured.basePath = StringUtils.EMPTY;
+    }
+
+    // Get admin advisory config from the API.
+    @Test
+    public void getAdminAdvisoryConfig() {
+
+        Response response = getResponseOfGet(ADMIN_ADVISORY_MGT_API_BASE_PATH + ADMIN_ADVISORY_BANNER_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("enableBanner", equalTo(ENABLE_BANNER))
+                .body("bannerContent", equalTo(BANNER_CONTENT));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/admin/advisory/management/v1/AdminAdvisoryManagementTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/admin/advisory/management/v1/AdminAdvisoryManagementTestBase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1;
+
+import io.restassured.RestAssured;
+import org.apache.commons.lang.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
+
+import java.io.IOException;
+
+/**
+ * Base test class for the Admin Advisory Management Rest APIs.
+ */
+public class AdminAdvisoryManagementTestBase extends RESTAPIServerTestBase {
+
+    public static final String API_DEFINITION_NAME = "admin-advisory-management.yaml";
+    public static final String API_VERSION = "v1";
+    public static final String API_PACKAGE_NAME =
+            "org.wso2.carbon.identity.api.server.admin.advisory.management.v1";
+    public static final String ADMIN_ADVISORY_MGT_API_BASE_PATH = "/admin-advisory-management";
+    public static final String ADMIN_ADVISORY_BANNER_PATH = "/banner";
+    public static final boolean ENABLE_BANNER = false;
+    public static final String BANNER_CONTENT = "Warning - unauthorized use of this tool is strictly prohibited. " +
+            "All activities performed using this tool are logged and monitored.";
+
+    protected static String swaggerDefinition;
+
+    static {
+        try {
+            swaggerDefinition = getAPISwaggerDefinition(API_PACKAGE_NAME, API_DEFINITION_NAME);
+        } catch (IOException e) {
+            Assert.fail(String.format("Unable to read the swagger definition %s from %s", API_DEFINITION_NAME,
+                    API_PACKAGE_NAME), e);
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() throws Exception {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void testFinish() {
+
+        RestAssured.basePath = StringUtils.EMPTY;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -189,6 +189,7 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementUserRegistrantSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>
         </classes>
     </test>
 

--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.2" useFeatures="true" includeLaunchers="true">
+version="4.9.4" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.2" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.2"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.4"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2289,7 +2289,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.9.2</carbon.kernel.version>
+        <carbon.kernel.version>4.9.4</carbon.kernel.version>
 
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.20</carbon.deployment.version>


### PR DESCRIPTION
## Purpose
This PR integrates the admin advisory banner to product IS. It also introduces the configs related to integrating the admin advisory management API and includes integration tests for the same.

The feature introduces the admin advisory configuration component to management console. Once enabled, a banner will be displayed in the management console login and console app login pages with the configured administrative message. 

### Related Issues
- Issue https://github.com/wso2/product-is/issues/15521

### Related PRs
- PR https://github.com/wso2/carbon-identity-framework/pull/4536
- PR https://github.com/wso2/carbon-kernel/pull/3560
- PR https://github.com/wso2/identity-api-server/pull/441
- PR https://github.com/wso2/identity-apps/pull/3908
- PR https://github.com/wso2/docs-is/pull/3714

`Configuration component`
![image](https://user-images.githubusercontent.com/46979289/233558237-9740ed90-bbcd-418e-bc42-9d0ecd6c3116.png)

`Management console login`
![image](https://user-images.githubusercontent.com/46979289/233559071-85c81c28-7696-43d3-8df3-036ef4af3ab8.png)

`Console app login`
![image](https://user-images.githubusercontent.com/46979289/233558958-03564052-1c44-47b2-a83f-897d9841007c.png)
