### PR TITLE
Remove admin banner component

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -70,6 +70,9 @@
                 <exclude>**/repository/components/plugins/org.wso2.carbon.roles.mgt.stub_**.jar</exclude>
                 <exclude>**/repository/components/plugins/org.wso2.carbon.server.admin.ui_**.jar</exclude>
                 <exclude>**/repository/components/plugins/org.wso2.carbon.server.admin.stub_**.jar</exclude>
+                <exclude>**/repository/components/plugins/org.wso2.carbon.admin.advisory.mgt.ui_**.jar</exclude>
+                <exclude>**/repository/components/plugins/org.wso2.carbon.admin.advisory.mgt.stub_**.jar</exclude>
+                <exclude>**/repository/components/plugins/org.wso2.carbon.admin.advisory.mgt_**.jar</exclude>
                 <exclude>**/repository/components/plugins/org.wso2.carbon.i18n_**.jar</exclude>
                 <exclude>**/repository/components/plugins/org.wso2.carbon.feature.mgt.stub_**.jar</exclude>
                 <exclude>**/repository/components/plugins/org.wso2.carbon.core.commons.stub_**.jar</exclude>

--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.2" useFeatures="true" includeLaunchers="true">
+version="4.9.4" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.2" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.2"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.4"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2166,7 +2166,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>6.0.32</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.33</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -2166,7 +2166,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>6.0.28</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.32</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -2289,7 +2289,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.9.2</carbon.kernel.version>
+        <carbon.kernel.version>4.9.4</carbon.kernel.version>
 
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.20</carbon.deployment.version>


### PR DESCRIPTION
## Purpose

Since the admin advisory banner feature introduced by the Kernel is not required for Asgardeo, this PR removes the related jars added by the feature while also bumping the kernel version.

### Related PRs
- PR https://github.com/wso2/carbon-kernel/pull/3560

