### PR TITLE
Update integration tests to use REST APIs in master branch (IV)

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/keystore/management/v1/model/CertificateRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/keystore/management/v1/model/CertificateRequest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+public class CertificateRequest {
+
+    private String alias;
+    private String certificate;
+
+    /**
+     **/
+    public CertificateRequest alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+
+    @ApiModelProperty(example = "newcert", required = true)
+    @JsonProperty("alias")
+    @Valid
+    @NotNull(message = "Property alias cannot be null.")
+
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+     **/
+    public CertificateRequest certificate(String certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+
+    @ApiModelProperty(required = true)
+    @JsonProperty("certificate")
+    @Valid
+    @NotNull(message = "Property certificate cannot be null.")
+
+    public String getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CertificateRequest certificateRequest = (CertificateRequest) o;
+        return Objects.equals(this.alias, certificateRequest.alias) &&
+                Objects.equals(this.certificate, certificateRequest.certificate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(alias, certificate);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class CertificateRequest {\n" +
+                "    alias: " + toIndentedString(alias) + "\n" +
+                "    certificate: " + toIndentedString(certificate) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
@@ -65,7 +65,7 @@ public class KeystoreMgtRestClient extends RestBaseClient {
      * Check whether a certain certificate is already added in the tenant keystore.
      *
      * @param alias alias.
-     * @return Boolean status of the tenant keystore availability.
+     * @return Boolean status of certificate availability in tenant keystore.
      */
     public Boolean checkCertInStore(String alias) throws Exception {
         String endPointUrl = serverUrl + String.format(KEYSTORE_BASE_PATH, tenantDomain) + PATH_SEPARATOR + alias;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
@@ -65,16 +65,13 @@ public class KeystoreMgtRestClient extends RestBaseClient {
      * Check whether a certain certificate is already added in the tenant keystore.
      *
      * @param alias alias.
+     * @return Boolean status of the tenant keystore availability.
      */
     public Boolean checkCertInStore(String alias) throws Exception {
         String endPointUrl = serverUrl + String.format(KEYSTORE_BASE_PATH, tenantDomain) + PATH_SEPARATOR + alias;
 
         try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
-            if (response.getStatusLine().getStatusCode() == HttpServletResponse.SC_OK) {
-                return true;
-            } else {
-                return false;
-            }
+            return response.getStatusLine().getStatusCode() == HttpServletResponse.SC_OK;
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.model.CertificateRequest;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class KeystoreMgtRestClient extends RestBaseClient {
+
+    private static final String KEYSTORE_BASE_PATH = "t/%s/api/server/v1/keystores/certs";
+    private final String serverUrl;
+    private final String tenantDomain;
+    private final String username;
+    private final String password;
+
+    public KeystoreMgtRestClient(String serverUrl, Tenant tenantInfo) {
+
+        this.serverUrl = serverUrl;
+        this.tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+    }
+
+    /**
+     * Upload the certificate to the tenant keystore. This API is not supported for super tenant.
+     *
+     * @param certificateRequest Certificate request object.
+     */
+    public void importCertToStore(CertificateRequest certificateRequest) throws Exception {
+        String jsonRequest = toJSONString(certificateRequest);
+        String endPointUrl = serverUrl + String.format(KEYSTORE_BASE_PATH, tenantDomain);
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
+                    "Certificate upload failed");
+        }
+    }
+
+    /**
+     * Check whether a certain certificate is already added in the tenant keystore.
+     *
+     * @param alias alias.
+     */
+    public Boolean checkCertInStore(String alias) throws Exception {
+        String endPointUrl = serverUrl + String.format(KEYSTORE_BASE_PATH, tenantDomain) + PATH_SEPARATOR + alias;
+
+        try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
+            if (response.getStatusLine().getStatusCode() == HttpServletResponse.SC_OK) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    private Header[] getHeaders() {
+        Header[] headerList = new Header[2];
+        headerList[0] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[1] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    /**
+     * Close the HTTP client.
+     */
+    public void closeHttpClient() throws IOException {
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
@@ -28,6 +28,7 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.carbon.utils.StringUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationListResponse;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
@@ -184,6 +185,21 @@ public class OAuth2RestClient extends RestBaseClient {
         try (CloseableHttpResponse response = getResponseOfHttpPut(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
                     String.format("Application %s inbound config update failed", inboundType));
+        }
+    }
+
+    /**
+     * Delete an Inbound Configuration
+     *
+     * @param appId Application id.
+     * @param inboundType Inbound Type to be deleted.
+     */
+    public Boolean deleteInboundConfiguration(String appId, String inboundType) throws IOException {
+        String endpointUrl = applicationManagementApiBasePath + PATH_SEPARATOR + appId + INBOUND_PROTOCOLS_BASE_PATH +
+                PATH_SEPARATOR + inboundType;
+
+        try (CloseableHttpResponse response = getResponseOfHttpDelete(endpointUrl, getHeaders())) {
+            return response.getStatusLine().getStatusCode() == HttpServletResponse.SC_NO_CONTENT;
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -36,6 +36,7 @@ import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.message.BasicNameValuePair;
+import org.json.JSONException;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.identity.application.common.model.xsd.Claim;
 import org.wso2.carbon.identity.application.common.model.xsd.ClaimMapping;
@@ -51,6 +52,25 @@ import org.wso2.identity.integration.common.clients.application.mgt.ApplicationM
 import org.wso2.identity.integration.common.clients.sso.saml.SAMLSSOConfigServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimConfiguration.DialectEnum;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimMappings;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.RequestedClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SAML2Configuration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SAML2ServiceProvider;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SAMLAssertionConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SAMLAttributeProfile;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SAMLResponseSigning;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SingleLogoutProfile;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SingleSignOnProfile;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,7 +85,7 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
     private static final String ATTRIBUTE_CS_INDEX_VALUE = "1239245949";
     private static final String ATTRIBUTE_CS_INDEX_NAME = "attrConsumServiceIndex";
     public static final String TENANT_DOMAIN_PARAM = "tenantDomain";
-
+    protected static final String SAML = "saml";
     protected static final String SAML_SSO_URL = "https://localhost:9853/samlsso";
     protected static final String SAML_IDP_SLO_URL = SAML_SSO_URL + "?slo=true";
     protected static final String SAML_SSO_LOGIN_URL = "http://localhost:8490/%s/samlsso?SAML2.HTTPBinding=%s";
@@ -87,6 +107,8 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
 
     private ApplicationManagementServiceClient applicationManagementServiceClient;
     protected SAMLSSOConfigServiceClient ssoConfigServiceClient;
+    protected SCIM2RestClient scim2RestClient;
+    protected OAuth2RestClient applicationMgtRestClient;
     private RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
     protected HttpClient httpClient;
     protected Lookup<CookieSpecProvider> cookieSpecRegistry;
@@ -270,6 +292,8 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
                 configContext);
         ssoConfigServiceClient = new SAMLSSOConfigServiceClient(backendURL, sessionCookie);
         remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        applicationMgtRestClient = new OAuth2RestClient(serverURL, tenantInfo);
 
         cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
                 .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
@@ -288,6 +312,8 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         ssoConfigServiceClient = null;
         applicationManagementServiceClient = null;
         remoteUSMServiceClient = null;
+        applicationMgtRestClient = null;
+        scim2RestClient = null;
         httpClient = null;
     }
 
@@ -304,6 +330,24 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         }
     }
 
+    public String addUser(SAMLConfig config) throws Exception {
+
+        log.info("Creating User " + config.getUser().getUsername());
+        UserObject user = new UserObject()
+                .userName(config.getUser().getTenantAwareUsername())
+                .password(config.getUser().getPassword());
+
+        if (config.getUser().getSetUserClaims()) {
+            user.setName(new Name()
+                    .givenName(config.getUser().getNickname())
+                    .familyName(config.getUser().getUsername()));
+            user.addEmail(new Email().value(config.getUser().getEmail()));
+        } else {
+            user.setName(new Name().familyName(config.getUser().getUsername()));
+        }
+        return scim2RestClient.createUser(user);
+    }
+
     /**
      * Create application for SAML artifact resolve.
      *
@@ -315,6 +359,26 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
 
         samlArtResolve = true;
         createApplication(config, appName);
+    }
+
+    public String addApplication(SAMLConfig config, String appName) throws JSONException, IOException {
+
+        ApplicationModel applicationModel = new ApplicationModel()
+                .name(appName)
+                .description("This is a test Service Provider")
+                .claimConfiguration(getClaimConfigurations());
+
+        if (config.httpBinding.equals(HttpBinding.HTTP_SOAP)) {
+            applicationModel.setAuthenticationSequence(new AuthenticationSequence()
+                    .addRequestPathAuthenticatorsItem("BasicAuthRequestPathAuthenticator"));
+        }
+
+        if (samlArtResolve) {
+            applicationModel.setAdvancedConfigurations(new AdvancedApplicationConfiguration()
+                    .skipLoginConsent(true));
+        }
+
+        return applicationMgtRestClient.createApplication(applicationModel);
     }
 
     public void createApplication(SAMLConfig config, String appName) throws Exception {
@@ -371,6 +435,11 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         applicationManagementServiceClient.updateApplicationData(serviceProvider);
     }
 
+    public void deleteUser(String userId) throws IOException {
+
+        scim2RestClient.deleteUser(userId);
+    }
+
     public void deleteUser(SAMLConfig config) {
 
         log.info("Deleting User " + config.getUser().getUsername());
@@ -379,6 +448,11 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         } catch (Exception e) {
             log.error("Error while deleting the user", e);
         }
+    }
+
+    public void deleteApp(String appId) throws Exception {
+
+        applicationMgtRestClient.deleteApplication(appId);
     }
 
     public void deleteApplication(String appName) throws Exception {
@@ -450,14 +524,41 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         return claimMappingList.toArray(new ClaimMapping[claimMappingList.size()]);
     }
 
+    public ClaimConfiguration getClaimConfigurations() {
+
+        return new ClaimConfiguration()
+                .dialect(DialectEnum.LOCAL)
+                .addClaimMappingsItem(new ClaimMappings()
+                        .applicationClaim(firstNameClaimURI)
+                        .localClaim(new org.wso2.identity.integration.test.rest.api.server.application.management
+                                .v1.model.Claim().uri(firstNameClaimURI)))
+                .addClaimMappingsItem(new ClaimMappings()
+                        .applicationClaim(lastNameClaimURI)
+                        .localClaim(new org.wso2.identity.integration.test.rest.api.server.application.management
+                                .v1.model.Claim().uri(lastNameClaimURI)))
+                .addClaimMappingsItem(new ClaimMappings()
+                        .applicationClaim(emailClaimURI)
+                        .localClaim(new org.wso2.identity.integration.test.rest.api.server.application.management.
+                                v1.model.Claim().uri(emailClaimURI)))
+                .addRequestedClaimsItem(new RequestedClaimConfiguration()
+                        .claim(new org.wso2.identity.integration.test.rest.api.server.application.management
+                                .v1.model.Claim().uri(firstNameClaimURI)))
+                .addRequestedClaimsItem(new RequestedClaimConfiguration()
+                        .claim(new org.wso2.identity.integration.test.rest.api.server.application.management
+                                .v1.model.Claim().uri(lastNameClaimURI)))
+                .addRequestedClaimsItem(new RequestedClaimConfiguration()
+                        .claim(new org.wso2.identity.integration.test.rest.api.server.application.management
+                                .v1.model.Claim().uri(emailClaimURI)));
+    }
+
     /**
      * @param config contains the details of the IDP initiated SSO enabled service provider application.
      * @return the created SAMLSSOServiceProviderDTO.
      */
-    public SAMLSSOServiceProviderDTO createSsoSPDTOForIdPInit(SAMLConfig config){
-        SAMLSSOServiceProviderDTO idpInitSpDTO = createSsoSPDTO(config);
-        idpInitSpDTO.setIdPInitSSOEnabled(true);
-        return idpInitSpDTO;
+    public SAML2Configuration getSAMLConfigurationsForIdPInit(SAMLConfig config){
+        SAML2Configuration idpInitSamlConfig = getSAMLConfigurations(config);
+        idpInitSamlConfig.getManualConfiguration().getSingleSignOnProfile().setEnableIdpInitiatedSingleSignOn(true);
+        return idpInitSamlConfig;
     }
 
     /**
@@ -470,6 +571,28 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
         SAMLSSOServiceProviderDTO idpInitSpDTO = createSsoSPDTO(config);
         idpInitSpDTO.setEnableSAML2ArtifactBinding(true);
         return idpInitSpDTO;
+    }
+
+    public SAML2Configuration getSAMLConfigurations(SAMLConfig config) {
+
+        SAML2ServiceProvider serviceProvider = new SAML2ServiceProvider()
+                .issuer(config.getApp().getArtifact())
+                .addAssertionConsumerUrl(String.format(ACS_URL, config.getApp().getArtifact()))
+                .defaultAssertionConsumerUrl(String.format(ACS_URL, config.getApp().getArtifact()))
+                .singleLogoutProfile(new SingleLogoutProfile()
+                        .enabled(true))
+                .responseSigning(new SAMLResponseSigning()
+                        .enabled(config.getApp().isSigningEnabled()))
+                .singleSignOnProfile(new SingleSignOnProfile()
+                        .assertion(new SAMLAssertionConfiguration().nameIdFormat(NAMEID_FORMAT))
+                        .attributeConsumingServiceIndex(ATTRIBUTE_CS_INDEX_VALUE));
+
+        if (config.getClaimType() != AbstractSAMLSSOTestCase.ClaimType.NONE) {
+            serviceProvider.setAttributeProfile(new SAMLAttributeProfile()
+                            .enabled(true)
+                            .alwaysIncludeAttributesInResponse(true));
+        }
+        return new SAML2Configuration().manualConfiguration(serviceProvider);
     }
 
     public SAMLSSOServiceProviderDTO createSsoServiceProviderDTO(SAMLConfig config){

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSLOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSLOTestCase.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -30,15 +30,13 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.identity.sso.saml.stub.IdentitySAMLSSOConfigServiceIdentityException;
-import org.wso2.carbon.identity.sso.saml.stub.types.SAMLSSOServiceProviderDTO;
 import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.carbon.logging.view.data.xsd.LogEvent;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SAML2ServiceProvider;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.CommonConstants;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
-import org.wso2.identity.integration.test.utils.UserUtil;
 
 import java.io.File;
 import java.rmi.RemoteException;
@@ -58,16 +56,17 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
     private static final String SAML_APP_ONE_ACS_URL = "http://localhost:8490/travelocity.com/home.jsp";
     private static final String SAML_APP_TWO_ACS_URL = "http://localhost:8490/travelocity.com-saml-tenantwithoutsigning/home.jsp";
 
-    private SAMLConfig samlConfigOne;
-    private SAMLConfig samlConfigTwo;
+    private final SAMLConfig samlConfigOne;
+    private final SAMLConfig samlConfigTwo;
     private String resultPage;
-    private SAMLSSOServiceProviderDTO samlssoServiceProviderDTO;
     private ServerConfigurationManager serverConfigurationManager;
     private String userId;
 
     private LogViewerClient logViewer;
 
     private static final Long WAIT_TIME = 10000L;
+    private String appOneId;
+    private String appTwoId;
 
     @Factory(dataProvider = "samlConfigProvider")
     public SAMLIdPInitiatedSLOTestCase(SAMLConfig samlConfigOne, SAMLConfig samlConfigTwo) {
@@ -96,11 +95,10 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
         super.init(samlConfigOne.getUserMode());
         super.testInit();
 
-        super.createUser(samlConfigOne);
-        userId = UserUtil.getUserId(samlConfigOne.getUser().getTenantAwareUsername(), isServer.getContextTenant());
+        userId = super.addUser(samlConfigOne);
 
-        super.createApplication(samlConfigOne, APPLICATION_ONE);
-        super.createApplication(samlConfigTwo, APPLICATION_TWO);
+        appOneId = super.addApplication(samlConfigOne, APPLICATION_ONE);
+        appTwoId = super.addApplication(samlConfigTwo, APPLICATION_TWO);
 
         logViewer = new LogViewerClient(backendURL, sessionCookie);
         changeISConfiguration();
@@ -110,9 +108,9 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
     public void testClear() throws Exception {
 
         resetISConfiguration();
-        super.deleteUser(samlConfigOne);
-        super.deleteApplication(APPLICATION_ONE);
-        super.deleteApplication(APPLICATION_TWO);
+        super.deleteUser(userId);
+        super.deleteApp(appOneId);
+        super.deleteApp(appTwoId);
         super.testClear();
     }
 
@@ -139,19 +137,15 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
     @Test(description = "Add service providers", groups = "wso2.is", priority = 1)
     public void testAddSP() throws Exception {
 
-        Boolean isAddSuccess;
+        applicationMgtRestClient.updateInboundDetailsOfApplication(appOneId, getSAMLConfigurations(samlConfigOne),
+                "saml");
+        SAML2ServiceProvider samlConfig = applicationMgtRestClient.getSAMLInboundDetails(appOneId);
+        Assert.assertNotNull(samlConfig, "Adding a service provider has failed for " + samlConfigOne);
 
-        isAddSuccess = ssoConfigServiceClient.addServiceProvider(super.createSsoServiceProviderDTO(samlConfigOne));
-        Assert.assertTrue(isAddSuccess, "Adding a service provider has failed for " + samlConfigOne);
-
-        samlssoServiceProviderDTO = getServiceProvider(samlConfigOne);
-        Assert.assertNotNull(samlssoServiceProviderDTO, "Adding a service provider has failed for " + samlConfigOne);
-
-        isAddSuccess = ssoConfigServiceClient.addServiceProvider(super.createSsoServiceProviderDTO(samlConfigTwo));
-        Assert.assertTrue(isAddSuccess, "Adding a service provider has failed for " + samlConfigTwo);
-
-        samlssoServiceProviderDTO = getServiceProvider(samlConfigTwo);
-        Assert.assertNotNull(samlssoServiceProviderDTO, "Adding a service provider has failed for " + samlConfigTwo);
+        applicationMgtRestClient.updateInboundDetailsOfApplication(appTwoId, getSAMLConfigurations(samlConfigTwo),
+                "saml");
+        samlConfig = applicationMgtRestClient.getSAMLInboundDetails(appTwoId);
+        Assert.assertNotNull(samlConfig, "Adding a service provider has failed for " + samlConfigTwo);
     }
 
     @Test(alwaysRun = true, description = "Testing SAML SSO login", groups = "wso2.is",
@@ -321,17 +315,5 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
             }
         }
         return matchFound;
-    }
-
-    private SAMLSSOServiceProviderDTO getServiceProvider(SAMLConfig samlConfig) throws RemoteException, IdentitySAMLSSOConfigServiceIdentityException {
-
-        SAMLSSOServiceProviderDTO[] samlssoServiceProviderDTOs = ssoConfigServiceClient.getServiceProviders()
-                .getServiceProviders();
-        for (SAMLSSOServiceProviderDTO spDTO : samlssoServiceProviderDTOs) {
-            if (spDTO.getIssuer().equals(samlConfig.getApp().getArtifact())) {
-                return spDTO;
-            }
-        }
-        return null;
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSLOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSLOTestCase.java
@@ -137,8 +137,7 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
     @Test(description = "Add service providers", groups = "wso2.is", priority = 1)
     public void testAddSP() throws Exception {
 
-        applicationMgtRestClient.updateInboundDetailsOfApplication(appOneId, getSAMLConfigurations(samlConfigOne),
-                "saml");
+        applicationMgtRestClient.updateInboundDetailsOfApplication(appOneId, getSAMLConfigurations(samlConfigOne), SAML);
         SAML2ServiceProvider samlConfig = applicationMgtRestClient.getSAMLInboundDetails(appOneId);
         Assert.assertNotNull(samlConfig, "Adding a service provider has failed for " + samlConfigOne);
 


### PR DESCRIPTION
## This PR will remove the soap based api implementations used in IS Integration Tests in test cases mentioned below.

## Modified following test cases

### saml
- AbstractSAMLSSOTestCase
- SAMLIdPInitiatedSSOTestCase
- SAMLInvalidIssuerTestCase
- SAMLQueryProfileTestCase
- SAMLSSOConsentTestCase

## Added following rest clients
- `KeystoreMgtRestClient`

## Related PRs
- https://github.com/wso2/product-is/pull/16223
- https://github.com/wso2/product-is/pull/16271
- https://github.com/wso2/product-is/pull/16354
