### PR TITLE
Update integration tests to use REST APIs (II)

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -31,7 +31,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONArray;
@@ -683,8 +682,7 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 
 		updateApplication(appId, applicationPatch);
 	}
-
-
+	
 	/**
 	 * Convert a x509 certificate to pem format.
 	 *

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -25,12 +25,16 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
@@ -43,6 +47,7 @@ import org.wso2.identity.integration.common.clients.oauth.OauthAdminClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.*;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimConfiguration.DialectEnum;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -133,11 +138,35 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 		inboundProtocolsConfig.setOidc(oidcConfig);
 
 		application.setInboundProtocolConfiguration(inboundProtocolsConfig);
-		application.setName(OAuth2Constant.OAUTH_APPLICATION_NAME);
+		application.setName(SERVICE_PROVIDER_NAME);
+		application.setIsManagementApp(true);
+
+		application.setClaimConfiguration(setApplicationClaimConfig()); ;
 
 		String appId = addApplication(application);
 
 		return getApplication(appId);
+	}
+
+	ClaimConfiguration setApplicationClaimConfig() {
+
+		ClaimMappings emailClaim = new ClaimMappings().applicationClaim(EMAIL_CLAIM_URI);
+		emailClaim.setLocalClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(EMAIL_CLAIM_URI));
+		ClaimMappings countryClaim = new ClaimMappings().applicationClaim(COUNTRY_CLAIM_URI);
+		countryClaim.setLocalClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(COUNTRY_CLAIM_URI));
+
+		RequestedClaimConfiguration emailRequestedClaim = new RequestedClaimConfiguration();
+		emailRequestedClaim.setClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(EMAIL_CLAIM_URI));
+		RequestedClaimConfiguration countryRequestedClaim = new RequestedClaimConfiguration();
+		countryRequestedClaim.setClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(COUNTRY_CLAIM_URI));
+
+		ClaimConfiguration claimConfiguration = new ClaimConfiguration().dialect(DialectEnum.CUSTOM);
+		claimConfiguration.addClaimMappingsItem(emailClaim);
+		claimConfiguration.addClaimMappingsItem(countryClaim);
+		claimConfiguration.addRequestedClaimsItem(emailRequestedClaim);
+		claimConfiguration.addRequestedClaimsItem(countryRequestedClaim);
+
+		return claimConfiguration;
 	}
 
     /**
@@ -301,36 +330,44 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 		return appDtoResult;
 	}
 
+	public void UpdateApplicationClaimConfig(String appId) throws Exception {
 
-
-	public void UpdateApplicationClaimConfig() throws Exception {
-		ServiceProvider serviceProvider = appMgtclient.getApplication(SERVICE_PROVIDER_NAME);
-		ClaimConfig claimConfig = getClaimConfig();
-		serviceProvider.setClaimConfig(claimConfig);
-		appMgtclient.updateApplicationData(serviceProvider);
+		ApplicationPatchModel applicationPatch = new ApplicationPatchModel();
+		applicationPatch.setClaimConfiguration(getClaimConfigurations());
+		restClient.updateApplication(appId, applicationPatch);
 	}
 
-	private ClaimConfig getClaimConfig() {
-		ClaimConfig claimConfig = new ClaimConfig();
-		ClaimMapping emailClaimMapping = getClaimMapping(EMAIL_CLAIM_URI);
-		ClaimMapping givenNameClaimMapping = getClaimMapping(GIVEN_NAME_CLAIM_URI);
-		ClaimMapping countryClaimMapping = getClaimMapping(COUNTRY_CLAIM_URI);
-		ClaimMapping customClaimMapping1 = getClaimMapping(customClaimURI1);
-		ClaimMapping customClaimMapping2 = getClaimMapping(customClaimURI2);
-		claimConfig.setClaimMappings(new org.wso2.carbon.identity.application.common.model.xsd
-				.ClaimMapping[]{emailClaimMapping, givenNameClaimMapping, countryClaimMapping, customClaimMapping1,
-				customClaimMapping2});
-		return claimConfig;
+	private ClaimConfiguration getClaimConfigurations() {
+
+		ClaimConfiguration claimConfiguration = new ClaimConfiguration().dialect(DialectEnum.CUSTOM);
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(EMAIL_CLAIM_URI));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(EMAIL_CLAIM_URI));
+
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(GIVEN_NAME_CLAIM_URI));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(GIVEN_NAME_CLAIM_URI));
+
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(COUNTRY_CLAIM_URI));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(COUNTRY_CLAIM_URI));
+
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(customClaimURI1));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(customClaimURI1));
+
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(customClaimURI2));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(customClaimURI2));
+
+		return claimConfiguration;
 	}
 
-	private ClaimMapping getClaimMapping(String claimUri) {
-		Claim claim = new Claim();
-		claim.setClaimUri(claimUri);
-		ClaimMapping claimMapping = new ClaimMapping();
-		claimMapping.setRequested(true);
-		claimMapping.setLocalClaim(claim);
-		claimMapping.setRemoteClaim(claim);
-		return claimMapping;
+	private ClaimMappings getClaimMapping(String claimUri) {
+		ClaimMappings claim = new ClaimMappings().applicationClaim(claimUri);
+		claim.setLocalClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(claimUri));
+		return claim;
+	}
+
+	private RequestedClaimConfiguration getRequestedClaim(String claimUri) {
+		RequestedClaimConfiguration requestedClaim = new RequestedClaimConfiguration();
+		requestedClaim.setClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(claimUri));
+		return requestedClaim;
 	}
 
 	/**
@@ -705,6 +742,7 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 
 		application.setInboundProtocolConfiguration(inboundProtocolsConfig);
 		application.setName(OAuth2Constant.OAUTH_APPLICATION_NAME);
+		application.isManagementApp(true);
 
 		String appId = addApplication(application);
 
@@ -821,5 +859,22 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 			throw new Exception("Error occurred while getting the response.");
 		}
 		return json;
+	}
+
+	/**
+	 * Get public certificate from jwks endpoint.
+	 *
+	 * @param client HttpClient.
+	 * @param endPoint jwks endpoint.
+	 * @return String object of the certificate.
+	 * @throws Exception Exception
+	 */
+	public String getPublicCertificate(CloseableHttpClient client, String endPoint) throws Exception {
+		HttpGet request = new HttpGet(endPoint);
+		CloseableHttpResponse response = client.execute(request);
+
+		JSONParser parser = new JSONParser();
+		JSONObject json = (JSONObject) parser.parse(EntityUtils.toString(response.getEntity()));
+		return ((JSONArray) ((JSONObject)((JSONArray) json.get("keys")).get(0)).get("x5c")).get(0).toString();
 	}
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase.java
@@ -1,22 +1,23 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.identity.integration.test.oauth2;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -27,7 +28,7 @@ import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
+import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -36,17 +37,22 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.identity.claim.metadata.mgt.stub.ClaimMetadataManagementServiceClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.stub.dto.ExternalClaimDTO;
-import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
-import org.wso2.carbon.identity.oauth2.stub.dto.OAuth2TokenValidationRequestDTO;
-import org.wso2.carbon.identity.oauth2.stub.dto.OAuth2TokenValidationRequestDTO_OAuth2AccessToken;
-import org.wso2.carbon.identity.oauth2.stub.dto.OAuth2TokenValidationResponseDTO;
-import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
-import org.wso2.carbon.um.ws.api.stub.ClaimValue;
-import org.wso2.identity.integration.common.clients.claim.metadata.mgt.ClaimMetadataManagementServiceClient;
-import org.wso2.identity.integration.common.clients.oauth.Oauth2TokenValidationClient;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.challenge.v1.model.ServerChallengeModel.Questions;
+import org.wso2.identity.integration.test.rest.api.server.challenge.v1.model.UserChallengeAnswer;
+import org.wso2.identity.integration.test.rest.api.server.claim.management.v1.model.ExternalClaimReq;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ListObject;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
+import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionEnterprise;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.ChallengeQuestionsRestClient;
+import org.wso2.identity.integration.test.restclients.ClaimManagementRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -55,9 +61,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,13 +70,15 @@ import static org.wso2.identity.integration.test.utils.DataExtractUtil.KeyValue;
 
 public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    public static final String OIDC_CLAIM_DIALECT = "http://wso2.org/oidc/claim";
+    public static final String ENCODED_OIDC_CLAIM_DIALECT = "aHR0cDovL3dzbzIub3JnL29pZGMvY2xhaW0";
+    private static final String USERS_PATH = "users";
+    private static final String CHALLENGE_QUESTION_SET_ID1 = "challengeQuestion1";
+    private static final String CHALLENGE_QUESTION_SET_ID2 = "challengeQuestion2";
+    private static final String CHALLENGE_QUESTION_SET1_Q1 = "City where you were born ?";
+    private static final String CHALLENGE_QUESTION_SET2_Q1 = "Model of your first car ?";
+    private static final String LOCALE = "en_US";
     private ServerConfigurationManager serverConfigurationManager;
-    private Oauth2TokenValidationClient oAuth2TokenValidationClient;
-    private AuthenticatorClient logManger;
-    private ClaimMetadataManagementServiceClient claimMetadataManagementServiceClient;
 
-    private File defaultConfigFile;
     private String adminUsername;
     private String adminPassword;
     private String accessToken;
@@ -84,16 +90,12 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
     private String consumerSecret;
 
     private DefaultHttpClient client;
-    private List<NameValuePair> consentParameters = new ArrayList<>();
-    private CookieStore cookieStore = new BasicCookieStore();
-    private static final String emailClaimURI = "http://wso2.org/claims/emailaddress";
-    private static final String givenNameClaimURI = "http://wso2.org/claims/givenname";
-    private static final String countryClaimURI = "http://wso2.org/claims/country";
+    private final List<NameValuePair> consentParameters = new ArrayList<>();
+    private final CookieStore cookieStore = new BasicCookieStore();
     private static final String customClaimURI1 = "http://wso2.org/claims/challengeQuestion1";
     private static final String customClaimURI2 = "http://wso2.org/claims/challengeQuestion2";
     private static final String externalClaimURI1 = "externalClaim1";
     private static final String externalClaimURI2 = "externalClaim2";
-
     private static final String USER_EMAIL = "abcrqo@wso2.com";
     private static final String USERNAME = "authcodegrantreqobjuser";
     private static final String PASSWORD = "pass123";
@@ -109,6 +111,15 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
             "iOnsiZXNzZW50aWFsIjp0cnVlfSwiY3VzdG9tQ2xhaW0xIjp7ImVzc2VudGlhbCI6dHJ1ZX0sImFjciI6eyJ2YWx1ZXMiOlsidXJuOm1" +
             "hY2U6aW5jb21tb246aWFwOnNpbHZlciJdfX19LCJpc3MiOiJLUjFwS0x1Z2RSUTlCbmNsTTV0YUMzVjNHZjBhIiwiaWF0IjoxNTE2Nzg" +
             "zMjc4LCJqdGkiOiIxMDAzIn0=.";
+
+    private SCIM2RestClient scim2RestClient;
+    private ClaimManagementRestClient claimManagementRestClient;
+    private ChallengeQuestionsRestClient challengeQuestionsRestClient;
+
+    private String applicationId;
+    private String userId;
+    private String claimId1;
+    private String claimId2;
 
     @BeforeTest(alwaysRun = true)
     public void initConfiguration() throws Exception {
@@ -127,60 +138,65 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
     public void testInit() throws Exception {
         super.init(TestUserMode.SUPER_TENANT_USER);
 
-        logManger = new AuthenticatorClient(backendURL);
         adminUsername = userInfo.getUserName();
         adminPassword = userInfo.getPassword();
-        String sessionIndex = logManger.login(isServer.getSuperTenant().getTenantAdmin().getUserName(),
-                isServer.getSuperTenant().getTenantAdmin().getPassword(),
-                isServer.getInstance().getHosts().get("default"));
-        oAuth2TokenValidationClient = new Oauth2TokenValidationClient(backendURL, sessionIndex);
+
         client = new DefaultHttpClient();
         client.setCookieStore(cookieStore);
         setSystemproperties();
-        remoteUSMServiceClient.addUser(USERNAME, PASSWORD, new String[]{"admin"}, getUserClaims(), "default", true);
-        claimMetadataManagementServiceClient = new ClaimMetadataManagementServiceClient(backendURL,
-                sessionIndex);
-        addOIDCClaims(externalClaimURI1, customClaimURI1);
-        addOIDCClaims(externalClaimURI2, customClaimURI2);
+
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        challengeQuestionsRestClient = new ChallengeQuestionsRestClient(serverURL, tenantInfo);
+        claimManagementRestClient = new ClaimManagementRestClient(serverURL, tenantInfo);
+
+        addAdminUser();
+        claimId1 = addOIDCClaims(externalClaimURI1, customClaimURI1);
+        claimId2 = addOIDCClaims(externalClaimURI2, customClaimURI2);
 
     }
 
-    private void addOIDCClaims(String externalClaim, String localClaim) throws RemoteException, ClaimMetadataManagementServiceClaimMetadataException {
-        ExternalClaimDTO externalClaimDTO = new ExternalClaimDTO();
-        externalClaimDTO.setExternalClaimDialectURI(OIDC_CLAIM_DIALECT);
-        externalClaimDTO.setMappedLocalClaimURI(localClaim);
-        externalClaimDTO.setExternalClaimURI(externalClaim);
-        claimMetadataManagementServiceClient.addExternalClaim(externalClaimDTO);
+    private String addOIDCClaims(String externalClaim, String localClaim) throws Exception {
+        ExternalClaimReq externalClaimReq = new ExternalClaimReq();
+        externalClaimReq.setClaimURI(externalClaim);
+        externalClaimReq.setMappedLocalClaimURI(localClaim);
+        return claimManagementRestClient.addExternalClaim(ENCODED_OIDC_CLAIM_DIALECT, externalClaimReq);
     }
 
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
 
-        deleteApplication();
-        removeOAuthApplicationData();
+        deleteApp(applicationId);
         // Delete the added OIDC claims.
-        claimMetadataManagementServiceClient.removeExternalClaim(OIDC_CLAIM_DIALECT, externalClaimURI1);
-        claimMetadataManagementServiceClient.removeExternalClaim(OIDC_CLAIM_DIALECT, externalClaimURI2);
+        claimManagementRestClient.deleteExternalClaim(ENCODED_OIDC_CLAIM_DIALECT, claimId1);
+        claimManagementRestClient.deleteExternalClaim(ENCODED_OIDC_CLAIM_DIALECT, claimId2);
 
-        logManger = null;
         consumerKey = null;
         accessToken = null;
+
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        claimManagementRestClient.closeHttpClient();
+        challengeQuestionsRestClient.closeHttpClient();
+        client.close();
     }
 
     @Test(groups = "wso2.is", description = "Check Oauth2 application registration")
     public void testRegisterApplication() throws Exception {
-        OAuthConsumerAppDTO appDto = createApplication();
-        UpdateApplicationClaimConfig();
-        Assert.assertNotNull(appDto, "Application creation failed.");
 
-        consumerKey = appDto.getOauthConsumerKey();
+        ApplicationResponseModel application = addApplication();
+        Assert.assertNotNull(application, "OAuth App creation failed.");
+        applicationId = application.getId();
+        UpdateApplicationClaimConfig(applicationId);
+
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        consumerKey = oidcConfig.getClientId();
         Assert.assertNotNull(consumerKey, "Application creation failed.");
-        consumerSecret = appDto.getOauthConsumerSecret();
+        consumerSecret = oidcConfig.getClientSecret();
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request", dependsOnMethods = "testRegisterApplication")
     public void testSendAuthorozedPost() throws Exception {
-        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("grantType", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("consumerKey", consumerKey));
         urlParameters.add(new BasicNameValuePair("callbackurl", OAuth2Constant.CALLBACK_URL));
@@ -205,7 +221,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         Assert.assertNotNull(response,
                 "Authorization request failed. Authorized user response is null.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKey\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
@@ -226,7 +242,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
                 response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
         Assert.assertNotNull(locationHeader, "Login response header is null");
         response = sendConsentGetRequest(client, locationHeader.getValue(), cookieStore, consentParameters);
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKeyConsent\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractSessionConsentDataFromResponse(response,
@@ -252,14 +268,16 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         response = sendPostRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Get Activation response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("Authorization Code", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractTableRowDataFromResponse(response,
                         keyPositionMap);
         Assert.assertNotNull(response, "Authorization Code key value is invalid.");
 
-        authorizationCode = keyValues.get(0).getValue();
+        if (keyValues != null) {
+            authorizationCode = keyValues.get(0).getValue();
+        }
         Assert.assertNotNull(authorizationCode, "Authorization code is null.");
         EntityUtils.consume(response.getEntity());
     }
@@ -272,7 +290,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
 
         response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"accessToken\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractInputValueFromResponse(response,
@@ -285,7 +303,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
 
         response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
 
-        keyPositionMap = new HashMap<String, Integer>(1);
+        keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("id=\"loggedUser\"", 1);
         keyValues = DataExtractUtil.extractLabelValueFromResponse(response, keyPositionMap);
         Assert.assertNotNull(keyValues, "Access token Key value is null.");
@@ -302,7 +320,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
         Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"valid\"", 1);
 
         List<KeyValue> keyValues =
@@ -326,80 +344,46 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
 
         Object obj = JSONValue.parse(rd);
-        String email = ((org.json.simple.JSONObject) obj).get("email").toString();
-        String givenName = ((org.json.simple.JSONObject) obj).get("given_name").toString();
+        String email = ((JSONObject) obj).get("email").toString();
+        String givenName = ((JSONObject) obj).get("given_name").toString();
 
         EntityUtils.consume(response.getEntity());
         Assert.assertEquals(USER_EMAIL, email, "Incorrect email claim value");
         Assert.assertEquals(GIVEN_NAME, givenName, "Incorrect given_name claim value");
         // externalClaim1 and externalClaim2 are not included in the requested scopes.
-        Assert.assertNull(((org.json.simple.JSONObject) obj).get("externalClaim1"));
-        Assert.assertNull(((org.json.simple.JSONObject) obj).get("externalClaim2"));
+        Assert.assertNull(((JSONObject) obj).get("externalClaim1"));
+        Assert.assertNull(((JSONObject) obj).get("externalClaim2"));
     }
 
     @Test(groups = "wso2.is", description = "Validate Token Expiration Time",
             dependsOnMethods = "testValidateAccessToken")
     public void testValidateTokenExpirationTime() throws Exception {
-        OAuth2TokenValidationRequestDTO requestDTO = new OAuth2TokenValidationRequestDTO();
-        OAuth2TokenValidationRequestDTO_OAuth2AccessToken accessTokenDTO = new
-                OAuth2TokenValidationRequestDTO_OAuth2AccessToken();
-        accessTokenDTO.setIdentifier(accessToken);
-        accessTokenDTO.setTokenType("bearer");
-        requestDTO.setAccessToken(accessTokenDTO);
+        JSONObject tokenResponse = introspectToken();
+        
+        Assert.assertNotNull(tokenResponse.get("exp"), "'exp' value is not included");
+        long expValue = Long.parseLong(tokenResponse.get("exp").toString());
+        // ratio between these vales is normally 999, used 975 just to be in the safe side
+        Assert.assertTrue(System.currentTimeMillis() / expValue > 975, "'exp' time is not in milliseconds");
 
-        OAuth2TokenValidationResponseDTO responseDTO = oAuth2TokenValidationClient.validateToken(requestDTO);
-        Assert.assertNotNull(responseDTO != null && responseDTO.getAuthorizationContextToken() != null,
-                "received authorization context token is null");
-
-        if (responseDTO != null && responseDTO.getAuthorizationContextToken() != null) {
-            String tokenString = responseDTO.getAuthorizationContextToken().getTokenString();
-            Assert.assertNotNull(tokenString, "received token string is null");
-
-            String[] tokenElements = tokenString.split("\\.");
-            Assert.assertTrue(tokenElements.length > 1, "Invalid JWT token received");
-
-            JSONObject jwtJsonObject = new JSONObject(new String(Base64.decodeBase64(tokenElements[1])));
-            Assert.assertNotNull(jwtJsonObject.get("exp"), "'exp' value is not included");
-
-            long expValue = Long.valueOf(jwtJsonObject.get("exp").toString());
-            // ratio between these vales is normally 999, used 975 just to be in the safe side
-            Assert.assertTrue(System.currentTimeMillis() / expValue > 975, "'exp time is not in milliseconds'");
-        }
     }
 
     @Test(groups = "wso2.is", description = "Validate Authorization Context of jwt Token", dependsOnMethods =
-            "testGetAccessToken")
-    public void testAuthorizationContextValidateJwtToken() throws Exception {
-        String claimURI[] = {OAuth2Constant.WSO2_CLAIM_DIALECT_ROLE};
-        OAuth2TokenValidationRequestDTO requestDTO = new OAuth2TokenValidationRequestDTO();
-        OAuth2TokenValidationRequestDTO_OAuth2AccessToken accessTokenDTO = new
-                OAuth2TokenValidationRequestDTO_OAuth2AccessToken();
-        accessTokenDTO.setIdentifier(accessToken);
-        accessTokenDTO.setTokenType("bearer");
-        requestDTO.setAccessToken(accessTokenDTO);
-        requestDTO.setRequiredClaimURIs(claimURI);
+            "testValidateAccessToken")
+    public void testValidateTokenScope() throws Exception {
+        JSONObject tokenResponse = introspectToken();
+        Assert.assertTrue(tokenResponse.size() > 1, "Invalid JWT token received");
+        Assert.assertNotNull(tokenResponse.get("scope"), "'scope' is not included");
 
-        OAuth2TokenValidationResponseDTO responseDTO = oAuth2TokenValidationClient.validateToken(requestDTO);
-        if (responseDTO != null && responseDTO.getAuthorizationContextToken() != null) {
-            String tokenString = responseDTO.getAuthorizationContextToken().getTokenString();
-
-            String[] tokenElements = tokenString.split("\\.");
-            JSONObject jwtJsonObject = new JSONObject(new String(Base64.decodeBase64(tokenElements[1])));
-            String jwtClaimMappingRoleValues = jwtJsonObject.get(OAuth2Constant.WSO2_CLAIM_DIALECT_ROLE).toString();
-            Assert.assertTrue(jwtClaimMappingRoleValues.contains(","), "Broken JWT Token from Authorization context");
-
-            String[] jwtClaimMappingRoleElements = jwtClaimMappingRoleValues.replaceAll("[\\[\\]\"]", "").split(",");
-            List<String> jwtClaimMappingRoleElementsList = Arrays.asList(jwtClaimMappingRoleElements);
-            Assert.assertTrue(jwtClaimMappingRoleElementsList.contains("Internal/everyone"), "Invalid JWT Token Role " +
-                    "Values");
-        }
+        String scopes = tokenResponse.get("scope").toString();
+        Assert.assertTrue(scopes.contains("email"), "Invalid JWT Token scope Value");
+        Assert.assertTrue(scopes.contains("openid"), "Invalid JWT Token scope Value");
     }
 
     private void changeISConfiguration() throws Exception {
 
         log.info("Adding entity id of SSOService to deployment.toml file");
         String carbonHome = Utils.getResidentCarbonHome();
-        defaultConfigFile = getDeploymentTomlFile(carbonHome);
+        File defaultConfigFile = getDeploymentTomlFile(carbonHome);
         File configuredIdentityXML = new File(getISResourceLocation() + File.separator + "oauth"
                 + File.separator + "jwt-token-gen-enabled-identity.toml");
         serverConfigurationManager = new ServerConfigurationManager(isServer);
@@ -419,27 +403,42 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         urlParameters.add(new BasicNameValuePair("password", PASSWORD));
         urlParameters.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
 
-        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, OAuth2Constant.COMMON_AUTH_URL);
-
-        return response;
+        return sendPostRequestWithParameters(client, urlParameters, OAuth2Constant.COMMON_AUTH_URL);
     }
 
-    protected ClaimValue[] getUserClaims() {
-        ClaimValue[] claimValues = new ClaimValue[5];
-        claimValues[0] = getClaimValue(emailClaimURI, USER_EMAIL);
-        claimValues[1] = getClaimValue(givenNameClaimURI, GIVEN_NAME);
-        claimValues[2] = getClaimValue(countryClaimURI, COUNTRY);
-        claimValues[3] = getClaimValue(customClaimURI1, CUSTOM_CLAIM1);
-        claimValues[4] = getClaimValue(customClaimURI2, CUSTOM_CLAIM2);
-
-        return claimValues;
+    private JSONObject introspectToken() throws Exception {
+        String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+                OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+        return introspectTokenWithTenant(client, accessToken, introspectionUrl, adminUsername, adminPassword);
     }
 
-    private ClaimValue getClaimValue(String claimURL, String claimVal) {
-        ClaimValue claim = new ClaimValue();
-        claim.setClaimURI(claimURL);
-        claim.setValue(claimVal);
-        return claim;
+    private void addAdminUser() throws Exception {
+        UserObject userInfo = new UserObject();
+        userInfo.setUserName(USERNAME);
+        userInfo.setPassword(PASSWORD);
+        userInfo.setName(new Name().givenName(GIVEN_NAME));
+        userInfo.addEmail(new Email().value(USER_EMAIL));
+        userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().country(COUNTRY));
+
+        userId = scim2RestClient.createUser(userInfo);
+        String roleId = scim2RestClient.getRoleIdByName("admin");
+
+        RoleItemAddGroupobj patchRoleItem = new RoleItemAddGroupobj();
+        patchRoleItem.setOp(RoleItemAddGroupobj.OpEnum.ADD);
+        patchRoleItem.setPath(USERS_PATH);
+        patchRoleItem.addValue(new ListObject().value(userId));
+
+        scim2RestClient.updateUserRole(new PatchOperationRequestObject().addOperations(patchRoleItem), roleId);
+
+        setChallengeQuestion(CHALLENGE_QUESTION_SET_ID1, CHALLENGE_QUESTION_SET1_Q1, CUSTOM_CLAIM1);
+        setChallengeQuestion(CHALLENGE_QUESTION_SET_ID2, CHALLENGE_QUESTION_SET2_Q1, CUSTOM_CLAIM2);
     }
 
+    private void setChallengeQuestion(String questionSetId, String question, String answer) throws Exception {
+        UserChallengeAnswer  challengeQuestionObj = new UserChallengeAnswer();
+        challengeQuestionObj.setChallengeQuestion(new Questions(LOCALE, question, null));
+        challengeQuestionObj.setAnswer(answer);
+
+        challengeQuestionsRestClient.setChallengeQuestionAnswer(userId, questionSetId, challengeQuestionObj);
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdTestCase.java
@@ -1,22 +1,23 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2015, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.identity.integration.test.oauth2;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -27,7 +28,7 @@ import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
+import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -37,20 +38,14 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.automation.engine.context.beans.ContextUrls;
-import org.wso2.carbon.automation.engine.context.beans.Tenant;
-import org.wso2.carbon.automation.engine.context.beans.User;
-import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
-import org.wso2.carbon.identity.oauth2.stub.dto.OAuth2TokenValidationRequestDTO;
-import org.wso2.carbon.identity.oauth2.stub.dto.OAuth2TokenValidationRequestDTO_OAuth2AccessToken;
-import org.wso2.carbon.identity.oauth2.stub.dto.OAuth2TokenValidationResponseDTO;
-import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
-import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
-import org.wso2.carbon.um.ws.api.stub.ClaimValue;
-import org.wso2.identity.integration.common.clients.application.mgt.ApplicationManagementServiceClient;
-import org.wso2.identity.integration.common.clients.oauth.Oauth2TokenValidationClient;
-import org.wso2.identity.integration.common.clients.oauth.OauthAdminClient;
-import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ListObject;
+import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
+import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
@@ -58,7 +53,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,8 +62,6 @@ import static org.wso2.identity.integration.test.utils.OAuth2Constant.COMMON_AUT
 
 public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    private Oauth2TokenValidationClient oAuth2TokenValidationClient;
-    private AuthenticatorClient logManger;
     private String accessToken;
     private String sessionDataKeyConsent;
     private String sessionDataKey;
@@ -81,16 +73,18 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
 
     private DefaultHttpClient client;
 
-    private static final String emailClaimURI = "http://wso2.org/claims/emailaddress";
-
+    private static final String USERS_PATH = "users";
     private static final String USER_EMAIL = "abc@wso2.com";
     private static final String USERNAME = "authcodegrantuser";
     private static final String PASSWORD = "pass123";
 
-    private List<NameValuePair> consentParameters = new ArrayList<>();
-    private CookieStore cookieStore = new BasicCookieStore();
+    private final List<NameValuePair> consentParameters = new ArrayList<>();
+    private final CookieStore cookieStore = new BasicCookieStore();
     private final String username;
     private final String userPassword;
+    private String applicationId;
+    private String userId;
+    private SCIM2RestClient scim2RestClient;
 
     @DataProvider(name = "configProvider")
     public static Object[][] configProvider() {
@@ -100,6 +94,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
     @Factory(dataProvider = "configProvider")
     public OAuth2ServiceAuthCodeGrantOpenIdTestCase(TestUserMode userMode) throws Exception {
 
+        super.init(userMode);
         context = new AutomationContext("IDENTITY", userMode);
         this.username = context.getContextTenant().getTenantAdmin().getUserName();
         this.userPassword = context.getContextTenant().getTenantAdmin().getPassword();
@@ -108,47 +103,43 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
 
-        backendURL = context.getContextUrls().getBackEndUrl();
-        loginLogoutClient = new LoginLogoutClient(context);
-        logManger = new AuthenticatorClient(backendURL);
-        sessionCookie = logManger.login(username, userPassword, context.getInstance().getHosts().get("default"));
-        identityContextUrls = context.getContextUrls();
         tenantInfo = context.getContextTenant();
-        userInfo = tenantInfo.getContextUser();
-        appMgtclient = new ApplicationManagementServiceClient(sessionCookie, backendURL, null);
-        adminClient = new OauthAdminClient(backendURL, sessionCookie);
-        remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
-        oAuth2TokenValidationClient = new Oauth2TokenValidationClient(backendURL, sessionCookie);
+        scim2RestClient =  new SCIM2RestClient(serverURL, tenantInfo);
+
         client = new DefaultHttpClient();
         client.setCookieStore(cookieStore);
         setSystemproperties();
-        remoteUSMServiceClient.addUser(USERNAME, PASSWORD, new String[]{"admin"},
-                getUserClaims(), "default", true);
+        addAdminUser();
     }
 
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
-        deleteApplication();
-        removeOAuthApplicationData();
+        deleteApp(applicationId);
+        scim2RestClient.deleteUser(userId);
 
-        logManger = null;
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        client.close();
+
         consumerKey = null;
         accessToken = null;
     }
 
     @Test(groups = "wso2.is", description = "Check Oauth2 application registration")
     public void testRegisterApplication() throws Exception {
-        OAuthConsumerAppDTO appDto = createApplication();
-        Assert.assertNotNull(appDto, "Application creation failed.");
+        ApplicationResponseModel application = addApplication();
+        Assert.assertNotNull(application, "OAuth App creation failed.");
+        applicationId = application.getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
 
-        consumerKey = appDto.getOauthConsumerKey();
+        consumerKey = oidcConfig.getClientId();
         Assert.assertNotNull(consumerKey, "Application creation failed.");
-        consumerSecret = appDto.getOauthConsumerSecret();
+        consumerSecret = oidcConfig.getClientSecret();
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request", dependsOnMethods = "testRegisterApplication")
-    public void testSendAuthorozedPost() throws Exception {
-        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+    public void testSendAuthorizedPost() throws Exception {
+        List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("grantType", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("consumerKey", consumerKey));
         urlParameters.add(new BasicNameValuePair("callbackurl", OAuth2Constant.CALLBACK_URL));
@@ -172,7 +163,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
         Assert.assertNotNull(response,
                 "Authorization request failed. Authorized user response is null.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKey\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
@@ -183,7 +174,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
         EntityUtils.consume(response.getEntity());
     }
 
-    @Test(groups = "wso2.is", description = "Send login post request", dependsOnMethods = "testSendAuthorozedPost")
+    @Test(groups = "wso2.is", description = "Send login post request", dependsOnMethods = "testSendAuthorizedPost")
     public void testSendLoginPost() throws Exception {
         HttpResponse response = sendLoginPost(client, sessionDataKey);
         Assert.assertNotNull(response, "Login request failed. response is null.");
@@ -193,7 +184,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
         Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
         Assert.assertNotNull(locationHeader, "Login response header is null");
         response = sendConsentGetRequest(client, locationHeader.getValue(), cookieStore, consentParameters);
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKeyConsent\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractSessionConsentDataFromResponse(response,
@@ -219,14 +210,16 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
         response = sendPostRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Get Activation response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("Authorization Code", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractTableRowDataFromResponse(response,
                         keyPositionMap);
         Assert.assertNotNull(response, "Authorization Code key value is invalid.");
 
-        authorizationCode = keyValues.get(0).getValue();
+        if (keyValues != null) {
+            authorizationCode = keyValues.get(0).getValue();
+        }
         Assert.assertNotNull(authorizationCode, "Authorization code is null.");
         EntityUtils.consume(response.getEntity());
     }
@@ -239,7 +232,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
 
         response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"accessToken\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractInputValueFromResponse(response,
@@ -252,7 +245,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
 
         response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
 
-        keyPositionMap = new HashMap<String, Integer>(1);
+        keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("id=\"loggedUser\"", 1);
         keyValues = DataExtractUtil.extractLabelValueFromResponse(response, keyPositionMap);
         Assert.assertNotNull(keyValues, "Access token Key value is null.");
@@ -267,10 +260,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
     @Test(groups = "wso2.is", description = "Validate access token", dependsOnMethods = "testGetAccessToken")
     public void testValidateAccessToken() throws Exception {
 
-        String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
-                OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
-        org.json.simple.JSONObject responseObj = introspectTokenWithTenant(client, accessToken, introspectionUrl,
-                username, userPassword);
+        JSONObject responseObj = introspectToken();
         Assert.assertNotNull(responseObj, "Validate access token failed. response is invalid.");
         Assert.assertEquals(responseObj.get("active"), true, "Token Validation failed");
     }
@@ -299,59 +289,25 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
     @Test(groups = "wso2.is", description = "Validate Token Expiration Time",
             dependsOnMethods = "testValidateAccessToken")
     public void testValidateTokenExpirationTime() throws Exception {
-        OAuth2TokenValidationRequestDTO requestDTO = new OAuth2TokenValidationRequestDTO();
-        OAuth2TokenValidationRequestDTO_OAuth2AccessToken accessTokenDTO = new
-                OAuth2TokenValidationRequestDTO_OAuth2AccessToken();
-        accessTokenDTO.setIdentifier(accessToken);
-        accessTokenDTO.setTokenType("bearer");
-        requestDTO.setAccessToken(accessTokenDTO);
+        JSONObject tokenResponse = introspectToken();
 
-        OAuth2TokenValidationResponseDTO responseDTO = oAuth2TokenValidationClient.validateToken(requestDTO);
-        Assert.assertNotNull(responseDTO != null && responseDTO.getAuthorizationContextToken() != null,
-                "received authorization context token is null");
-
-        if (responseDTO != null && responseDTO.getAuthorizationContextToken() != null) {
-            String tokenString = responseDTO.getAuthorizationContextToken().getTokenString();
-            Assert.assertNotNull(tokenString, "received token string is null");
-
-            String[] tokenElements = tokenString.split("\\.");
-            Assert.assertTrue(tokenElements.length > 1, "Invalid JWT token received");
-
-            JSONObject jwtJsonObject = new JSONObject(new String(Base64.decodeBase64(tokenElements[1])));
-            Assert.assertNotNull(jwtJsonObject.get("exp"), "'exp' value is not included");
-
-            long expValue = Long.valueOf(jwtJsonObject.get("exp").toString());
-            // ratio between these vales is normally 999, used 975 just to be in the safe side
-            Assert.assertTrue(System.currentTimeMillis() / expValue > 975, "'exp time is not in milliseconds'");
-        }
+        Assert.assertNotNull(tokenResponse.get("exp"), "'exp' value is not included");
+        long expValue = Long.parseLong(tokenResponse.get("exp").toString());
+        // ratio between these vales is normally 999, used 975 just to be in the safe side
+        Assert.assertTrue(System.currentTimeMillis() / expValue > 975, "'exp time is not in milliseconds'");
     }
 
     @Test(groups = "wso2.is", description = "Validate Authorization Context of jwt Token", dependsOnMethods =
-            "testGetAccessToken")
-    public void testAuthorizationContextValidateJwtToken() throws Exception {
-        String claimURI[] = {OAuth2Constant.WSO2_CLAIM_DIALECT_ROLE};
-        OAuth2TokenValidationRequestDTO requestDTO = new OAuth2TokenValidationRequestDTO();
-        OAuth2TokenValidationRequestDTO_OAuth2AccessToken accessTokenDTO = new
-                OAuth2TokenValidationRequestDTO_OAuth2AccessToken();
-        accessTokenDTO.setIdentifier(accessToken);
-        accessTokenDTO.setTokenType("bearer");
-        requestDTO.setAccessToken(accessTokenDTO);
-        requestDTO.setRequiredClaimURIs(claimURI);
+            "testValidateAccessToken")
+    public void testValidateTokenScope() throws Exception {
+        JSONObject tokenResponse = introspectToken();
 
-        OAuth2TokenValidationResponseDTO responseDTO = oAuth2TokenValidationClient.validateToken(requestDTO);
-        if (responseDTO != null && responseDTO.getAuthorizationContextToken() != null) {
-            String tokenString = responseDTO.getAuthorizationContextToken().getTokenString();
+        Assert.assertTrue(tokenResponse.size() > 1, "Invalid JWT token received");
+        Assert.assertNotNull(tokenResponse.get("scope"), "'scope' is not included");
 
-            String[] tokenElements = tokenString.split("\\.");
-            JSONObject jwtJsonObject = new JSONObject(new String(Base64.decodeBase64(tokenElements[1])));
-            String jwtClaimMappingRoleValues = jwtJsonObject.get(OAuth2Constant.WSO2_CLAIM_DIALECT_ROLE).toString();
-            Assert.assertTrue(jwtClaimMappingRoleValues.contains(","), "Broken JWT Token from Authorization context");
-
-            String[] jwtClaimMappingRoleElements = jwtClaimMappingRoleValues.replaceAll("[\\[\\]\"]", "").split(",");
-            List<String> jwtClaimMappingRoleElementsList = Arrays.asList(jwtClaimMappingRoleElements);
-            Assert.assertTrue(jwtClaimMappingRoleElementsList.contains("Internal/everyone"), "Invalid JWT Token Role " +
-                    "Values");
-        }
+        String scopes = tokenResponse.get("scope").toString();
+        Assert.assertTrue(scopes.contains("email"), "Invalid JWT Token scope Value");
+        Assert.assertTrue(scopes.contains("openid"), "Invalid JWT Token scope Value");
     }
 
     public HttpResponse sendLoginPost(HttpClient client, String sessionDataKey) throws IOException {
@@ -360,19 +316,29 @@ public class OAuth2ServiceAuthCodeGrantOpenIdTestCase extends OAuth2ServiceAbstr
         urlParameters.add(new BasicNameValuePair("password", PASSWORD));
         urlParameters.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
 
-        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, COMMON_AUTH_URL);
-
-        return response;
+        return sendPostRequestWithParameters(client, urlParameters, COMMON_AUTH_URL);
     }
 
-    protected ClaimValue[] getUserClaims() {
-        ClaimValue[] claimValues = new ClaimValue[1];
+    private JSONObject introspectToken() throws Exception {
+        String introspectionUrl = tenantInfo.getDomain().equalsIgnoreCase("carbon.super") ?
+                OAuth2Constant.INTRO_SPEC_ENDPOINT : OAuth2Constant.TENANT_INTRO_SPEC_ENDPOINT;
+        return introspectTokenWithTenant(client, accessToken, introspectionUrl, username, userPassword);
+    }
 
-        ClaimValue email = new ClaimValue();
-        email.setClaimURI(emailClaimURI);
-        email.setValue(USER_EMAIL);
-        claimValues[0] = email;
+    private void addAdminUser() throws Exception {
+        UserObject userInfo = new UserObject();
+        userInfo.setUserName(USERNAME);
+        userInfo.setPassword(PASSWORD);
+        userInfo.addEmail(new Email().value(USER_EMAIL));
 
-        return claimValues;
+        userId = scim2RestClient.createUser(userInfo);
+        String roleId = scim2RestClient.getRoleIdByName("admin");
+
+        RoleItemAddGroupobj patchRoleItem = new RoleItemAddGroupobj();
+        patchRoleItem.setOp(RoleItemAddGroupobj.OpEnum.ADD);
+        patchRoleItem.setPath(USERS_PATH);
+        patchRoleItem.addValue(new ListObject().value(userId));
+
+        scim2RestClient.updateUserRole(new PatchOperationRequestObject().addOperations(patchRoleItem), roleId);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantTestCase.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2015, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -23,7 +23,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
@@ -34,8 +35,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
-import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
@@ -55,9 +56,6 @@ import static org.wso2.identity.integration.test.utils.OAuth2Constant.USER_AGENT
 
 public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    private AuthenticatorClient logManger;
-    private String adminUsername;
-    private String adminPassword;
     private String accessToken;
     private String sessionDataKeyConsent;
     private String sessionDataKey;
@@ -67,19 +65,14 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
 
     private static final String PLAYGROUND_RESET_PAGE = "http://localhost:" + CommonConstants.DEFAULT_TOMCAT_PORT +
             "/playground2/oauth2.jsp?reset=true";
-    private DefaultHttpClient client;
+    private CloseableHttpClient client;
+    private String applicationId;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
 
         super.init(TestUserMode.SUPER_TENANT_USER);
-        logManger = new AuthenticatorClient(backendURL);
-        adminUsername = userInfo.getUserName();
-        adminPassword = userInfo.getPassword();
-        logManger.login(isServer.getSuperTenant().getTenantAdmin().getUserName(),
-                isServer.getSuperTenant().getTenantAdmin().getPassword(),
-                isServer.getInstance().getHosts().get("default"));
-        client = new DefaultHttpClient();
+        client = HttpClients.createDefault();
 
         setSystemproperties();
     }
@@ -87,29 +80,30 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
 
-        this.logManger.logOut();
-        deleteApplication();
-        removeOAuthApplicationData();
-
+        deleteApp(applicationId);
+        restClient.closeHttpClient();
+        client.close();
     }
 
     @Test(groups = "wso2.is", description = "Check Oauth2 application registration")
     public void testRegisterApplication() throws Exception {
 
-        OAuthConsumerAppDTO appDto = createApplication();
-        Assert.assertNotNull(appDto, "Application creation failed.");
+        ApplicationResponseModel application = addApplication();
+        Assert.assertNotNull(application, "OAuth App creation failed.");
+        applicationId = application.getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
 
-        consumerKey = appDto.getOauthConsumerKey();
+        consumerKey = oidcConfig.getClientId();
         Assert.assertNotNull(consumerKey, "Application creation failed.");
 
-        consumerSecret = appDto.getOauthConsumerSecret();
+        consumerSecret = oidcConfig.getClientSecret();
         Assert.assertNotNull(consumerSecret, "Application creation failed.");
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request", dependsOnMethods = "testRegisterApplication")
     public void testSendAuthorizedPost() throws Exception {
 
-        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("grantType", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("consumerKey", consumerKey));
         urlParameters.add(new BasicNameValuePair("callbackurl", OAuth2Constant.CALLBACK_URL));
@@ -130,7 +124,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
         response = sendGetRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Authorized user response is null.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKey\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
@@ -164,7 +158,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
         response = sendGetRequest(client, locationHeader.getValue());
         // TODO: This fix is done to handle situations where consent page is skipped. Need to identify cause for this
         //  intermittent issue.
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(2);
+        Map<String, Integer> keyPositionMap = new HashMap<>(2);
         keyPositionMap.put("name=\"" + OAuth2Constant.SESSION_DATA_KEY_CONSENT + "\"", 1);
         keyPositionMap.put(AUTH_CODE_BODY_ELEMENT, 2);
         List<KeyValue> keyValues =
@@ -196,7 +190,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
         response = sendPostRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Get Activation response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put(AUTH_CODE_BODY_ELEMENT, 1);
         List<KeyValue> keyValues = DataExtractUtil.extractTableRowDataFromResponse(response, keyPositionMap);
         Assert.assertNotNull(keyValues, "Authorization Code key value is invalid.");
@@ -213,7 +207,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
         EntityUtils.consume(response.getEntity());
 
         response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"accessToken\"", 1);
         List<KeyValue> keyValues =
                 DataExtractUtil.extractInputValueFromResponse(response,
@@ -232,7 +226,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
         HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
         Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"valid\"", 1);
 
         List<KeyValue> keyValues =
@@ -302,7 +296,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
         response = sendGetRequest(client, locationHeader.getValue());
         // TODO: This fix is done to handle situations where consent page is skipped. Need to identify cause for this
         //  intermittent issue.
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(2);
+        Map<String, Integer> keyPositionMap = new HashMap<>(2);
         keyPositionMap.put("name=\"" + OAuth2Constant.SESSION_DATA_KEY_CONSENT + "\"", 1);
         keyPositionMap.put(AUTH_CODE_BODY_ELEMENT, 2);
         List<KeyValue> keyValues =
@@ -357,7 +351,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
             = "testInvalidAuthzCode")
     public void testSendAuthorozedPostForError() throws Exception {
 
-        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
         urlParameters.add(new BasicNameValuePair("redirect_uri", OAuth2Constant.CALLBACK_URL));
         AutomationContext automationContext = new AutomationContext("IDENTITY", TestUserMode.SUPER_TENANT_ADMIN);
@@ -374,7 +368,7 @@ public class OAuth2ServiceAuthCodeGrantTestCase extends OAuth2ServiceAbstractInt
             = "testSendAuthorozedPostForError")
     public void testInvalidRedirectUri() throws Exception {
 
-        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
         AutomationContext automationContext = new AutomationContext("IDENTITY", TestUserMode.SUPER_TENANT_ADMIN);
         String authorizeEndpoint = automationContext.getContextUrls().getBackEndUrl()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2HashAlgorithmTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2HashAlgorithmTestCase.java
@@ -1,24 +1,27 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.identity.integration.test.oauth2;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -26,9 +29,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
-import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -48,15 +50,14 @@ import static org.wso2.identity.integration.test.utils.OAuth2Constant.USER_AGENT
  */
 public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    private AuthenticatorClient logManger;
     private String accessToken;
     private String sessionDataKeyConsent;
     private String sessionDataKey;
-    private String authorizationCode;
     private String consumerKey;
     private String consumerSecret;
-    private DefaultHttpClient client;
+    private CloseableHttpClient client;
     private ServerConfigurationManager serverConfigurationManager;
+    private String applicationId;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -72,11 +73,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         serverConfigurationManager.applyConfigurationWithoutRestart(configuredTomlFile, defaultTomlFile, true);
         serverConfigurationManager.restartGracefully();
         super.init(TestUserMode.SUPER_TENANT_USER);
-        logManger = new AuthenticatorClient(backendURL);
-        logManger.login(isServer.getSuperTenant().getTenantAdmin().getUserName(),
-                isServer.getSuperTenant().getTenantAdmin().getPassword(),
-                isServer.getInstance().getHosts().get("default"));
-        client = new DefaultHttpClient();
+        client = HttpClients.createDefault();
 
         setSystemproperties();
         registerAndDeployApplication();
@@ -85,9 +82,9 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
 
-        deleteApplication();
-        removeOAuthApplicationData();
-        logManger = null;
+        deleteApp(applicationId);
+        restClient.closeHttpClient();
+        client.close();
         consumerKey = null;
         accessToken = null;
         serverConfigurationManager.restoreToLastConfiguration(false);
@@ -96,7 +93,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
     @Test(groups = "wso2.is", description = "Send authorize user request")
     public void testSendAuthorozedPost() throws Exception {
 
-        List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
+        List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("grantType", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("consumerKey", consumerKey));
         urlParameters.add(new BasicNameValuePair("callbackurl", OAuth2Constant.CALLBACK_URL));
@@ -117,7 +114,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         response = sendGetRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Authorized user response is null.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKey\"", 1);
         List<DataExtractUtil.KeyValue> keyValues =
                 DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
@@ -148,7 +145,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         EntityUtils.consume(response.getEntity());
 
         response = sendGetRequest(client, locationHeader.getValue());
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"" + OAuth2Constant.SESSION_DATA_KEY_CONSENT + "\"", 1);
         List<DataExtractUtil.KeyValue> keyValues =
                 DataExtractUtil.extractSessionConsentDataFromResponse(response,
@@ -174,13 +171,16 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         response = sendPostRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Get Activation response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("Authorization Code", 1);
         List<DataExtractUtil.KeyValue> keyValues =
                 DataExtractUtil.extractTableRowDataFromResponse(response,
                         keyPositionMap);
         Assert.assertNotNull(response, "Authorization Code key value is invalid.");
-        authorizationCode = keyValues.get(0).getValue();
+        String authorizationCode = null;
+        if (keyValues != null) {
+            authorizationCode = keyValues.get(0).getValue();
+        }
         Assert.assertNotNull(authorizationCode, "Authorization code is null.");
         EntityUtils.consume(response.getEntity());
 
@@ -194,7 +194,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         EntityUtils.consume(response.getEntity());
 
         response = sendPostRequest(client, OAuth2Constant.AUTHORIZED_URL);
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"accessToken\"", 1);
         List<DataExtractUtil.KeyValue> keyValues =
                 DataExtractUtil.extractInputValueFromResponse(response,
@@ -213,7 +213,7 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
         HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
         Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"valid\"", 1);
 
         List<DataExtractUtil.KeyValue> keyValues =
@@ -228,9 +228,10 @@ public class Oauth2HashAlgorithmTestCase extends OAuth2ServiceAbstractIntegratio
 
     private void registerAndDeployApplication() throws Exception {
 
-        OAuthConsumerAppDTO appDto = createApplication();
-        consumerKey = appDto.getOauthConsumerKey();
-        consumerSecret = appDto.getOauthConsumerSecret();
+        applicationId = addApplication().getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        consumerKey = oidcConfig.getClientId();
+        consumerSecret = oidcConfig.getClientSecret();
     }
 
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2PersistenceProcessorInsertTokenTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2PersistenceProcessorInsertTokenTestCase.java
@@ -1,24 +1,27 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.identity.integration.test.oauth2;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.testng.Assert;
@@ -26,9 +29,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.identity.oauth.stub.dto.OAuthConsumerAppDTO;
-import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -47,15 +49,14 @@ import static org.wso2.identity.integration.test.utils.OAuth2Constant.USER_AGENT
  */
 public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    private AuthenticatorClient logManger;
     private String accessToken;
     private String sessionDataKeyConsent;
     private String sessionDataKey;
-    private String authorizationCode;
     private String consumerKey;
     private String consumerSecret;
-    private DefaultHttpClient client;
+    private CloseableHttpClient client;
     private ServerConfigurationManager serverConfigurationManager;
+    private String applicationId;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -70,11 +71,7 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
         serverConfigurationManager.applyConfigurationWithoutRestart(configuredTomlFile, defaultTomlFile, true);
         serverConfigurationManager.restartForcefully();
         super.init(TestUserMode.SUPER_TENANT_ADMIN);
-        logManger = new AuthenticatorClient(backendURL);
-        logManger.login(isServer.getSuperTenant().getTenantAdmin().getUserName(),
-                isServer.getSuperTenant().getTenantAdmin().getPassword(),
-                isServer.getInstance().getHosts().get("default"));
-        client = new DefaultHttpClient();
+        client = HttpClients.createDefault();
 
         setSystemproperties();
         registerAndDeployApplication();
@@ -83,10 +80,10 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
 
-        deleteApplication();
-        removeOAuthApplicationData();
+        deleteApp(applicationId);
+        restClient.closeHttpClient();
+        client.close();
 
-        logManger = null;
         consumerKey = null;
         accessToken = null;
 
@@ -117,7 +114,7 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
         response = sendGetRequest(client, locationHeader.getValue());
         Assert.assertNotNull(response, "Authorized user response is null.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"sessionDataKey\"", 1);
         List<DataExtractUtil.KeyValue> keyValues =
                 DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
@@ -148,7 +145,7 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
         EntityUtils.consume(response.getEntity());
 
         response = sendGetRequest(client, locationHeader.getValue());
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"" + OAuth2Constant.SESSION_DATA_KEY_CONSENT + "\"", 1);
         List<DataExtractUtil.KeyValue> keyValues =
                 DataExtractUtil.extractSessionConsentDataFromResponse(response,
@@ -180,7 +177,10 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
                 DataExtractUtil.extractTableRowDataFromResponse(response,
                         keyPositionMap);
         Assert.assertNotNull(response, "Authorization Code key value is invalid.");
-        authorizationCode = keyValues.get(0).getValue();
+        String authorizationCode = null;
+        if (keyValues != null) {
+            authorizationCode = keyValues.get(0).getValue();
+        }
         Assert.assertNotNull(authorizationCode, "Authorization code is null.");
         EntityUtils.consume(response.getEntity());
 
@@ -213,7 +213,7 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
         HttpResponse response = sendValidateAccessTokenPost(client, accessToken);
         Assert.assertNotNull(response, "Validate access token response is invalid.");
 
-        Map<String, Integer> keyPositionMap = new HashMap<String, Integer>(1);
+        Map<String, Integer> keyPositionMap = new HashMap<>(1);
         keyPositionMap.put("name=\"valid\"", 1);
 
         List<DataExtractUtil.KeyValue> keyValues =
@@ -228,9 +228,10 @@ public class Oauth2PersistenceProcessorInsertTokenTestCase extends OAuth2Service
 
     private void registerAndDeployApplication() throws Exception {
 
-        OAuthConsumerAppDTO appDto = createApplication();
-        consumerKey = appDto.getOauthConsumerKey();
-        consumerSecret = appDto.getOauthConsumerSecret();
+        applicationId = addApplication().getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        consumerKey = oidcConfig.getClientId();
+        consumerSecret = oidcConfig.getClientSecret();
     }
 
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ApplicationModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ApplicationModel.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2019, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
 
@@ -31,6 +33,7 @@ public class ApplicationModel  {
     private String description;
     private String imageUrl;
     private String loginUrl;
+    private Boolean isManagementApp;
     private ClaimConfiguration claimConfiguration;
     private InboundProtocols inboundProtocolConfiguration;
     private AuthenticationSequence authenticationSequence;
@@ -127,6 +130,24 @@ public class ApplicationModel  {
     }
     public void setLoginUrl(String loginUrl) {
         this.loginUrl = loginUrl;
+    }
+
+    /**
+     **/
+    public ApplicationModel isManagementApp(Boolean isManagementApp) {
+
+        this.isManagementApp = isManagementApp;
+        return this;
+    }
+
+    @ApiModelProperty(example = "false")
+    @JsonProperty("isManagementApp")
+    @Valid
+    public Boolean getIsManagementApp() {
+        return isManagementApp;
+    }
+    public void setIsManagementApp(Boolean isManagementApp) {
+        this.isManagementApp = isManagementApp;
     }
 
     /**
@@ -236,6 +257,7 @@ public class ApplicationModel  {
             Objects.equals(this.description, applicationModel.description) &&
             Objects.equals(this.imageUrl, applicationModel.imageUrl) &&
             Objects.equals(this.loginUrl, applicationModel.loginUrl) &&
+            Objects.equals(this.isManagementApp, applicationModel.isManagementApp) &&
             Objects.equals(this.claimConfiguration, applicationModel.claimConfiguration) &&
             Objects.equals(this.inboundProtocolConfiguration, applicationModel.inboundProtocolConfiguration) &&
             Objects.equals(this.authenticationSequence, applicationModel.authenticationSequence) &&
@@ -245,7 +267,8 @@ public class ApplicationModel  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, imageUrl, loginUrl, claimConfiguration, inboundProtocolConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations);
+        return Objects.hash(id, name, description, imageUrl, loginUrl, isManagementApp, claimConfiguration,
+                inboundProtocolConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations);
     }
 
     @Override
@@ -259,6 +282,7 @@ public class ApplicationModel  {
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    imageUrl: ").append(toIndentedString(imageUrl)).append("\n");
         sb.append("    loginUrl: ").append(toIndentedString(loginUrl)).append("\n");
+        sb.append("    isManagementApp: ").append(toIndentedString(isManagementApp)).append("\n");
         sb.append("    claimConfiguration: ").append(toIndentedString(claimConfiguration)).append("\n");
         sb.append("    inboundProtocolConfiguration: ").append(toIndentedString(inboundProtocolConfiguration)).append("\n");
         sb.append("    authenticationSequence: ").append(toIndentedString(authenticationSequence)).append("\n");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ClaimMappings.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ClaimMappings.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2019, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
 
@@ -24,43 +26,43 @@ import javax.validation.Valid;
 
 public class ClaimMappings  {
   
-    private String applicationClaimUri;
-    private String localClaimUri;
+    private String applicationClaim;
+    private Claim localClaim;
 
     /**
     **/
-    public ClaimMappings applicationClaimUri(String applicationClaimUri) {
+    public ClaimMappings applicationClaim(String applicationClaim) {
 
-        this.applicationClaimUri = applicationClaimUri;
+        this.applicationClaim = applicationClaim;
         return this;
     }
     
-    @ApiModelProperty(example = "firstname", value = "")
-    @JsonProperty("applicationClaimUri")
+    @ApiModelProperty(example = "firstname")
+    @JsonProperty("applicationClaim")
     @Valid
-    public String getApplicationClaimUri() {
-        return applicationClaimUri;
+    public String getApplicationClaim() {
+        return applicationClaim;
     }
-    public void setApplicationClaimUri(String applicationClaimUri) {
-        this.applicationClaimUri = applicationClaimUri;
+    public void setApplicationClaim(String applicationClaim) {
+        this.applicationClaim = applicationClaim;
     }
 
     /**
     **/
-    public ClaimMappings localClaimUri(String localClaimUri) {
+    public ClaimMappings localClaim(Claim localClaim) {
 
-        this.localClaimUri = localClaimUri;
+        this.localClaim = localClaim;
         return this;
     }
     
-    @ApiModelProperty(example = "http://wso2.org/claims/givenname", value = "")
-    @JsonProperty("localClaimUri")
+    @ApiModelProperty(example = "http://wso2.org/claims/givenname")
+    @JsonProperty("localClaim")
     @Valid
-    public String getLocalClaimUri() {
-        return localClaimUri;
+    public Claim getLocalClaim() {
+        return localClaim;
     }
-    public void setLocalClaimUri(String localClaimUri) {
-        this.localClaimUri = localClaimUri;
+    public void setLocalClaim(Claim localClaim) {
+        this.localClaim = localClaim;
     }
 
 
@@ -75,25 +77,22 @@ public class ClaimMappings  {
             return false;
         }
         ClaimMappings claimMappings = (ClaimMappings) o;
-        return Objects.equals(this.applicationClaimUri, claimMappings.applicationClaimUri) &&
-            Objects.equals(this.localClaimUri, claimMappings.localClaimUri);
+        return Objects.equals(this.applicationClaim, claimMappings.applicationClaim) &&
+            Objects.equals(this.localClaim, claimMappings.localClaim);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(applicationClaimUri, localClaimUri);
+        return Objects.hash(applicationClaim, localClaim);
     }
 
     @Override
     public String toString() {
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("class ClaimMappings {\n");
-
-        sb.append("    applicationClaimUri: ").append(toIndentedString(applicationClaimUri)).append("\n");
-        sb.append("    localClaimUri: ").append(toIndentedString(localClaimUri)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        return "class ClaimMappings {\n" +
+                "    applicationClaim: " + toIndentedString(applicationClaim) + "\n" +
+                "    localClaim: " + toIndentedString(localClaim) + "\n" +
+                "}";
     }
 
     /**
@@ -105,7 +104,7 @@ public class ClaimMappings  {
         if (o == null) {
             return "null";
         }
-        return o.toString().replace("\n", "\n");
+        return o.toString();
     }
 }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/RequestedClaimConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/RequestedClaimConfiguration.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2019, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
 
@@ -24,26 +26,26 @@ import javax.validation.Valid;
 
 public class RequestedClaimConfiguration  {
   
-    private String claimUri;
-    private Boolean mandatory;
+    private Claim claim;
+    private Boolean mandatory = false;
 
     /**
     * User claims that need to be sent back to the application. If the claim mappings are local, use local claim uris. If the custom claim mappings are configured, use the mapped applicationClaimUri
     **/
-    public RequestedClaimConfiguration claimUri(String claimUri) {
+    public RequestedClaimConfiguration claim(Claim claim) {
 
-        this.claimUri = claimUri;
+        this.claim = claim;
         return this;
     }
     
     @ApiModelProperty(example = "http://wso2.org/claims/givenname", value = "User claims that need to be sent back to the application. If the claim mappings are local, use local claim uris. If the custom claim mappings are configured, use the mapped applicationClaimUri")
-    @JsonProperty("claimUri")
+    @JsonProperty("claim")
     @Valid
-    public String getClaimUri() {
-        return claimUri;
+    public Claim getClaim() {
+        return claim;
     }
-    public void setClaimUri(String claimUri) {
-        this.claimUri = claimUri;
+    public void setClaim(Claim claim) {
+        this.claim = claim;
     }
 
     /**
@@ -76,13 +78,13 @@ public class RequestedClaimConfiguration  {
             return false;
         }
         RequestedClaimConfiguration requestedClaimConfiguration = (RequestedClaimConfiguration) o;
-        return Objects.equals(this.claimUri, requestedClaimConfiguration.claimUri) &&
+        return Objects.equals(this.claim, requestedClaimConfiguration.claim) &&
             Objects.equals(this.mandatory, requestedClaimConfiguration.mandatory);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(claimUri, mandatory);
+        return Objects.hash(claim, mandatory);
     }
 
     @Override
@@ -91,7 +93,7 @@ public class RequestedClaimConfiguration  {
         StringBuilder sb = new StringBuilder();
         sb.append("class RequestedClaimConfiguration {\n");
 
-        sb.append("    claimUri: ").append(toIndentedString(claimUri)).append("\n");
+        sb.append("    claim: ").append(toIndentedString(claim)).append("\n");
         sb.append("    mandatory: ").append(toIndentedString(mandatory)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/challenge/v1/model/UserChallengeAnswer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/challenge/v1/model/UserChallengeAnswer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.challenge.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.identity.integration.test.rest.api.server.challenge.v1.model.ServerChallengeModel.Questions;
+
+import javax.validation.Valid;
+import java.util.Objects;
+
+public class UserChallengeAnswer {
+    private Questions challengeQuestion;
+    private String answer;
+
+    /**
+     *
+     **/
+    public UserChallengeAnswer challengeQuestion(Questions challengeQuestion) {
+
+        this.challengeQuestion = challengeQuestion;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("challengeQuestion")
+    @Valid
+    public Questions getChallengeQuestion() {
+        return challengeQuestion;
+    }
+
+    public void setChallengeQuestion(Questions challengeQuestion) {
+        this.challengeQuestion = challengeQuestion;
+    }
+
+    /**
+     *
+     **/
+    public UserChallengeAnswer answer(String answer) {
+
+        this.answer = answer;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Colombo")
+    @JsonProperty("answer")
+    @Valid
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserChallengeAnswer userChallengeAnswer = (UserChallengeAnswer) o;
+        return Objects.equals(this.challengeQuestion, userChallengeAnswer.challengeQuestion) &&
+                Objects.equals(this.answer, userChallengeAnswer.answer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(challengeQuestion, answer);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class UserChallengeAnswer {\n" +
+                "    challengeQuestion: " + toIndentedString(challengeQuestion) + "\n" +
+                "    answer: " + toIndentedString(answer) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/ExternalClaimReq.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/ExternalClaimReq.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.claim.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.Objects;
+
+public class ExternalClaimReq {
+
+    private String claimURI;
+    private String mappedLocalClaimURI;
+
+    /**
+     **/
+    public ExternalClaimReq claimURI(String claimURI) {
+
+        this.claimURI = claimURI;
+        return this;
+    }
+
+    @ApiModelProperty(example = "http://updateddummy.org/claim/emailaddress")
+    @JsonProperty("claimURI")
+    @Valid
+    public String getClaimURI() {
+        return claimURI;
+    }
+    public void setClaimURI(String claimURI) {
+        this.claimURI = claimURI;
+    }
+
+    /**
+     **/
+    public ExternalClaimReq mappedLocalClaimURI(String mappedLocalClaimURI) {
+
+        this.mappedLocalClaimURI = mappedLocalClaimURI;
+        return this;
+    }
+
+    @ApiModelProperty(example = "http://wso2.org/claims/emailaddress")
+    @JsonProperty("mappedLocalClaimURI")
+    @Valid
+    public String getMappedLocalClaimURI() {
+        return mappedLocalClaimURI;
+    }
+    public void setMappedLocalClaimURI(String mappedLocalClaimURI) {
+        this.mappedLocalClaimURI = mappedLocalClaimURI;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExternalClaimReq externalClaimReq = (ExternalClaimReq) o;
+        return Objects.equals(this.claimURI, externalClaimReq.claimURI) &&
+                Objects.equals(this.mappedLocalClaimURI, externalClaimReq.mappedLocalClaimURI);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(claimURI, mappedLocalClaimURI);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ExternalClaimReq {\n" +
+                "    claimURI: " + toIndentedString(claimURI) + "\n" +
+                "    mappedLocalClaimURI: " + toIndentedString(mappedLocalClaimURI) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Claims.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Claims.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Claims {
+    private Claim userIdClaim;
+    private Claim roleClaim;
+    private List<ClaimMapping> mappings;
+    private List<ProvisioningClaim> provisioningClaims;
+
+    /**
+     *
+     **/
+    public Claims userIdClaim(Claim userIdClaim) {
+
+        this.userIdClaim = userIdClaim;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("userIdClaim")
+    @Valid
+    public Claim getUserIdClaim() {
+        return userIdClaim;
+    }
+
+    public void setUserIdClaim(Claim userIdClaim) {
+        this.userIdClaim = userIdClaim;
+    }
+
+    /**
+     *
+     **/
+    public Claims roleClaim(Claim roleClaim) {
+
+        this.roleClaim = roleClaim;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("roleClaim")
+    @Valid
+    public Claim getRoleClaim() {
+        return roleClaim;
+    }
+
+    public void setRoleClaim(Claim roleClaim) {
+        this.roleClaim = roleClaim;
+    }
+
+    /**
+     *
+     **/
+    public Claims mappings(List<ClaimMapping> mappings) {
+
+        this.mappings = mappings;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("mappings")
+    @Valid
+    public List<ClaimMapping> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(List<ClaimMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    public Claims addMappings(ClaimMapping mapping) {
+        if (this.mappings == null) {
+            this.mappings = new ArrayList<>();
+        }
+        this.mappings.add(mapping);
+        return this;
+    }
+
+    /**
+     *
+     **/
+    public Claims provisioningClaims(List<ProvisioningClaim> provisioningClaims) {
+
+        this.provisioningClaims = provisioningClaims;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("provisioningClaims")
+    @Valid
+    public List<ProvisioningClaim> getProvisioningClaims() {
+        return provisioningClaims;
+    }
+
+    public void setProvisioningClaims(List<ProvisioningClaim> provisioningClaims) {
+        this.provisioningClaims = provisioningClaims;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Claims claims = (Claims) o;
+        return  Objects.equals(this.userIdClaim, claims.userIdClaim) &&
+                Objects.equals(this.roleClaim, claims.roleClaim) &&
+                Objects.equals(this.mappings, claims.mappings) &&
+                Objects.equals(this.provisioningClaims, claims.provisioningClaims);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userIdClaim, roleClaim, mappings, provisioningClaims);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class Claims {\n" +
+                "    userIdClaim: " + toIndentedString(userIdClaim) + "\n" +
+                "    roleClaim: " + toIndentedString(roleClaim) + "\n" +
+                "    mappings: " + toIndentedString(mappings) + "\n" +
+                "    provisioningClaims: " + toIndentedString(provisioningClaims) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private static String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+
+    public static class ClaimMapping {
+        private String idpClaim;
+        private Claim localClaim;
+
+        /**
+         *
+         **/
+        public ClaimMapping idpClaim(String idpClaim) {
+
+            this.idpClaim = idpClaim;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("idpClaim")
+        @Valid
+        public String getIdpClaim() {
+            return idpClaim;
+        }
+
+        public void setIdpClaim(String idpClaim) {
+            this.idpClaim = idpClaim;
+        }
+
+        /**
+         *
+         **/
+        public ClaimMapping localClaim(Claim localClaim) {
+
+            this.localClaim = localClaim;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("localClaim")
+        @Valid
+        public Claim getLocalClaim() {
+            return localClaim;
+        }
+
+        public void setLocalClaim(Claim localClaim) {
+            this.localClaim = localClaim;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ClaimMapping claimMapping = (ClaimMapping) o;
+            return Objects.equals(this.idpClaim, claimMapping.idpClaim) &&
+                    Objects.equals(this.localClaim, claimMapping.localClaim);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(idpClaim, localClaim);
+        }
+
+        @Override
+        public String toString() {
+
+            return "class ClaimMapping {\n" +
+                    "    idpClaim: " + toIndentedString(idpClaim) + "\n" +
+                    "    localClaim: " + toIndentedString(localClaim) + "\n" +
+                    "}";
+        }
+
+        /**
+         * Convert the given object to string with each line indented by 4 spaces
+         * (except the first line).
+         */
+        private String toIndentedString(java.lang.Object o) {
+
+            if (o == null) {
+                return "null";
+            }
+            return o.toString();
+        }
+    }
+
+    public static class ProvisioningClaim {
+        private Claim claim;
+        private String defaultValue;
+
+        /**
+         *
+         **/
+        public ProvisioningClaim claim(Claim claim) {
+
+            this.claim = claim;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("claim")
+        @Valid
+        public Claim getClaim() {
+            return claim;
+        }
+
+        public void setClaim(Claim claim) {
+            this.claim = claim;
+        }
+
+        /**
+         *
+         **/
+        public ProvisioningClaim defaultValue(String defaultValue) {
+
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("defaultValue")
+        @Valid
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ProvisioningClaim provisioningClaim = (ProvisioningClaim) o;
+            return Objects.equals(this.claim, provisioningClaim.claim) &&
+                    Objects.equals(this.defaultValue, provisioningClaim.defaultValue);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(claim, defaultValue);
+        }
+
+        @Override
+        public String toString() {
+
+            return "class ProvisioningClaim {\n" +
+                    "    claim: " + toIndentedString(claim) + "\n" +
+                    "    defaultValue: " + toIndentedString(defaultValue) + "\n" +
+                    "}";
+        }
+
+        /**
+         * Convert the given object to string with each line indented by 4 spaces
+         * (except the first line).
+         */
+        private String toIndentedString(java.lang.Object o) {
+
+            if (o == null) {
+                return "null";
+            }
+            return o.toString();
+        }
+    }
+
+    public static class Claim {
+        private String id;
+        private String uri;
+        private String displayName;
+
+        /**
+         *
+         **/
+        public Claim id(String id) {
+
+            this.id = id;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("id")
+        @Valid
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        /**
+         *
+         **/
+        public Claim uri(String uri) {
+
+            this.uri = uri;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("uri")
+        @Valid
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        /**
+         *
+         **/
+        public Claim displayName(String displayName) {
+
+            this.displayName = displayName;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("displayName")
+        @Valid
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public void setDisplayName(String displayName) {
+            this.displayName = displayName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Claim claim = (Claim) o;
+            return Objects.equals(this.id, claim.id) &&
+                    Objects.equals(this.uri, claim.uri) &&
+                    Objects.equals(this.displayName, claim.displayName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, uri, displayName);
+        }
+
+        @Override
+        public String toString() {
+
+            return "class Claim {\n" +
+                    "    id: " + toIndentedString(id) + "\n" +
+                    "    uri: " + toIndentedString(uri) + "\n" +
+                    "    displayName: " + toIndentedString(displayName) + "\n" +
+                    "}";
+        }
+
+        /**
+         * Convert the given object to string with each line indented by 4 spaces
+         * (except the first line).
+         */
+        private String toIndentedString(java.lang.Object o) {
+
+            if (o == null) {
+                return "null";
+            }
+            return o.toString();
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/FederatedAuthenticatorRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/FederatedAuthenticatorRequest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Objects;
+
+public class FederatedAuthenticatorRequest {
+    private String defaultAuthenticatorId;
+    private List<FederatedAuthenticator> authenticators;
+
+    /**
+     *
+     **/
+    public FederatedAuthenticatorRequest defaultAuthenticatorId(String defaultAuthenticatorId) {
+
+        this.defaultAuthenticatorId = defaultAuthenticatorId;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("defaultAuthenticatorId")
+    @Valid
+    public String getDefaultAuthenticatorId() {
+        return defaultAuthenticatorId;
+    }
+
+    public void setDefaultAuthenticatorId(String defaultAuthenticatorId) {
+        this.defaultAuthenticatorId = defaultAuthenticatorId;
+    }
+
+    /**
+     *
+     **/
+    public FederatedAuthenticatorRequest authenticators(List<FederatedAuthenticator> authenticators) {
+
+        this.authenticators = authenticators;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("authenticators")
+    @Valid
+    public List<FederatedAuthenticator> getAuthenticators() {
+        return authenticators;
+    }
+
+    public void setAuthenticators(List<FederatedAuthenticator> authenticators) {
+        this.authenticators = authenticators;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FederatedAuthenticatorRequest federatedAuthenticatorRequest = (FederatedAuthenticatorRequest) o;
+        return Objects.equals(this.defaultAuthenticatorId, federatedAuthenticatorRequest.defaultAuthenticatorId) &&
+                Objects.equals(this.authenticators, federatedAuthenticatorRequest.authenticators);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultAuthenticatorId, authenticators);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class FederatedAuthenticatorRequest {\n" +
+                "    defaultAuthenticatorId: " + toIndentedString(defaultAuthenticatorId) + "\n" +
+                "    authenticators: " + toIndentedString(authenticators) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private static String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+
+    public static class FederatedAuthenticator {
+        private String authenticatorId;
+        private String name;
+        private Boolean isEnabled = false;
+        private Boolean isDefault = false;
+        private List<Property> properties = null;
+
+        /**
+         *
+         **/
+        public FederatedAuthenticator authenticatorId(String authenticatorId) {
+
+            this.authenticatorId = authenticatorId;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("authenticatorId")
+        @Valid
+        public String getAuthenticatorId() {
+            return authenticatorId;
+        }
+
+        public void setAuthenticatorId(String authenticatorId) {
+            this.authenticatorId = authenticatorId;
+        }
+
+        /**
+         *
+         **/
+        public FederatedAuthenticator name(String name) {
+
+            this.name = name;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("name")
+        @Valid
+        public String getScheme() {
+            return name;
+        }
+
+        public void setScheme(String name) {
+            this.name = name;
+        }
+
+        /**
+         *
+         **/
+        public FederatedAuthenticator isEnabled(Boolean isEnabled) {
+
+            this.isEnabled = isEnabled;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("isEnabled")
+        @Valid
+        public Boolean getIsEnabled() {
+            return isEnabled;
+        }
+
+        public void setIsEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+        }
+
+        /**
+         *
+         **/
+        public FederatedAuthenticator isDefault(Boolean isDefault) {
+
+            this.isDefault = isDefault;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("isDefault")
+        @Valid
+        public Boolean getIsDefault() {
+            return isDefault;
+        }
+
+        public void setIsDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+        }
+
+        /**
+         *
+         **/
+        public FederatedAuthenticator properties(List<Property> properties) {
+
+            this.properties = properties;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("properties")
+        @Valid
+        public List<Property> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(List<Property> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public String toString() {
+
+            return "class FederatedAuthenticator {\n" +
+                    "    authenticatorId: " + toIndentedString(authenticatorId) + "\n" +
+                    "    name: " + toIndentedString(name) + "\n" +
+                    "    isEnabled: " + toIndentedString(isEnabled) + "\n" +
+                    "    isDefault: " + toIndentedString(isDefault) + "\n" +
+                    "    properties: " + toIndentedString(properties) + "\n" +
+                    "}";
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/IdentityProviderPOSTRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/IdentityProviderPOSTRequest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class IdentityProviderPOSTRequest {
+
+    private String name;
+    private String description;
+    private String image;
+    private Boolean isPrimary = false;
+    private Boolean isFederationHub = false;
+    private String homeRealmIdentifier;
+    private Certificate certificate;
+    private String alias;
+    private Claims claims;
+    private Roles roles;
+    private FederatedAuthenticatorRequest federatedAuthenticators;
+    private ProvisioningRequest provisioning;
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest image(String image) {
+
+        this.image = image;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest isPrimary(Boolean isPrimary) {
+
+        this.isPrimary = isPrimary;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("isPrimary")
+    @Valid
+    public Boolean getIsPrimary() {
+        return isPrimary;
+    }
+
+    public void setIsPrimary(Boolean isPrimary) {
+        this.isPrimary = isPrimary;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest isFederationHub(Boolean isFederationHub) {
+
+        this.isFederationHub = isFederationHub;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("isFederationHub")
+    @Valid
+    public Boolean getIsFederationHub() {
+        return isFederationHub;
+    }
+
+    public void setIsFederationHub(Boolean isFederationHub) {
+        this.isFederationHub = isFederationHub;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest homeRealmIdentifier(String homeRealmIdentifier) {
+
+        this.homeRealmIdentifier = homeRealmIdentifier;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("homeRealmIdentifier")
+    @Valid
+    public String getHomeRealmIdentifier() {
+        return homeRealmIdentifier;
+    }
+
+    public void setHomeRealmIdentifier(String homeRealmIdentifier) {
+        this.homeRealmIdentifier = homeRealmIdentifier;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("certificate")
+    @Valid
+    public Certificate getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest claims(Claims claims) {
+
+        this.claims = claims;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("claims")
+    @Valid
+    public Claims getClaims() {
+        return claims;
+    }
+
+    public void setClaims(Claims claims) {
+        this.claims = claims;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest roles(Roles roles) {
+
+        this.roles = roles;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("roles")
+    @Valid
+    public Roles getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest federatedAuthenticators(FederatedAuthenticatorRequest federatedAuthenticators) {
+
+        this.federatedAuthenticators = federatedAuthenticators;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("federatedAuthenticators")
+    @Valid
+    public FederatedAuthenticatorRequest getFederatedAuthenticators() {
+        return federatedAuthenticators;
+    }
+
+    public void setFederatedAuthenticators(FederatedAuthenticatorRequest federatedAuthenticators) {
+        this.federatedAuthenticators = federatedAuthenticators;
+    }
+
+    /**
+     *
+     **/
+    public IdentityProviderPOSTRequest provisioning(ProvisioningRequest provisioning) {
+
+        this.provisioning = provisioning;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("provisioning")
+    @Valid
+    public ProvisioningRequest getProvisioning() {
+        return provisioning;
+    }
+
+    public void setProvisioning(ProvisioningRequest provisioning) {
+        this.provisioning = provisioning;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderPOSTRequest identityProviderPOSTRequest = (IdentityProviderPOSTRequest) o;
+        return Objects.equals(this.name, identityProviderPOSTRequest.name) && Objects.equals(this.description, identityProviderPOSTRequest.description) && Objects.equals(this.image, identityProviderPOSTRequest.image) && Objects.equals(this.isPrimary, identityProviderPOSTRequest.isPrimary) && Objects.equals(this.isFederationHub, identityProviderPOSTRequest.isFederationHub) && Objects.equals(this.homeRealmIdentifier, identityProviderPOSTRequest.homeRealmIdentifier) && Objects.equals(this.certificate, identityProviderPOSTRequest.certificate) && Objects.equals(this.alias, identityProviderPOSTRequest.alias) && Objects.equals(this.claims, identityProviderPOSTRequest.claims) && Objects.equals(this.roles, identityProviderPOSTRequest.roles) && Objects.equals(this.federatedAuthenticators, identityProviderPOSTRequest.federatedAuthenticators) && Objects.equals(this.provisioning, identityProviderPOSTRequest.provisioning);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, image, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, claims, roles, federatedAuthenticators, provisioning);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class IdentityProviderPOSTRequest {\n" + "    name: " + toIndentedString(name) + "\n" + "    description: " + toIndentedString(description) + "\n" + "    image: " + toIndentedString(image) + "\n" + "    isPrimary: " + toIndentedString(isPrimary) + "\n" + "    isFederationHub: " + toIndentedString(isFederationHub) + "\n" + "    homeRealmIdentifier: " + toIndentedString(homeRealmIdentifier) + "\n" + "    certificate: " + toIndentedString(certificate) + "\n" + "    alias: " + toIndentedString(alias) + "\n" + "    claims: " + toIndentedString(claims) + "\n" + "    roles: " + toIndentedString(roles) + "\n" + "    federatedAuthenticators: " + toIndentedString(federatedAuthenticators) + "\n" + "    provisioning: " + toIndentedString(provisioning) + "\n" + "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private static String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+
+    public static class Certificate {
+        private List<String> certificates = null;
+        private String jwksUri;
+
+        /**
+         *
+         **/
+        public Certificate certificates(List<String> certificates) {
+
+            this.certificates = certificates;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("certificates")
+        @Valid
+        public List<String> getCertificates() {
+            return certificates;
+        }
+
+        public void setCertificates(List<String> certificates) {
+            this.certificates = certificates;
+        }
+
+        public Certificate addCertificates(String certificate) {
+            if (this.certificates == null) {
+                this.certificates = new ArrayList<>();
+            }
+            this.certificates.add(certificate);
+            return this;
+        }
+
+        /**
+         *
+         **/
+        public Certificate jwksUri(String jwksUri) {
+
+            this.jwksUri = jwksUri;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("jwksUri")
+        @Valid
+        public String getJwksUri() {
+            return jwksUri;
+        }
+
+        public void setJwksUri(String jwksUri) {
+            this.jwksUri = jwksUri;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Certificate certificate = (Certificate) o;
+            return Objects.equals(this.certificates, certificate.certificates) &&
+                    Objects.equals(this.jwksUri, certificate.jwksUri);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(certificates, jwksUri);
+        }
+
+        @Override
+        public String toString() {
+
+            return "class Certificate {\n" +
+                    "    certificates: " + toIndentedString(certificates) + "\n" +
+                    "    jwksUri: " + toIndentedString(jwksUri) + "\n" +
+                    "}";
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/PatchRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/PatchRequest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+
+public class PatchRequest {
+
+    @XmlType(name="OperationEnum")
+    @XmlEnum()
+    public enum OperationEnum {
+
+        @XmlEnumValue("ADD") ADD("ADD"),
+        @XmlEnumValue("REMOVE") REMOVE("REMOVE"),
+        @XmlEnumValue("REPLACE") REPLACE("REPLACE");
+
+        private String value;
+
+        OperationEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static OperationEnum fromValue(String value) {
+            for (OperationEnum b : OperationEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private OperationEnum operation;
+    private String path;
+    private String value;
+
+    /**
+     * The operation to be performed
+     **/
+    public PatchRequest operation(OperationEnum operation) {
+
+        this.operation = operation;
+        return this;
+    }
+
+    @ApiModelProperty(example = "REPLACE", required = true, value = "The operation to be performed")
+    @JsonProperty("operation")
+    @Valid
+    public OperationEnum getOperation() {
+        return operation;
+    }
+    public void setOperation(OperationEnum operation) {
+        this.operation = operation;
+    }
+
+    /**
+     * A JSON-Pointer
+     **/
+    public PatchRequest path(String path) {
+
+        this.path = path;
+        return this;
+    }
+
+    @ApiModelProperty(example = "/idleSessionTimeoutPeriod", required = true, value = "A JSON-Pointer")
+    @JsonProperty("path")
+    @Valid
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+     * The value to be used within the operations
+     **/
+    public PatchRequest value(String value) {
+
+        this.value = value;
+        return this;
+    }
+
+    @ApiModelProperty(example = "30", value = "The value to be used within the operations")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PatchRequest patchRequest = (PatchRequest) o;
+        return Objects.equals(this.operation, patchRequest.operation) &&
+                Objects.equals(this.path, patchRequest.path) &&
+                Objects.equals(this.value, patchRequest.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, path, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class PatchRequest {\n");
+
+        sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Property.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Property.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.Objects;
+
+public class Property {
+    private String key;
+    private String value;
+
+    /**
+     *
+     **/
+    public Property key(String key) {
+
+        this.key = key;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("key")
+    @Valid
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     *
+     **/
+    public Property value(String value) {
+
+        this.value = value;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Property property = (Property) o;
+        return Objects.equals(this.key, property.key) &&
+                Objects.equals(this.value, property.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class Property {\n" +
+                "    key: " + toIndentedString(key) + "\n" +
+                "    value: " + toIndentedString(value) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/ProvisioningRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/ProvisioningRequest.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+import java.util.List;
+import java.util.Objects;
+
+public class ProvisioningRequest {
+    private JustInTimeProvisioning jit;
+    private OutboundProvisioningRequest outboundConnectors;
+
+    /**
+     *
+     **/
+    public ProvisioningRequest jit(JustInTimeProvisioning jit) {
+
+        this.jit = jit;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("jit")
+    @Valid
+    public JustInTimeProvisioning getJit() {
+        return jit;
+    }
+
+    public void setJit(JustInTimeProvisioning jit) {
+        this.jit = jit;
+    }
+
+    /**
+     *
+     **/
+    public ProvisioningRequest outboundConnectors(OutboundProvisioningRequest outboundConnectors) {
+
+        this.outboundConnectors = outboundConnectors;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("outboundConnectors")
+    @Valid
+    public OutboundProvisioningRequest getOutboundConnectors() {
+        return outboundConnectors;
+    }
+
+    public void setOutboundConnectors(OutboundProvisioningRequest outboundConnectors) {
+        this.outboundConnectors = outboundConnectors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProvisioningRequest provisioningRequest = (ProvisioningRequest) o;
+        return Objects.equals(this.jit, provisioningRequest.jit) &&
+                Objects.equals(this.outboundConnectors, provisioningRequest.outboundConnectors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jit, outboundConnectors);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ProvisioningRequest {\n" +
+                "    jit: " + toIndentedString(jit) + "\n" +
+                "    outboundConnectors: " + toIndentedString(outboundConnectors) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private static String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+
+    public static class JustInTimeProvisioning {
+
+        private Boolean isEnabled = false;
+
+        @XmlType(name="SchemeEnum")
+        @XmlEnum()
+        public enum SchemeEnum {
+
+            @XmlEnumValue("PROMPT_USERNAME_PASSWORD_CONSENT") PROMPT_USERNAME_PASSWORD_CONSENT("PROMPT_USERNAME_PASSWORD_CONSENT"),
+            @XmlEnumValue("PROMPT_PASSWORD_CONSENT") PROMPT_PASSWORD_CONSENT("PROMPT_PASSWORD_CONSENT"),
+            @XmlEnumValue("PROMPT_CONSENT") PROMPT_CONSENT("PROMPT_CONSENT"),
+            @XmlEnumValue("PROVISION_SILENTLY") PROVISION_SILENTLY("PROVISION_SILENTLY");
+
+
+            private final String value;
+
+            SchemeEnum(String v) {
+                value = v;
+            }
+
+            public String value() {
+                return value;
+            }
+
+            @Override
+            public String toString() {
+                return String.valueOf(value);
+            }
+
+            public static SchemeEnum fromValue(String value) {
+                for (SchemeEnum b : SchemeEnum.values()) {
+                    if (b.value.equals(value)) {
+                        return b;
+                    }
+                }
+                throw new IllegalArgumentException("Unexpected value '" + value + "'");
+            }
+        }
+
+        private SchemeEnum scheme = SchemeEnum.PROVISION_SILENTLY;
+        private String userstore = "PRIMARY";
+        private Boolean associateLocalUser;
+
+        /**
+         *
+         **/
+        public JustInTimeProvisioning isEnabled(Boolean isEnabled) {
+
+            this.isEnabled = isEnabled;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("isEnabled")
+        @Valid
+        public Boolean getIsEnabled() {
+            return isEnabled;
+        }
+
+        public void setIsEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+        }
+
+        /**
+         *
+         **/
+        public JustInTimeProvisioning scheme(SchemeEnum scheme) {
+
+            this.scheme = scheme;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("scheme")
+        @Valid
+        public SchemeEnum getScheme() {
+            return scheme;
+        }
+
+        public void setScheme(SchemeEnum scheme) {
+            this.scheme = scheme;
+        }
+
+        /**
+         *
+         **/
+        public JustInTimeProvisioning userstore(String userstore) {
+
+            this.userstore = userstore;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("userstore")
+        @Valid
+        public String getUserstore() {
+            return userstore;
+        }
+
+        public void setUserstore(String userstore) {
+            this.userstore = userstore;
+        }
+
+        /**
+         *
+         **/
+        public JustInTimeProvisioning associateLocalUser(Boolean associateLocalUser) {
+
+            this.associateLocalUser = associateLocalUser;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("associateLocalUser")
+        @Valid
+        public Boolean getAssociateLocalUser() {
+            return associateLocalUser;
+        }
+
+        public void setAssociateLocalUser(Boolean associateLocalUser) {
+            this.associateLocalUser = associateLocalUser;
+        }
+
+        @Override
+        public String toString() {
+
+            return "class JustInTimeProvisioning {\n" +
+                    "    isEnabled: " + toIndentedString(isEnabled) + "\n" +
+                    "    scheme: " + toIndentedString(scheme) + "\n" +
+                    "    userstore: " + toIndentedString(userstore) + "\n" +
+                    "    associateLocalUser: " + toIndentedString(associateLocalUser) + "\n" +
+                    "}";
+        }
+    }
+
+    public static class OutboundProvisioningRequest {
+        private String defaultConnectorId;
+        private List<OutboundConnector> connectors;
+
+        /**
+         *
+         **/
+        public OutboundProvisioningRequest defaultConnectorId(String defaultConnectorId) {
+
+            this.defaultConnectorId = defaultConnectorId;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("defaultConnectorId")
+        @Valid
+        public String getDefaultConnectorId() {
+            return defaultConnectorId;
+        }
+
+        public void setDefaultConnectorId(String defaultConnectorId) {
+            this.defaultConnectorId = defaultConnectorId;
+        }
+
+        /**
+         *
+         **/
+        public OutboundProvisioningRequest connectors(List<OutboundConnector> connectors) {
+
+            this.connectors = connectors;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("connectors")
+        @Valid
+        public List<OutboundConnector> getConnectors() {
+            return connectors;
+        }
+
+        public void setConnectors(List<OutboundConnector> connectors) {
+            this.connectors = connectors;
+        }
+
+        @Override
+        public String toString() {
+
+            return "class OutboundProvisioningRequest {\n" +
+                    "    defaultConnectorId: " + toIndentedString(defaultConnectorId) + "\n" +
+                    "    connectors: " + toIndentedString(connectors) + "\n" +
+                    "}";
+        }
+
+        public static class OutboundConnector {
+            private String connectorId;
+            private String name;
+            private Boolean isEnabled = false;
+            private Boolean isDefault = false;
+            private Boolean blockingEnabled = false;
+            private Boolean rulesEnabled = false;
+            private List<Property> properties = null;
+
+            /**
+             *
+             **/
+            public OutboundConnector connectorId(String connectorId) {
+
+                this.connectorId = connectorId;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("connectorId")
+            @Valid
+            public String getConnectorId() {
+                return connectorId;
+            }
+
+            public void setConnectorId(String connectorId) {
+                this.connectorId = connectorId;
+            }
+
+            /**
+             *
+             **/
+            public OutboundConnector name(String name) {
+
+                this.name = name;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("name")
+            @Valid
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            /**
+             *
+             **/
+            public OutboundConnector isEnabled(Boolean isEnabled) {
+
+                this.isEnabled = isEnabled;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("isEnabled")
+            @Valid
+            public Boolean getIsEnabled() {
+                return isEnabled;
+            }
+
+            public void setIsEnabled(Boolean isEnabled) {
+                this.isEnabled = isEnabled;
+            }
+
+            /**
+             *
+             **/
+            public OutboundConnector isDefault(Boolean isDefault) {
+
+                this.isDefault = isDefault;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("isDefault")
+            @Valid
+            public Boolean getIsDefault() {
+                return isDefault;
+            }
+
+            public void setIsDefault(Boolean isDefault) {
+                this.isDefault = isDefault;
+            }
+
+            /**
+             *
+             **/
+            public OutboundConnector blockingEnabled(Boolean blockingEnabled) {
+
+                this.blockingEnabled = blockingEnabled;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("blockingEnabled")
+            @Valid
+            public Boolean getBlockingEnabled() {
+                return blockingEnabled;
+            }
+
+            public void setBlockingEnabled(Boolean blockingEnabled) {
+                this.blockingEnabled = blockingEnabled;
+            }
+
+            /**
+             *
+             **/
+            public OutboundConnector rulesEnabled(Boolean rulesEnabled) {
+
+                this.rulesEnabled = rulesEnabled;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("rulesEnabled")
+            @Valid
+            public Boolean getRulesEnabled() {
+                return rulesEnabled;
+            }
+
+            public void setRulesEnabled(Boolean rulesEnabled) {
+                this.rulesEnabled = rulesEnabled;
+            }
+
+            /**
+             *
+             **/
+            public OutboundConnector properties(List<Property> properties) {
+
+                this.properties = properties;
+                return this;
+            }
+
+            @ApiModelProperty()
+            @JsonProperty("properties")
+            @Valid
+            public List<Property> getProperties() {
+                return properties;
+            }
+
+            public void setProperties(List<Property> properties) {
+                this.properties = properties;
+            }
+
+            @Override
+            public String toString() {
+
+                return "class OutboundConnector {\n" +
+                        "    connectorId: " + toIndentedString(connectorId) + "\n" +
+                        "    name: " + toIndentedString(name) + "\n" +
+                        "    isEnabled: " + toIndentedString(isEnabled) + "\n" +
+                        "    isDefault: " + toIndentedString(isDefault) + "\n" +
+                        "    blockingEnabled: " + toIndentedString(blockingEnabled) + "\n" +
+                        "    rulesEnabled: " + toIndentedString(rulesEnabled) + "\n" +
+                        "    properties: " + toIndentedString(properties) + "\n" +
+                        "}";
+            }
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Roles.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Roles.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Objects;
+
+public class Roles {
+    private List<RoleMapping> mappings;
+    private List<String> outboundProvisioningRoles;
+
+    /**
+     *
+     **/
+    public Roles mappings(List<RoleMapping> mappings) {
+
+        this.mappings = mappings;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("mappings")
+    @Valid
+    public List<RoleMapping> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(List<RoleMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    /**
+     *
+     **/
+    public Roles outboundProvisioningRoles(List<String> outboundProvisioningRoles) {
+
+        this.outboundProvisioningRoles = outboundProvisioningRoles;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("outboundProvisioningRoles")
+    @Valid
+    public List<String> getOutboundProvisioningRoles() {
+        return outboundProvisioningRoles;
+    }
+
+    public void setOutboundProvisioningRoles(List<String> outboundProvisioningRoles) {
+        this.outboundProvisioningRoles = outboundProvisioningRoles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Roles Roles = (Roles) o;
+        return  Objects.equals(this.mappings, Roles.mappings) &&
+                Objects.equals(this.outboundProvisioningRoles, Roles.outboundProvisioningRoles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mappings, outboundProvisioningRoles);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class Roles {\n" +
+                "    mappings: " + toIndentedString(mappings) + "\n" +
+                "    outboundProvisioningRoles: " + toIndentedString(outboundProvisioningRoles) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private static String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+
+    public static class RoleMapping {
+        private String idpRole;
+        private String localRole;
+
+        /**
+         *
+         **/
+        public RoleMapping idpRole(String idpRole) {
+
+            this.idpRole = idpRole;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("idpRole")
+        @Valid
+        public String getIdpRole() {
+            return idpRole;
+        }
+
+        public void setIdpRole(String idpRole) {
+            this.idpRole = idpRole;
+        }
+
+        /**
+         *
+         **/
+        public RoleMapping localRole(String localRole) {
+
+            this.localRole = localRole;
+            return this;
+        }
+
+        @ApiModelProperty()
+        @JsonProperty("localRole")
+        @Valid
+        public String getLocalRole() {
+            return localRole;
+        }
+
+        public void setLocalRole(String localRole) {
+            this.localRole = localRole;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RoleMapping roleMapping = (RoleMapping) o;
+            return Objects.equals(this.idpRole, roleMapping.idpRole) &&
+                    Objects.equals(this.localRole, roleMapping.localRole);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(idpRole, localRole);
+        }
+
+        @Override
+        public String toString() {
+
+            return "class RoleMapping {\n" +
+                    "    idpRole: " + toIndentedString(idpRole) + "\n" +
+                    "    localRole: " + toIndentedString(localRole) + "\n" +
+                    "}";
+        }
+
+        /**
+         * Convert the given object to string with each line indented by 4 spaces
+         * (except the first line).
+         */
+        private String toIndentedString(java.lang.Object o) {
+
+            if (o == null) {
+                return "null";
+            }
+            return o.toString();
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/oidc/scope/management/v1/model/ScopeUpdateRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/oidc/scope/management/v1/model/ScopeUpdateRequest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ScopeUpdateRequest {
+    private String displayName;
+    private String description;
+    private List<String> claims = null;
+
+    /**
+     *
+     **/
+    public ScopeUpdateRequest displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+
+    @ApiModelProperty(example = "scopeOne")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     *
+     **/
+    public ScopeUpdateRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Sample updated scope one")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     *
+     **/
+    public ScopeUpdateRequest claims(List<String> claims) {
+
+        this.claims = claims;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Sample updated scope one")
+    @JsonProperty("claims")
+    @Valid
+    public List<String> getClaims() {
+        return claims;
+    }
+
+    public void setClaims(List<String> claims) {
+        this.claims = claims;
+    }
+
+    public ScopeUpdateRequest addClaims(String claim) {
+        if (this.claims == null) {
+            this.claims = new ArrayList<>();
+        }
+        this.claims.add(claim);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScopeUpdateRequest scope = (ScopeUpdateRequest) o;
+        return Objects.equals(this.displayName, scope.displayName) &&
+                Objects.equals(this.description, scope.description) &&
+                Objects.equals(this.claims, scope.claims);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, description, claims);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ScopeUpdateRequest {\n" +
+                "    displayName: " + toIndentedString(displayName) + "\n" +
+                "    description: " + toIndentedString(description) + "\n" +
+                "    claims: " + toIndentedString(claims) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/ScimSchemaExtensionEnterprise.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/ScimSchemaExtensionEnterprise.java
@@ -28,6 +28,7 @@ public class ScimSchemaExtensionEnterprise {
     private Manager manager;
     private String employeeNumber;
     private Boolean accountLocked;
+    private String country;
 
     /**
      *
@@ -89,6 +90,26 @@ public class ScimSchemaExtensionEnterprise {
         this.accountLocked = accountLocked;
     }
 
+    /**
+     *
+     **/
+    public ScimSchemaExtensionEnterprise country(String country) {
+
+        this.country = country;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Sri Lanka")
+    @JsonProperty("country")
+    @Valid
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
     @Override
     public boolean equals(Object o) {
 
@@ -101,12 +122,13 @@ public class ScimSchemaExtensionEnterprise {
         ScimSchemaExtensionEnterprise scimSchemaExtensionEnterprise = (ScimSchemaExtensionEnterprise) o;
         return Objects.equals(this.manager, scimSchemaExtensionEnterprise.manager) &&
                 Objects.equals(this.employeeNumber, scimSchemaExtensionEnterprise.employeeNumber) &&
-                Objects.equals(this.accountLocked, scimSchemaExtensionEnterprise.accountLocked);
+                Objects.equals(this.accountLocked, scimSchemaExtensionEnterprise.accountLocked) &&
+                Objects.equals(this.country, scimSchemaExtensionEnterprise.country);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(manager, employeeNumber, accountLocked);
+        return Objects.hash(manager, employeeNumber, accountLocked, country);
     }
 
     @Override
@@ -116,6 +138,7 @@ public class ScimSchemaExtensionEnterprise {
                 "    manager: " + toIndentedString(manager) + "\n" +
                 "    employeeNumber: " + toIndentedString(employeeNumber) + "\n" +
                 "    accountLocked: " + toIndentedString(accountLocked) + "\n" +
+                "    country: " + toIndentedString(country) + "\n" +
                 "}";
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/UserItemAddGroupobj.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/UserItemAddGroupobj.java
@@ -64,7 +64,7 @@ public class UserItemAddGroupobj {
 
     private OpEnum op = null;
     private String path;
-    private Boolean value = null;
+    private Object value = null;
 
     /**
      **/
@@ -107,7 +107,7 @@ public class UserItemAddGroupobj {
     /**
      *
      **/
-    public UserItemAddGroupobj value(Boolean value) {
+    public UserItemAddGroupobj value(Object value) {
 
         this.value = value;
         return this;
@@ -116,11 +116,11 @@ public class UserItemAddGroupobj {
     @ApiModelProperty()
     @JsonProperty("value")
     @Valid
-    public Boolean getValue() {
+    public Object getValue() {
         return value;
     }
 
-    public void setValue(Boolean value) {
+    public void setValue(Object value) {
         this.value = value;
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ChallengeQuestionsRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ChallengeQuestionsRestClient.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.server.challenge.v1.model.UserChallengeAnswer;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ChallengeQuestionsRestClient extends RestBaseClient {
+    private final String serverUrl;
+    private static final String CHALLENGE_QUESTION_BASE_PATH = "api/users/v1/%s/challenge-answers";
+    private final String tenantDomain;
+    private final String username;
+    private final String password;
+
+    public ChallengeQuestionsRestClient(String serverUrl, Tenant tenantInfo) {
+
+        this.serverUrl = serverUrl;
+        this.tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+    }
+
+    /**
+     * Set Answers for the user challenge questions
+     *
+     * @param userId userId.
+     * @param questionSetId Challenge Question Set id.
+     * @param challengeAsnwerObj Challenge Question request object.
+     */
+    public void setChallengeQuestionAnswer(String userId, String questionSetId,
+                                           UserChallengeAnswer challengeAsnwerObj) throws Exception {
+
+        String jsonRequest = toJSONString(challengeAsnwerObj);
+        String endPointUrl = serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR +
+                String.format(CHALLENGE_QUESTION_BASE_PATH, userId) + PATH_SEPARATOR +  questionSetId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
+                    "Setting Challenge Answer is failed");
+        }
+    }
+
+    private Header[] getHeaders() {
+        Header[] headerList = new Header[3];
+        headerList[0] = new BasicHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
+        headerList[1] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    /**
+     * Close the HTTP client.
+     *
+     */
+    public void closeHttpClient() throws IOException {
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ClaimManagementRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ClaimManagementRestClient.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.server.claim.management.v1.model.ExternalClaimReq;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ClaimManagementRestClient extends RestBaseClient {
+
+    private static final String TENANT_PATH = "t/%s";
+    private static final String API_SERVER_BASE_PATH = "/api/server/v1";
+    private static final String CLAIM_DIALECTS_ENDPOINT_URI = "/claim-dialects";
+
+    public static final String CLAIMS_ENDPOINT_URI = "/claims";
+    private final CloseableHttpClient client;
+    private final String username;
+    private final String password;
+    private final String serverBasePath;
+
+    public ClaimManagementRestClient(String backendURL, Tenant tenantInfo) {
+        client = HttpClients.createDefault();
+
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+
+        String tenantDomain = tenantInfo.getContextUser().getUserDomain();
+
+        serverBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH;
+    }
+
+    /**
+     * Add External Claim
+     *
+     * @param dialectId Claim dialect id.
+     * @param claimRequest External Claim request object.
+     */
+    public String addExternalClaim(String dialectId, ExternalClaimReq claimRequest) throws Exception {
+        String endPointUrl = serverBasePath + CLAIM_DIALECTS_ENDPOINT_URI + PATH_SEPARATOR + dialectId +
+                CLAIMS_ENDPOINT_URI;
+        String jsonRequest = toJSONString(claimRequest);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
+            String[] locationElements = response.getHeaders(LOCATION_HEADER)[0].toString().split(PATH_SEPARATOR);
+            return locationElements[locationElements.length - 1];
+        }
+    }
+
+    /**
+     * Get an External Claim.
+     *
+     * @param dialectId Claim dialect id.
+     * @param claimId claim id.
+     * @return JSONObject JSON object of the response.
+     * @throws Exception Exception.
+     */
+    public JSONObject getExternalClaim(String dialectId, String claimId) throws Exception {
+        String endPointUrl = serverBasePath + CLAIM_DIALECTS_ENDPOINT_URI + PATH_SEPARATOR + dialectId +
+                CLAIMS_ENDPOINT_URI + PATH_SEPARATOR + claimId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    /**
+     * Delete an External Claim.
+     *
+     * @param dialectId Claim dialect id.
+     * @param claimId claim id.
+     * @throws IOException IOException.
+     */
+    public void deleteExternalClaim(String dialectId, String claimId) throws IOException {
+        String endPointUrl = serverBasePath + CLAIM_DIALECTS_ENDPOINT_URI + PATH_SEPARATOR + dialectId +
+                CLAIMS_ENDPOINT_URI + PATH_SEPARATOR + claimId;
+        try (CloseableHttpResponse response = getResponseOfHttpDelete(endPointUrl, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_NO_CONTENT,
+                    "External claim deletion failed");
+        }
+    }
+
+    private Header[] getHeaders() {
+        Header[] headerList = new Header[2];
+        headerList[0] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[1] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    /**
+     * Close the HTTP client.
+     *
+     */
+    public void closeHttpClient() throws IOException {
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdpMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdpMgtRestClient.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Claims;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.IdentityProviderPOSTRequest;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class IdpMgtRestClient extends RestBaseClient {
+    private static final String CLAIMS_PATH = "/claims";
+    private final String serverUrl;
+    private final String IDENTITY_PROVIDER_BASE_PATH = "t/%s/api/server/v1/identity-providers";
+    private final String tenantDomain;
+    private final String username;
+    private final String password;
+
+    public IdpMgtRestClient(String serverUrl, Tenant tenantInfo) {
+
+        this.serverUrl = serverUrl;
+        this.tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+    }
+
+    /**
+     * Create an Identity Provider.
+     *
+     * @param idpCreateReqObj Identity Provider request object.
+     */
+    public String createIdentityProvider(IdentityProviderPOSTRequest idpCreateReqObj) throws Exception {
+        String jsonRequest = toJSONString(idpCreateReqObj);
+        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain);
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
+                    "Idp creation failed");
+            JSONObject jsonResponse = getJSONObject(EntityUtils.toString(response.getEntity()));
+            return jsonResponse.get("id").toString();
+        }
+    }
+
+    /**
+     * Update an Identity Provider claim configurations.
+     *
+     * @param idpId Identity Provider Id
+     * @param idpClaims Identity Provider claim request object.
+     */
+    public void updateIdpClaimConfig(String idpId, Claims idpClaims) throws IOException {
+        String jsonRequest = toJSONString(idpClaims);
+        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain) + PATH_SEPARATOR +
+                idpId + CLAIMS_PATH;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPut(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Idp claim configurations update, failed");
+        }
+    }
+
+    /**
+     * Delete an Identity Provider.
+     *
+     * @param idpId Identity Provider Id
+     */
+    public void deleteIdp(String idpId) throws IOException {
+        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain) + PATH_SEPARATOR +
+                idpId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpDelete(endPointUrl, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_NO_CONTENT,
+                    "Idp deletion failed");
+        }
+    }
+
+    private Header[] getHeaders() {
+        Header[] headerList = new Header[3];
+        headerList[0] = new BasicHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
+        headerList[1] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    /**
+     * Close the HTTP client.
+     *
+     */
+    public void closeHttpClient() throws IOException {
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OIDCScopeMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OIDCScopeMgtRestClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.model.ScopeUpdateRequest;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class OIDCScopeMgtRestClient extends RestBaseClient {
+    private final String serverUrl;
+    private final String OIDC_SCOPE_MGT_BASE_PATH = "t/%s/api/server/v1/oidc/scopes";
+    private final String tenantDomain;
+    private final String username;
+    private final String password;
+
+    public OIDCScopeMgtRestClient(String serverUrl, Tenant tenantInfo) {
+
+        this.serverUrl = serverUrl;
+        this.tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+    }
+
+    /**
+     * Get an OIDC scope
+     *
+     * @param scopeId userId.
+     * @return Scope object.
+     */
+    public JSONObject getScope(String scopeId) throws Exception {
+        String endPointUrl = serverUrl + String.format(OIDC_SCOPE_MGT_BASE_PATH, tenantDomain) +
+                PATH_SEPARATOR +  scopeId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    /**
+     * update an OIDC scope
+     *
+     * @param scopeId userId.
+     * @param scopeUpdateObj Scope update request object.
+     */
+    public void updateScope(String scopeId, ScopeUpdateRequest scopeUpdateObj) throws Exception {
+        String jsonRequest = toJSONString(scopeUpdateObj);
+        String endPointUrl = serverUrl + String.format(OIDC_SCOPE_MGT_BASE_PATH, tenantDomain) +
+                PATH_SEPARATOR +  scopeId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPut(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Scope update failed");
+        }
+    }
+
+    private Header[] getHeaders() {
+        Header[] headerList = new Header[3];
+        headerList[0] = new BasicHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
+        headerList[1] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    /**
+     * Close the HTTP client.
+     *
+     */
+    public void closeHttpClient() throws IOException {
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -40,7 +40,7 @@ public class SCIM2RestClient extends RestBaseClient {
 
     private static final String SCIM2_USERS_ENDPOINT = "scim2/Users";
     private static final String SCIM2_ROLES_ENDPOINT = "scim2/Roles";
-    private static final String SCIM2_ROLE_SEARCH_PATH = "/.search";
+    private static final String SCIM2_SEARCH_PATH = "/.search";
     private static final String SCIM_JSON_CONTENT_TYPE = "application/scim+json";
     private static final String ROLE_SEARCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:SearchRequest";
     private static final String DISPLAY_NAME_ATTRIBUTE = "displayName";
@@ -104,7 +104,23 @@ public class SCIM2RestClient extends RestBaseClient {
 
         try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
-                    "Role update failed");
+                    "User update failed");
+        }
+    }
+
+    /**
+     * Search a user and get requested attributes
+     *
+     * @param userSearchReq json String of user search request.
+     * @return JSONObject of the user search response.
+     */
+    public JSONObject searchUser(String userSearchReq) throws Exception {
+        String endPointUrl = getUsersPath() + SCIM2_SEARCH_PATH;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, userSearchReq, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "User search failed");
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
         }
     }
 
@@ -171,7 +187,7 @@ public class SCIM2RestClient extends RestBaseClient {
 
         String jsonRequest = toJSONString(roleSearchObj);
 
-        try (CloseableHttpResponse response = getResponseOfHttpPost(getRolesPath() + SCIM2_ROLE_SEARCH_PATH,
+        try (CloseableHttpResponse response = getResponseOfHttpPost(getRolesPath() + SCIM2_SEARCH_PATH,
                 jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
                     "Role search failed");


### PR DESCRIPTION
## This PR will remove the soap based api implementations used in IS Integration Tests in test cases mentioned below.

## Modified following test cases
### OAuth2
- Oauth2TokenRenewalPerRequestTestCase 
- SystemScopePermissionValidationTestCase
- Oauth2PersistenceProcessorTestCase
- Oauth2PersistenceProcessorInsertTokenTestCase
- Oauth2HashAlgorithmTestCase
- OAuth2TokenScopeValidatorTestCase
- OAuth2TokenRevocationWithSessionTerminationTestCase
- OAuth2ServiceAuthCodeGrantTestCase
- OAuth2ServiceAuthCodeGrantOpenIdTestCase
- OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase
- OAuth2ServiceJWTGrantTestCase

## Added following rest clients
- `ClaimManagementRestClient` 
-  `ChallengeQuestionsRestClient`
-  `OIDCScopeMgtRestClient`
-  `IdpMgtRestClient`

## Related Issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/17487