### PR TITLE
Migrate security-mgt module from framework to its own group.

### DIFF
--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -265,7 +265,7 @@
             <version>${org.apache.velocity.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
             <artifactId>org.wso2.carbon.security.mgt.stub</artifactId>
         </dependency>
         <dependency>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -117,7 +117,7 @@
                                     org.wso2.carbon.analytics-common:org.wso2.carbon.event.publisher.aggregate.feature:${carbon.analytics-common.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity.framework:org.wso2.carbon.security.mgt.feature:${carbon.identity.framework.version}
+                                    org.wso2.carbon.security.mgt:org.wso2.carbon.security.mgt.feature:${carbon.security.mgt.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.inbound.auth.sts:org.wso2.carbon.mex.server.feature:${identity.inbound.auth.sts.version}
@@ -611,7 +611,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.security.mgt.feature.group</id>
-                                    <version>${carbon.identity.framework.version}</version>
+                                    <version>${carbon.security.mgt.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.registry.core.feature.group</id>
@@ -1232,7 +1232,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.security.mgt.feature.group</id>
-                                    <version>${carbon.identity.framework.version}</version>
+                                    <version>${carbon.security.mgt.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.registry.core.feature.group</id>
@@ -1743,7 +1743,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.security.mgt.server.feature.group</id>
-                                    <version>${carbon.identity.framework.version}</version>
+                                    <version>${carbon.security.mgt.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.registry.core.server.feature.group</id>
@@ -2268,7 +2268,7 @@
                                 <!-- 8 Carbon Identity -->
                                 <feature>
                                     <id>org.wso2.carbon.security.mgt.server.feature.group</id>
-                                    <version>${carbon.identity.framework.version}</version>
+                                    <version>${carbon.security.mgt.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.user.mgt.server.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2272,7 +2272,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.292</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.293</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--Carbon Security Mgt Version-->
@@ -2297,10 +2297,10 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.saml.version>5.11.19</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.11.106</identity.inbound.auth.oauth.version>
-        <identity.inbound.auth.openid.version>5.9.3</identity.inbound.auth.openid.version>
-        <identity.inbound.auth.sts.version>5.10.14</identity.inbound.auth.sts.version>
+        <identity.inbound.auth.saml.version>5.11.20</identity.inbound.auth.saml.version>
+        <identity.inbound.auth.oauth.version>6.11.108</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.openid.version>5.9.4</identity.inbound.auth.openid.version>
+        <identity.inbound.auth.sts.version>5.10.15</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.3</identity.inbound.provisioning.scim.version>
         <identity.inbound.provisioning.scim2.version>3.4.26</identity.inbound.provisioning.scim2.version>
 
@@ -2311,7 +2311,7 @@
 
 
         <!-- Identity User Versions -->
-        <identity.user.account.association.version>5.5.4</identity.user.account.association.version>
+        <identity.user.account.association.version>5.5.5</identity.user.account.association.version>
         <identity.user.ws.version>5.7.4</identity.user.ws.version>
 
         <!-- Identity Userstore Versions -->
@@ -2368,7 +2368,7 @@
         <identity.oauth2.token.exchange.grant.version>1.1.3</identity.oauth2.token.exchange.grant.version>
 
         <!--SAML Metadata-->
-        <identity.metadata.saml.version>1.7.5</identity.metadata.saml.version>
+        <identity.metadata.saml.version>1.7.6</identity.metadata.saml.version>
 
         <!-- Connector Versions -->
         <authenticator.totp.version>3.3.15</authenticator.totp.version>
@@ -2400,7 +2400,7 @@
         <identity.server.api.version>1.2.68</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
-        <identity.tool.samlsso.validator.version>5.5.4</identity.tool.samlsso.validator.version>
+        <identity.tool.samlsso.validator.version>5.5.5</identity.tool.samlsso.validator.version>
         <identity.app.authz.xacml.version>2.3.1</identity.app.authz.xacml.version>
         <identity.oauth.addons.version>2.4.25</identity.oauth.addons.version>
         <org.wso2.carbon.extension.identity.x509certificate.version>1.1.3</org.wso2.carbon.extension.identity.x509certificate.version>
@@ -2422,7 +2422,7 @@
         <carbon.deployment.version>4.12.20</carbon.deployment.version>
         <carbon.commons.version>4.10.5</carbon.commons.version>
         <carbon.registry.version>4.8.15</carbon.registry.version>
-        <carbon.multitenancy.version>4.11.8</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.11.9</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.business-process.version>4.5.66</carbon.business-process.version>
         <carbon.analytics-common.version>5.2.53</carbon.analytics-common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1357,9 +1357,9 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <groupId>org.wso2.carbon.security.mgt</groupId>
                 <artifactId>org.wso2.carbon.security.mgt.stub</artifactId>
-                <version>${carbon.identity.framework.version}</version>
+                <version>${carbon.security.mgt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.workflow.impl.bps</groupId>
@@ -2274,6 +2274,10 @@
         <!--Carbon Identity Framework Version-->
         <carbon.identity.framework.version>5.25.292</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
+
+        <!--Carbon Security Mgt Version-->
+        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
+        <carbon.security.mgt.version.range>[1.0.0,2.0.0)</carbon.security.mgt.version.range>
 
         <!--SAML Common Utils Version-->
         <saml.common.util.version>1.3.0</saml.common.util.version>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR contains the changes made to migrate the security-mgt component from framework and move it to new carbon.security.mgt group. This is a milestone of the following issue[1].

### Related Issues
- https://github.com/wso2/product-is/issues/16422

### When should this PR be merged
> This PR should be merged after the following set of PR got merged and released.

1. https://github.com/wso2-extensions/identity-metadata-saml2/pull/86
2. https://github.com/wso2-extensions/identity-tool-samlsso-validator/pull/43
3. https://github.com/wso2/carbon-multitenancy/pull/241
4. https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/401
5. https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/140
6. https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2137
7. https://github.com/wso2-extensions/identity-user-account-association/pull/49
8. https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/95
9. https://github.com/wso2/carbon-identity-framework/pull/4856
