### PR TITLE
[7.x.x] Change default cookie specs provider to RFC6265CookieSpecProvider

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/CrossProtocolLogoutTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/CrossProtocolLogoutTestCase.java
@@ -21,11 +21,17 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -65,6 +71,8 @@ import static org.wso2.identity.integration.test.utils.CommonConstants.DEFAULT_T
  */
 public class CrossProtocolLogoutTestCase extends ISIntegrationTest {
 
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private HttpClient client;
     private final String OIDC_APP_NAME = "playground2";
     private final String SAML_ISSUER = "travelocity.com";
@@ -93,7 +101,16 @@ public class CrossProtocolLogoutTestCase extends ISIntegrationTest {
         createServiceProvider();
         createSAMLApplication();
 
-        client = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
         SAML_SSO_URL = identityContextUrls.getWebAppURLHttps() + "/samlsso";
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/AbstractIdentityFederationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/AbstractIdentityFederationTestCase.java
@@ -23,11 +23,15 @@ import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
-import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
 import org.wso2.carbon.automation.extensions.servers.carbonserver.MultipleServersManager;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
@@ -286,7 +290,17 @@ public abstract class AbstractIdentityFederationTestCase extends ISIntegrationTe
 
     public HttpClient getNewHttpClientWithCookieStore() {
 
-        return HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieStore(new BasicCookieStore())
+                .build();
     }
 
     private String getSecureServiceUrl(int portOffset, String baseUrl) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2DeviceFlowTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2DeviceFlowTestCase.java
@@ -21,11 +21,17 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
@@ -71,14 +77,26 @@ public class OAuth2DeviceFlowTestCase extends OAuth2ServiceAbstractIntegrationTe
     private String appId;
     private String userCode;
     private String deviceCode;
-    private CloseableHttpClient client;
 
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
+    private CloseableHttpClient client;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
 
         super.init(TestUserMode.SUPER_TENANT_USER);
-        client = HttpClients.createDefault();
+
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
 
         setSystemproperties();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RequestObjectSignatureValidationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2RequestObjectSignatureValidationTestCase.java
@@ -27,10 +27,14 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.params.HttpClientParams;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -124,22 +128,25 @@ public class OAuth2RequestObjectSignatureValidationTestCase extends OAuth2Servic
             dependsOnMethods = "updateServiceProviderCert")
     public void sentAuthorizationGrantRequest() throws Exception {
 
-        HttpClient client = getRedirectDisabledClient();
-        HttpResponse response = sendGetRequest(client, getAuthzRequestUrl(consumerKey));
-        // If the request is valid it will return a 302 to redirect to the login page.
-        assertForLoginPage(response);
-        EntityUtils.consume(response.getEntity());
+        try (CloseableHttpClient client = getRedirectDisabledClient()) {
+            HttpResponse response = sendGetRequest(client, getAuthzRequestUrl(consumerKey));
+            // If the request is valid it will return a 302 to redirect to the login page.
+            assertForLoginPage(response);
+            EntityUtils.consume(response.getEntity());
+        }
     }
 
     @Test(groups = "wso2.is", description = "Check Initial OAuth2 Authorize Request with unsigned request object",
             dependsOnMethods = "sentAuthorizationGrantRequest")
     public void sendAuthorizationGrantRequestWithPlainJWTRequestObject() throws Exception {
 
-        HttpClient client = getRedirectDisabledClient();
-        String unsignedRequestObject = buildPlainJWT(consumerKey);
-        HttpResponse response = sendGetRequest(client, getAuthzRequestUrl(consumerKey, unsignedRequestObject));
-        assertForLoginPage(response);
-        EntityUtils.consume(response.getEntity());
+        try (CloseableHttpClient client = getRedirectDisabledClient()) {
+            String unsignedRequestObject = buildPlainJWT(consumerKey);
+            HttpResponse response =
+                    sendGetRequest(client, getAuthzRequestUrl(consumerKey, unsignedRequestObject));
+            assertForLoginPage(response);
+            EntityUtils.consume(response.getEntity());
+        }
     }
 
     @Test(groups = "wso2.is", description = "Check enabling option to enforce request object signature validation",
@@ -210,10 +217,19 @@ public class OAuth2RequestObjectSignatureValidationTestCase extends OAuth2Servic
         return location.getValue();
     }
 
-    private HttpClient getRedirectDisabledClient() {
-        HttpClient client = new DefaultHttpClient();
-        HttpClientParams.setRedirecting(client.getParams(), false);
-        return client;
+    private CloseableHttpClient getRedirectDisabledClient() {
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .disableRedirectHandling()
+                .build();
     }
 
     private String getAuthzRequestUrl(String clientId, String requestObject) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -24,11 +24,18 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
@@ -373,11 +380,20 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 		return response;
 	}
 
-	public HttpResponse sendConsentGetRequest(DefaultHttpClient client, String locationURL, CookieStore cookieStore,
+	public HttpResponse sendConsentGetRequest(CloseableHttpClient client, String locationURL, CookieStore cookieStore,
 											  List<NameValuePair> consentRequiredClaimsFromResponse) throws Exception {
 
-		HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create().disableRedirectHandling()
-																		.setDefaultCookieStore(cookieStore).build();
+		Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+				.register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+				.build();
+		RequestConfig requestConfig = RequestConfig.custom()
+				.setCookieSpec(CookieSpecs.DEFAULT)
+				.build();
+		HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create()
+				.setDefaultRequestConfig(requestConfig)
+				.setDefaultCookieSpecRegistry(cookieSpecRegistry)
+				.disableRedirectHandling()
+				.setDefaultCookieStore(cookieStore).build();
 		HttpGet getRequest = new HttpGet(locationURL);
 		getRequest.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
 		HttpResponse response = httpClientWithoutAutoRedirections.execute(getRequest);
@@ -385,7 +401,6 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 		consentRequiredClaimsFromResponse.addAll(Utils.getConsentRequiredClaimsFromResponse(response));
 		Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
 		HttpResponse httpResponse = sendGetRequest(httpClientWithoutAutoRedirections, locationHeader.getValue());
-		client.setCookieStore(cookieStore);
 		EntityUtils.consume(response.getEntity());
 		return httpResponse;
 	}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceImplicitGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceImplicitGrantTestCase.java
@@ -21,8 +21,14 @@ package org.wso2.identity.integration.test.oauth2;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -59,6 +65,8 @@ public class OAuth2ServiceImplicitGrantTestCase extends OAuth2ServiceAbstractInt
 	private String consumerKey;
 	private String consumerSecret;
 
+	private Lookup<CookieSpecProvider> cookieSpecRegistry;
+	private RequestConfig requestConfig;
 	private CloseableHttpClient client;
 	private final String username;
 	private final String userPassword;
@@ -86,7 +94,16 @@ public class OAuth2ServiceImplicitGrantTestCase extends OAuth2ServiceAbstractInt
 		tenantInfo = context.getContextTenant();
 
 		setSystemproperties();
-		client = HttpClientBuilder.create().build();
+		cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+				.register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+				.build();
+		requestConfig = RequestConfig.custom()
+				.setCookieSpec(CookieSpecs.DEFAULT)
+				.build();
+		client = HttpClientBuilder.create()
+				.setDefaultRequestConfig(requestConfig)
+				.setDefaultCookieSpecRegistry(cookieSpecRegistry)
+				.build();
 		scopes = "abc";
 	}
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceRegexCallbackUrlTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceRegexCallbackUrlTestCase.java
@@ -21,8 +21,14 @@ package org.wso2.identity.integration.test.oauth2;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -57,6 +63,8 @@ public class OAuth2ServiceRegexCallbackUrlTestCase extends OAuth2ServiceAbstract
 	private String consumerSecret;
 	private String applicationId;
 
+	private Lookup<CookieSpecProvider> cookieSpecRegistry;
+	private RequestConfig requestConfig;
 	private CloseableHttpClient client;
 
 	@BeforeClass(alwaysRun = true)
@@ -64,7 +72,17 @@ public class OAuth2ServiceRegexCallbackUrlTestCase extends OAuth2ServiceAbstract
 		super.init(TestUserMode.SUPER_TENANT_USER);
 
 		setSystemproperties();
-		client = HttpClientBuilder.create().build();
+
+		cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+				.register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+				.build();
+		requestConfig = RequestConfig.custom()
+				.setCookieSpec(CookieSpecs.DEFAULT)
+				.build();
+		client = HttpClientBuilder.create()
+				.setDefaultRequestConfig(requestConfig)
+				.setDefaultCookieSpecRegistry(cookieSpecRegistry)
+				.build();
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceSAML2BearerGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceSAML2BearerGrantTestCase.java
@@ -23,10 +23,16 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -83,6 +89,8 @@ public class OAuth2ServiceSAML2BearerGrantTestCase extends OAuth2ServiceAbstract
     private static final String SAML_SSO_URL = "https://localhost:9853/samlsso";
     private static final String ISSUER = "travelocity.com";
 
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private CloseableHttpClient client;
     private String samlAppId;
 
@@ -97,7 +105,16 @@ public class OAuth2ServiceSAML2BearerGrantTestCase extends OAuth2ServiceAbstract
         consumerKey = oidcConfig.getClientId();
         consumerSecret = oidcConfig.getClientSecret();
 
-        client = HttpClientBuilder.create().build();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
         log.info(String.format("Oauth app initialized with key: %s, secret: %s.", consumerKey, consumerSecret));
         samlAppId = application.getId();
     }
@@ -137,7 +154,10 @@ public class OAuth2ServiceSAML2BearerGrantTestCase extends OAuth2ServiceAbstract
     public void testSAML2BearerInvalidAudience() {
 
         try {
-            client = HttpClientBuilder.create().build();
+            client = HttpClientBuilder.create()
+                    .setDefaultRequestConfig(requestConfig)
+                    .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                    .build();
 
             SAML2ServiceProvider saml2AppConfig = getSAMLInboundDetailsOfApplication(samlAppId);
             Assert.assertNotNull(saml2AppConfig, "No service provider exists for issuer" + ISSUER);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationAfterAccountDisablingTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationAfterAccountDisablingTestCase.java
@@ -40,7 +40,13 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.json.simple.JSONObject;
 import org.testng.Assert;
@@ -107,6 +113,8 @@ public class OAuth2TokenRevocationAfterAccountDisablingTestCase extends OAuth2Se
     private final Map<String, AccessToken> accessTokens = new HashMap<>();
     private final Map<String, AccessToken> privilegedAccessTokens = new HashMap<>();
 
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private HttpClient client;
     private SCIM2RestClient scim2RestClient;
     private String userId;
@@ -144,7 +152,17 @@ public class OAuth2TokenRevocationAfterAccountDisablingTestCase extends OAuth2Se
         identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
 
         userId = addNewTestUser();
-        client = HttpClientBuilder.create().disableRedirectHandling().build();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithMultipleSessionTerminationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithMultipleSessionTerminationTestCase.java
@@ -26,10 +26,16 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
@@ -69,6 +75,8 @@ public class OAuth2TokenRevocationWithMultipleSessionTerminationTestCase extends
     private String consumerSecret;
     private String sessionDataKeyConsent;
     private String sessionDataKey;
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private  HttpClient httpClientForFirstSession;
     private  HttpClient httpClientForSecondSession;
     private static final String SESSION_API_ENDPOINT = "https://localhost:9853/t/carbon.super/api/users/v1/me/sessions";
@@ -80,8 +88,23 @@ public class OAuth2TokenRevocationWithMultipleSessionTerminationTestCase extends
         super.init();
         setSystemproperties();
         super.init(TestUserMode.SUPER_TENANT_USER);
-        httpClientForFirstSession = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
-        httpClientForSecondSession = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
+
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        httpClientForFirstSession = HttpClientBuilder.create()
+                .setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
+        httpClientForSecondSession = HttpClientBuilder.create()
+                .setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithSessionTerminationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationWithSessionTerminationTestCase.java
@@ -26,10 +26,16 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
@@ -68,6 +74,8 @@ public class OAuth2TokenRevocationWithSessionTerminationTestCase extends OAuth2S
     private String sessionDataKeyConsent;
     private String sessionDataKey;
     private String authorizationCode;
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private HttpClient client;
     private String accessToken;
     private List<String> sessionIdList;
@@ -84,7 +92,18 @@ public class OAuth2TokenRevocationWithSessionTerminationTestCase extends OAuth2S
         setSystemproperties();
         remoteUSMServiceClient.addUser(USERNAME, PASSWORD, new String[]{"admin"},
                 getUserClaims(), "default", true);
-        client = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
+
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OIDCMetadataTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OIDCMetadataTest.java
@@ -20,8 +20,14 @@ package org.wso2.identity.integration.test.oauth2;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.testng.Assert;
@@ -74,7 +80,16 @@ public class OIDCMetadataTest extends ISIntegrationTest {
 
     private void testResponseContent(String oidcMetadataEndpoint) throws IOException, JSONException {
 
-        HttpClient client = HttpClientBuilder.create().build();
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        HttpClient client = HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
         HttpResponse httpResponse = sendGetRequest(client, oidcMetadataEndpoint);
         String content = DataExtractUtil.getContentData(httpResponse);
         Assert.assertNotNull(content, "Response content is not received");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2HashAlgorithmTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2HashAlgorithmTestCase.java
@@ -18,7 +18,14 @@ package org.wso2.identity.integration.test.oauth2;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -55,7 +62,9 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
     private String authorizationCode;
     private String consumerKey;
     private String consumerSecret;
-    private DefaultHttpClient client;
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
+    private CloseableHttpClient client;
     private ServerConfigurationManager serverConfigurationManager;
 
     @BeforeClass(alwaysRun = true)
@@ -76,7 +85,16 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         logManger.login(isServer.getSuperTenant().getTenantAdmin().getUserName(),
                 isServer.getSuperTenant().getTenantAdmin().getPassword(),
                 isServer.getInstance().getHosts().get("default"));
-        client = new DefaultHttpClient();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build();
 
         setSystemproperties();
         registerAndDeployApplication();
@@ -91,6 +109,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         consumerKey = null;
         accessToken = null;
         serverConfigurationManager.restoreToLastConfiguration(false);
+        client.close();
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/consented/token/OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/consented/token/OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase.java
@@ -40,8 +40,14 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
@@ -251,8 +257,18 @@ public class OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTes
     private HttpResponse sendConsentGetRequest(String locationURL,
             List<NameValuePair> consentRequiredClaimsFromResponse) throws Exception {
 
-        HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create().disableRedirectHandling()
-                .setDefaultCookieStore(cookieStore).build();
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultCookieStore(cookieStore)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
         HttpGet getRequest = new HttpGet(locationURL);
         getRequest.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
         HttpResponse response = httpClientWithoutAutoRedirections.execute(getRequest);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/consented/token/OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/consented/token/OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest.java
@@ -36,9 +36,15 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
@@ -78,6 +84,8 @@ public class OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest extend
 
     protected CookieStore cookieStore = new BasicCookieStore();
 
+    protected Lookup<CookieSpecProvider> cookieSpecRegistry;
+    protected RequestConfig requestConfig;
     protected HttpClient client;
     protected String accessToken;
     protected String refreshToken;
@@ -85,7 +93,16 @@ public class OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest extend
     protected void initConsentedTokenTest() throws Exception {
 
         super.init(TestUserMode.SUPER_TENANT_ADMIN);
-        client = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultCookieStore(cookieStore).build();
     }
 
     protected void createUser() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCIdentityFederationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCIdentityFederationTestCase.java
@@ -23,12 +23,18 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.opensaml.xml.util.Base64;
@@ -121,6 +127,8 @@ public class OIDCIdentityFederationTestCase extends AbstractIdentityFederationTe
     private static final int PORT_OFFSET_1 = 1;
 
     CookieStore cookieStore;
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private CloseableHttpClient client;
 
     @DataProvider(name = "configProvider")
@@ -162,7 +170,17 @@ public class OIDCIdentityFederationTestCase extends AbstractIdentityFederationTe
         createServiceProviderInPrimaryIS();
 
         cookieStore = new BasicCookieStore();
-        client = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieStore(cookieStore)
+                .build();
 
         boolean userCreated = addUserToSecondaryIS();
         Assert.assertTrue(userCreated, "User creation failed in secondary IS.");
@@ -607,7 +625,10 @@ public class OIDCIdentityFederationTestCase extends AbstractIdentityFederationTe
 
     private String testAuthzCode(String authzResponseURL) throws Exception {
 
-        HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create().disableRedirectHandling()
+        HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
                 .setDefaultCookieStore(cookieStore).build();
 
         HttpResponse response = sendGetRequest(httpClientWithoutAutoRedirections, authzResponseURL);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/ChangeACSUrlTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/ChangeACSUrlTestCase.java
@@ -21,13 +21,19 @@ package org.wso2.identity.integration.test.saml;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -158,8 +164,17 @@ public class ChangeACSUrlTestCase extends AbstractIdentityFederationTestCase {
     @Test(groups = "wso2.is", description = "Check SAML To SAML fedaration flow")
     public void testChangeACSUrl() throws Exception {
 
-        try (CloseableHttpClient client =
-                     HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build()) {
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        try (CloseableHttpClient client = HttpClientBuilder.create()
+                             .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                             .setDefaultRequestConfig(requestConfig)
+                             .setDefaultCookieStore(new BasicCookieStore())
+                             .build()) {
             String sessionId = sendSAMLRequestToPrimaryIS(client);
             Assert.assertNotNull(sessionId, "Unable to acquire 'sessionDataKey' value");
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLFederationWithFileBasedSPAndIDPTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLFederationWithFileBasedSPAndIDPTestCase.java
@@ -22,11 +22,17 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -156,7 +162,7 @@ public class SAMLFederationWithFileBasedSPAndIDPTestCase extends AbstractIdentit
     @Test(groups = "wso2.is", dependsOnMethods = {"testCreateServiceProviderInSecondaryIS"}, description = "Check SAML To SAML fedaration flow")
     public void testSAMLToSAMLFederation() throws Exception {
 
-        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+        try (CloseableHttpClient client = getClosableHTTPClient()) {
             String sessionId = sendSAMLRequestToPrimaryIS(client);
             Assert.assertNotNull(sessionId, "Unable to acquire 'sessionDataKey' value");
 
@@ -485,4 +491,17 @@ public class SAMLFederationWithFileBasedSPAndIDPTestCase extends AbstractIdentit
         return String.format("https://localhost:%s/services/", DEFAULT_PORT + PORT_OFFSET_1);
     }
 
+    private CloseableHttpClient getClosableHTTPClient() {
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTS.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTS.java
@@ -5,12 +5,18 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -68,6 +74,8 @@ public class TestPassiveSTS extends ISIntegrationTest {
 
     private ApplicationManagementServiceClient appMgtClient;
     private ServiceProvider serviceProvider;
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
     private CloseableHttpClient client;
 
     @DataProvider(name = "configProvider")
@@ -96,7 +104,16 @@ public class TestPassiveSTS extends ISIntegrationTest {
 
         appMgtClient = new ApplicationManagementServiceClient(sessionCookie, backendURL, null);
 
-        client = HttpClientBuilder.create().setDefaultCookieStore(new BasicCookieStore()).build();
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieStore(new BasicCookieStore()).build();
         String isURL = backendURL.substring(0, backendURL.indexOf("services/"));
         this.passiveStsURL = isURL + "passivests";
 

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/HTTPCommonClient.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/HTTPCommonClient.java
@@ -20,15 +20,22 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -49,7 +56,16 @@ public class HTTPCommonClient {
 
     public HTTPCommonClient() {
 
-        this.client = HttpClients.createDefault();
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        this.client = HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
     }
 
     /**

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/ScenarioTestBase.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/ScenarioTestBase.java
@@ -21,9 +21,14 @@ package org.wso2.identity.scenarios.commons;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.commons.collections.MapUtils;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
@@ -125,8 +130,17 @@ public class ScenarioTestBase {
     }
 
     public CloseableHttpClient createHttpClient(int timeOutInSeconds) {
-        RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(timeOutInSeconds * 1000).build();
-        return HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(timeOutInSeconds * 1000)
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
     }
 
     public CloseableHttpClient createHttpClient() {


### PR DESCRIPTION
$Subject

### Purpose

- Httpclient used in Integration tests was not using RFC6265CookieSpecProvider as default cookie specs provider.
In order to upgrade tomcat-catalina > 9.0.68, we need to set `RFC6265CookieSpecProvider` as default cookie specs provider for httpclient used in intgration tests.
- Change deprecated `DefaultHttpClient` usage to `ClosableHttpClient`
- Setting `RFC6265CookieSpecProvider` as default cookie specs provider handles cookies from Tomcat's Legacy Cookie Processor as well, hence this change is backward compatible
- The tests have passed locally with and without tomcat-catalina changes.