### PR TITLE
Upgrade dependency version of email OTP authenticator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2326,7 +2326,7 @@
         <authenticator.office365.version>2.1.2</authenticator.office365.version>
         <authenticator.smsotp.version>3.3.10</authenticator.smsotp.version>
         <authenticator.magiclink.version>1.1.8</authenticator.magiclink.version>
-        <authenticator.emailotp.version>4.1.11</authenticator.emailotp.version>
+        <authenticator.emailotp.version>4.1.12</authenticator.emailotp.version>
         <authenticator.twitter.version>1.1.1</authenticator.twitter.version>
         <authenticator.x509.version>3.1.10</authenticator.x509.version>
         <identity.extension.utils>1.0.14</identity.extension.utils>


### PR DESCRIPTION
### Purpose

This PR upgrades the component `org.wso2.carbon.identity.authenticator.emailotp.jar` from 4.1.11 to 4.1.12 to resolve the integration test run failure observed in https://github.com/wso2/product-is/actions/runs/5391741667.

Related PR - https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/158