### PR TITLE
Include empty directories when copying extensions from P2 profile to IS directory.

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -176,6 +176,7 @@
             <outputDirectory>wso2is-${pom.version}/repository/resources/identity/extensions</outputDirectory>
             <includes>
                 <include>**/*.json</include>
+                <include>**/</include>
             </includes>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
### Purpose

When building the IS pack, the empty directory named `identity-verification-providers` should be included in the `IS_HOME/repository/resources/identity/extensions/` directory.

### Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/4693