### PR TITLE
[7.x.x] Bump versions and change tests for sha1 removal

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/saml-metadata-super-tenant.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/saml-metadata-super-tenant.json
@@ -99,7 +99,7 @@
       "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384",
       "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"
     ],
-    "defaultValue": "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+    "defaultValue": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
   },
   "responseDigestAlgorithm": {
     "options": [
@@ -110,7 +110,7 @@
       "http://www.w3.org/2001/04/xmldsig-more#sha384",
       "http://www.w3.org/2001/04/xmlenc#sha512"
     ],
-    "defaultValue": "http://www.w3.org/2000/09/xmldsig#sha1"
+    "defaultValue": "http://www.w3.org/2001/04/xmlenc#sha256"
   },
   "assertionEncryptionAlgorithm": {
     "options": [

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/saml-metadata-tenant.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/saml-metadata-tenant.json
@@ -20,7 +20,7 @@
       "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384",
       "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"
     ],
-    "defaultValue": "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+    "defaultValue": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
   },
   "responseDigestAlgorithm": {
     "options": [
@@ -31,7 +31,7 @@
       "http://www.w3.org/2001/04/xmldsig-more#sha384",
       "http://www.w3.org/2001/04/xmlenc#sha512"
     ],
-    "defaultValue": "http://www.w3.org/2000/09/xmldsig#sha1"
+    "defaultValue": "http://www.w3.org/2001/04/xmlenc#sha256"
   },
   "assertionEncryptionAlgorithm": {
     "options": [

--- a/pom.xml
+++ b/pom.xml
@@ -2135,7 +2135,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>6.0.58</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.59</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
With the changing of usages of SHA1 in the product to SHA256, the default values returned in SAML metadata endpoint have changed. The integration tests data have been changed accordingly.