### PR TITLE
Bump identity framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2135,7 +2135,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>6.0.62</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.63</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/4698

Released Tag
- https://github.com/wso2/carbon-identity-framework/releases/tag/v6.0.63