### PR TITLE
Update getEmailTemplates using REST API in the AccountLockEnabledTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
@@ -168,6 +168,7 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
         usmClient.deleteUser(testLockUser1);
         usmClient.deleteUser(testLockUser2);
         disableAccountLocking(ENABLE_ACCOUNT_LOCK);
+        emailTemplatesRestClient.closeHttpClient();
     }
 
     protected String getISResourceLocation() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2016, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
@@ -34,11 +34,10 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.stub.bean.Property;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.um.ws.api.stub.ClaimValue;
-import org.wso2.identity.integration.common.clients.ResourceAdminServiceClient;
 import org.wso2.identity.integration.common.clients.mgt.IdentityGovernanceServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
-import org.wso2.identity.integration.test.restclients.ResourceAdminServiceRestClient;
+import org.wso2.identity.integration.test.restclients.EmailTemplatesRestClient;
 
 public class AccountLockEnabledTestCase extends ISIntegrationTest {
 
@@ -65,7 +64,7 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
     private AuthenticatorClient authenticatorClient;
     private RemoteUserStoreManagerServiceClient usmClient;
     private IdentityGovernanceServiceClient identityGovernanceServiceClient;
-    private ResourceAdminServiceRestClient resourceAdminServiceRestClient;
+    private EmailTemplatesRestClient emailTemplatesRestClient;
 
     private static final String ENABLE_ACCOUNT_LOCK = "account.lock.handler.lock.on.max.failed.attempts.enable";
     private static final String TRUE_STRING = "true";
@@ -79,7 +78,7 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
         authenticatorClient = new AuthenticatorClient(backendURL);
         enableAccountLocking(ENABLE_ACCOUNT_LOCK);
         usmClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
-        resourceAdminServiceRestClient = new ResourceAdminServiceRestClient(backendURL.replace("services/",
+        emailTemplatesRestClient = new EmailTemplatesRestClient(backendURL.replace("services/",
                 ""), tenantInfo);
     }
 
@@ -129,13 +128,13 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
         usmClient.addUser(testLockUser2, testLockUser2Password, new String[] { "admin" }, claimvalues, null, false);
 
         JSONObject emailTemplateResourceContent =
-                resourceAdminServiceRestClient.getEmailTemplate(accountLockTemplateWhenUserExceedsFailedAttempts,
+                emailTemplatesRestClient.getEmailTemplate(accountLockTemplateWhenUserExceedsFailedAttempts,
                         USER_LOCALE);
         Assert.assertTrue("Test Failure : Email Content applicable for account lock is not available.",
                 StringUtils.isNotEmpty((String) emailTemplateResourceContent.get("body")));
 
         JSONObject emailTemplateResourceContentAdminTriggered =
-                resourceAdminServiceRestClient.getEmailTemplate(accountLockTemplateWhenAdminTriggered, USER_LOCALE);
+                emailTemplatesRestClient.getEmailTemplate(accountLockTemplateWhenAdminTriggered, USER_LOCALE);
         Assert.assertTrue("Test Failure : Email Content applicable for account lock is not available.",
                 StringUtils.isNotEmpty((String) emailTemplateResourceContentAdminTriggered.get("body")));
     }
@@ -153,12 +152,12 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
             usmClient.addUser(testLockUser3, testLockUser3Password, new String[] { "admin" }, claimvalues, null, false);
 
             JSONObject emailTemplateResourceContent =
-                    resourceAdminServiceRestClient.getEmailTemplate(accountUnlockTemplateTimeBased, USER_LOCALE);
+                    emailTemplatesRestClient.getEmailTemplate(accountUnlockTemplateTimeBased, USER_LOCALE);
             Assert.assertTrue("Test Failure : Email Content applicable for account unlock is not available.",
                     StringUtils.isNotEmpty((String) emailTemplateResourceContent.get("body")));
 
             JSONObject emailTemplateResourceContentAdminTriggered =
-                    resourceAdminServiceRestClient.getEmailTemplate(accountUnlockTemplateAdminTriggered, USER_LOCALE);
+                    emailTemplatesRestClient.getEmailTemplate(accountUnlockTemplateAdminTriggered, USER_LOCALE);
             Assert.assertTrue("Test Failure : Email Content applicable for account unlock is not available.",
                     StringUtils.isNotEmpty((String) emailTemplateResourceContentAdminTriggered.get("body")));
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/dto/ConnectorsPatchReq.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/dto/ConnectorsPatchReq.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/dto/ConnectorsPatchReq.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/dto/ConnectorsPatchReq.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ConnectorsPatchReq {
+
+    @XmlType(name="OperationEnum")
+    @XmlEnum()
+    public enum OperationEnum {
+
+        @XmlEnumValue("UPDATE") UPDATE("UPDATE");
+
+        private String value;
+
+        OperationEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static ConnectorsPatchReq.OperationEnum fromValue(String value) {
+            for (ConnectorsPatchReq.OperationEnum b : ConnectorsPatchReq.OperationEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private OperationEnum operation = OperationEnum.UPDATE;
+    private List<PropertyReq> properties;
+
+    /**
+     **/
+    public ConnectorsPatchReq operation(OperationEnum operation) {
+        this.operation = operation;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("operation")
+    @Valid
+    public OperationEnum getOperation() {
+        return operation;
+    }
+    public void setOperation(OperationEnum operation) {
+        this.operation = operation;
+    }
+
+    /**
+     **/
+    public ConnectorsPatchReq properties(List<PropertyReq> properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("properties")
+    @Valid
+    public List<PropertyReq> getProperties() { return properties; }
+
+    public void setProperties(List<PropertyReq> properties) { this.properties = properties; }
+
+    public ConnectorsPatchReq addProperties(PropertyReq property) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(property);
+        return this;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectorsPatchReq connectorsPatchReq = (ConnectorsPatchReq) o;
+        return Objects.equals(this.operation, connectorsPatchReq.operation) &&
+                Objects.equals(this.properties, connectorsPatchReq.properties);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(operation, properties);
+    }
+
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
@@ -20,7 +20,6 @@ package org.wso2.identity.integration.test.restclients;
 import io.restassured.http.ContentType;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
@@ -1,9 +1,27 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.identity.integration.test.restclients;
 
 import io.restassured.http.ContentType;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -12,54 +30,49 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
-import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
-
 import java.io.IOException;
 
 public class EmailTemplatesRestClient {
 
-    protected static final String TENANT_PATH = "t/%s";
-    protected static final String API_SERVER_BASE_PATH = "/api/server/v1";
-    public static final String EMAIL_TEMPLATES_EMAIL_BASE_PATH = "/email";
-    public static final String EMAIL_TEMPLATE_TYPES_PATH = "/template-types";
-    public static final String EMAIL_TEMPLATES_PATH = "/templates";
-    public static final String PATH_SEPARATOR = "/";
+    private static final String TENANT_PATH = "t/%s";
+    private static final String API_SERVER_BASE_PATH = "/api/server/v1";
+    private static final String EMAIL_TEMPLATES_EMAIL_BASE_PATH = "/email";
+    private static final String EMAIL_TEMPLATE_TYPES_PATH = "/template-types";
+    private static final String EMAIL_TEMPLATES_PATH = "/templates";
+    private static final String PATH_SEPARATOR = "/";
     public static final String BASIC_AUTHORIZATION_ATTRIBUTE = "Basic ";
     public static final String CONTENT_TYPE_ATTRIBUTE = "Content-Type";
     public static final String AUTHORIZATION_ATTRIBUTE = "Authorization";
-    private final String EMAIL_TEMPLATE_API_BASE_PATH;
+    private final String emailTemplateApiBasePath;
     private final CloseableHttpClient client;
-    private final String USERNAME;
-    private final String PASSWORD;
-
+    private final String username;
+    private final String password;
 
     public EmailTemplatesRestClient(String backendURL, Tenant tenantInfo) {
         client = HttpClients.createDefault();
 
-        this.USERNAME = tenantInfo.getContextUser().getUserName();
-        this.PASSWORD = tenantInfo.getContextUser().getPassword();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
 
         String tenantDomain = tenantInfo.getContextUser().getUserDomain();
 
-        EMAIL_TEMPLATE_API_BASE_PATH = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
+        emailTemplateApiBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
                 EMAIL_TEMPLATES_EMAIL_BASE_PATH + EMAIL_TEMPLATE_TYPES_PATH;
     }
 
     public JSONObject getEmailTemplate(String templateTypeId, String templateId) throws Exception {
-
-        String endPointUrl = EMAIL_TEMPLATE_API_BASE_PATH + PATH_SEPARATOR +
+        String endPointUrl = emailTemplateApiBasePath + PATH_SEPARATOR +
                 getEncodedEmailTemplateTypeId(templateTypeId) + EMAIL_TEMPLATES_PATH + PATH_SEPARATOR + templateId;
 
-        HttpResponse response = getResponseOfHttpGet(endPointUrl);
+        CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl);
 
         String responseBody = EntityUtils.toString(response.getEntity());
-        EntityUtils.consume(response.getEntity());
+        response.close();
 
         return getJSONObject(responseBody);
     }
 
-    private HttpResponse getResponseOfHttpGet(String endPointUrl) throws IOException {
-
+    private CloseableHttpResponse getResponseOfHttpGet(String endPointUrl) throws IOException {
         HttpGet request = new HttpGet(endPointUrl);
         request.setHeaders(getHeaders());
 
@@ -67,10 +80,9 @@ public class EmailTemplatesRestClient {
     }
 
     private Header[] getHeaders() {
-
         Header[] headerList = new Header[2];
         headerList[0] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
-                Base64.encodeBase64String((USERNAME + ":" + PASSWORD).getBytes()).trim());
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
         headerList[1] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
 
         return headerList;
@@ -89,5 +101,9 @@ public class EmailTemplatesRestClient {
         }
 
         return json;
+    }
+
+    public void closeHttpClient() throws IOException {
+        client.close();
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
@@ -16,7 +16,7 @@ import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
 import java.io.IOException;
 
-public class ResourceAdminServiceRestClient extends RESTTestBase {
+public class EmailTemplatesRestClient {
 
     protected static final String TENANT_PATH = "t/%s";
     protected static final String API_SERVER_BASE_PATH = "/api/server/v1";
@@ -33,7 +33,7 @@ public class ResourceAdminServiceRestClient extends RESTTestBase {
     private final String PASSWORD;
 
 
-    public ResourceAdminServiceRestClient(String backendURL, Tenant tenantInfo) {
+    public EmailTemplatesRestClient(String backendURL, Tenant tenantInfo) {
         client = HttpClients.createDefault();
 
         this.USERNAME = tenantInfo.getContextUser().getUserName();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.identity.integration.test.restclients;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class IdentityGovernanceRestClient {
+
+    private static final String TENANT_PATH = "t/%s";
+    private static final String API_SERVER_BASE_PATH = "/api/server/v1";
+    private static final String IDENTITY_GOVERNANCE_BASE_PATH = "/identity-governance";
+    private static final String CONNECTORS_BASE_PATH = "/connectors";
+    private static final String PATH_SEPARATOR = "/";
+    private static final String BASIC_AUTHORIZATION_ATTRIBUTE = "Basic ";
+    private static final String CONTENT_TYPE_ATTRIBUTE = "Content-Type";
+    private static final String AUTHORIZATION_ATTRIBUTE = "Authorization";
+    private final String identityGovernanceApiBasePath;
+    private final CloseableHttpClient client;
+    private final String username;
+    private final String password;
+
+    public IdentityGovernanceRestClient(String backendURL, Tenant tenantInfo) {
+        client = HttpClients.createDefault();
+
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+
+        String tenantDomain = tenantInfo.getContextUser().getUserDomain();
+
+        identityGovernanceApiBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
+                IDENTITY_GOVERNANCE_BASE_PATH;
+    }
+
+    public void updateConnectors(String categoryId, String connectorId, ConnectorsPatchReq connectorPatch)
+            throws IOException {
+        String jsonRequest = toJSONString(connectorPatch);
+        String endPointUrl = identityGovernanceApiBasePath + PATH_SEPARATOR + categoryId +
+                CONNECTORS_BASE_PATH + PATH_SEPARATOR + connectorId;
+
+        CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest);
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                "Connector update failed");
+        response.close();
+    }
+
+    private String toJSONString(java.lang.Object object) {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(object);
+    }
+
+    private CloseableHttpResponse getResponseOfHttpPatch(String endPointUrl, String jsonRequest) throws IOException {
+
+        HttpPatch request = new HttpPatch(endPointUrl);
+        request.setHeaders(getHeaders());
+        request.setEntity(new StringEntity(jsonRequest));
+
+        return client.execute(request);
+    }
+
+    private Header[] getHeaders() {
+
+        Header[] headerList = new Header[2];
+        headerList[0] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[1] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    public void closeHttpClient() throws IOException {
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ResourceAdminServiceRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ResourceAdminServiceRestClient.java
@@ -1,0 +1,93 @@
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
+
+import java.io.IOException;
+
+public class ResourceAdminServiceRestClient extends RESTTestBase {
+
+    protected static final String TENANT_PATH = "t/%s";
+    protected static final String API_SERVER_BASE_PATH = "/api/server/v1";
+    public static final String EMAIL_TEMPLATES_EMAIL_BASE_PATH = "/email";
+    public static final String EMAIL_TEMPLATE_TYPES_PATH = "/template-types";
+    public static final String EMAIL_TEMPLATES_PATH = "/templates";
+    public static final String PATH_SEPARATOR = "/";
+    public static final String BASIC_AUTHORIZATION_ATTRIBUTE = "Basic ";
+    public static final String CONTENT_TYPE_ATTRIBUTE = "Content-Type";
+    public static final String AUTHORIZATION_ATTRIBUTE = "Authorization";
+    private final String EMAIL_TEMPLATE_API_BASE_PATH;
+    private final CloseableHttpClient client;
+    private final String USERNAME;
+    private final String PASSWORD;
+
+
+    public ResourceAdminServiceRestClient(String backendURL, Tenant tenantInfo) {
+        client = HttpClients.createDefault();
+
+        this.USERNAME = tenantInfo.getContextUser().getUserName();
+        this.PASSWORD = tenantInfo.getContextUser().getPassword();
+
+        String tenantDomain = tenantInfo.getContextUser().getUserDomain();
+
+        EMAIL_TEMPLATE_API_BASE_PATH = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
+                EMAIL_TEMPLATES_EMAIL_BASE_PATH + EMAIL_TEMPLATE_TYPES_PATH;
+    }
+
+    public JSONObject getEmailTemplate(String templateTypeId, String templateId) throws Exception {
+
+        String endPointUrl = EMAIL_TEMPLATE_API_BASE_PATH + PATH_SEPARATOR +
+                getEncodedEmailTemplateTypeId(templateTypeId) + EMAIL_TEMPLATES_PATH + PATH_SEPARATOR + templateId;
+
+        HttpResponse response = getResponseOfHttpGet(endPointUrl);
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        EntityUtils.consume(response.getEntity());
+
+        return getJSONObject(responseBody);
+    }
+
+    private HttpResponse getResponseOfHttpGet(String endPointUrl) throws IOException {
+
+        HttpGet request = new HttpGet(endPointUrl);
+        request.setHeaders(getHeaders());
+
+        return client.execute(request);
+    }
+
+    private Header[] getHeaders() {
+
+        Header[] headerList = new Header[2];
+        headerList[0] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((USERNAME + ":" + PASSWORD).getBytes()).trim());
+        headerList[1] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    private String getEncodedEmailTemplateTypeId(String emailTemplateTypeId) {
+        return Base64.encodeBase64String(emailTemplateTypeId.getBytes());
+    }
+
+    private JSONObject getJSONObject(String responseString) throws Exception {
+        JSONParser parser = new JSONParser();
+        JSONObject json = (JSONObject) parser.parse(responseString);
+        if (json == null) {
+            throw new Exception(
+                    "Error occurred while getting the response");
+        }
+
+        return json;
+    }
+}


### PR DESCRIPTION
## Purpose
This PR removes `resourceAdminServiceClient` which has used SOAP services to retrieve the Email Templates(only) and replaced it with a REST API based `EmailTemplatesRestClient` in the `AccountLockEnabledTestCase`

Also added `IdentityGovernanceRestClient` by replacing the soap api based `IdentityGovernanceServiceClient` 
