### PR TITLE
Add integration tests for updating multiple governance connectors

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/IdentityGovernanceFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/IdentityGovernanceFailureTest.java
@@ -36,6 +36,10 @@ import java.io.IOException;
  */
 public class IdentityGovernanceFailureTest extends IdentityGovernanceTestBase {
 
+    private static final String CATEGORY_PASSWORD_POLICIES = "UGFzc3dvcmQgUG9saWNpZXM";
+    private static final String INCORRECT_CATEGORY_PASSWORD_POLICIES = "YWNjb3VudC5sb2mhhbmRsZXI";
+    private static final String CATEGORY_ACCOUNT_MANAGEMENT_PROPERTIES = "QWNjb3VudCBNYW5hZ2VtZW50";
+
     @Factory(dataProvider = "restAPIUserConfigProvider")
     public IdentityGovernanceFailureTest(TestUserMode userMode) throws Exception {
 
@@ -109,5 +113,32 @@ public class IdentityGovernanceFailureTest extends IdentityGovernanceTestBase {
         Response response = getResponseOfPost(IDENTITY_GOVERNANCE_ENDPOINT_URI + "/preferences", body);
         validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "IDG-50012",
                 "SelfRegistration.Enble");
+    }
+
+    @Test
+    public void testUpdateGovernanceConnectorsIncorrectCategoryID() throws IOException {
+
+        String body = readResource("update-multiple-connector-properties.json");
+        Response response = getResponseOfPatch(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                "/" + INCORRECT_CATEGORY_PASSWORD_POLICIES + "/connectors/", body);
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "IDG-50008");
+    }
+
+    @Test
+    public void testUpdateGovernanceConnectorsIncorrectConnectorID() throws IOException {
+
+        String body = readResource("update-multiple-connector-properties-incorrect.json");
+        Response response = getResponseOfPatch(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                                "/" + CATEGORY_PASSWORD_POLICIES + "/connectors/", body);
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "IDG-50009");
+    }
+
+    @Test
+    public void testUpdateGovernanceConnectorsMismatch() throws IOException {
+
+        String body = readResource("update-multiple-connector-properties.json");
+        Response response = getResponseOfPatch(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                "/" + CATEGORY_ACCOUNT_MANAGEMENT_PROPERTIES + "/connectors/", body);
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "IDG-50009");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/IdentityGovernanceSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/IdentityGovernanceSuccessTest.java
@@ -54,6 +54,9 @@ public class IdentityGovernanceSuccessTest extends IdentityGovernanceTestBase {
 
     private static final String CATEGORY_ACCOUNT_MANAGEMENT_PROPERTIES = "QWNjb3VudCBNYW5hZ2VtZW50";
     private static final String CONNECTOR_LOCK_IDLE_ACCOUNTS = "c3VzcGVuc2lvbi5ub3RpZmljYXRpb24";
+    private static final String CATEGORY_PASSWORD_POLICIES = "UGFzc3dvcmQgUG9saWNpZXM";
+    private static final String CONNECTOR_PASSWORD_EXPIRY = "cGFzc3dvcmRFeHBpcnlWMg";
+    private static final String CONNECTOR_PASSWORD_HISTORY = "cGFzc3dvcmRIaXN0b3J5";
     private Map<String, CategoriesRes> categories;
     private static List<PreferenceResp> connectors;
     private static List<PreferenceResp> connectorsWithAllProperties;
@@ -252,6 +255,41 @@ public class IdentityGovernanceSuccessTest extends IdentityGovernanceTestBase {
                 .body("properties.find{it.name == '" +
                                 "suspension.notification.account.disable.delay" + "' }.value",
                         equalTo("91"));
+    }
+
+    @Test
+    public void testUpdateGovernanceConnectors() throws IOException {
+
+        String body = readResource("update-multiple-connector-properties.json");
+        Response response =
+                getResponseOfPatch(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                                "/" + CATEGORY_PASSWORD_POLICIES + "/connectors/", body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+
+        Response getResponsePasswordExpiry =
+                getResponseOfGet(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                        "/" + CATEGORY_PASSWORD_POLICIES + "/connectors/" + CONNECTOR_PASSWORD_EXPIRY);
+
+        getResponsePasswordExpiry.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.find{it.name == 'passwordExpiry.enablePasswordExpiry' }.value",
+                        equalTo("true"));
+
+        Response getResponsePasswordHistory =
+                getResponseOfGet(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                        "/" + CATEGORY_PASSWORD_POLICIES + "/connectors/" + CONNECTOR_PASSWORD_HISTORY);
+
+        getResponsePasswordHistory.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.find{it.name == 'passwordHistory.enable' }.value",
+                        equalTo("true"));
     }
 
     @Test

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/update-multiple-connector-properties-incorrect.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/update-multiple-connector-properties-incorrect.json
@@ -1,0 +1,18 @@
+{
+  "operation": "UPDATE",
+  "connectors": [
+    {
+      "id": "cGFzc3dvcmRIaXN0b3J5",
+      "properties":[
+        {"name":"passwordHistory.count","value":"10"},{"name":"passwordHistory.enable","value":"true"}
+      ]
+    },
+    {
+      "id": "YWNjb3VudC5sb2mhhbmRsZXI",
+      "properties":[
+        {"name":"passwordExpiry.enablePasswordExpiry","value":"true"},
+        {"name":"passwordExpiry.passwordExpiryInDays","value":"20"}
+      ]
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/update-multiple-connector-properties.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/update-multiple-connector-properties.json
@@ -1,0 +1,18 @@
+{
+  "operation": "UPDATE",
+  "connectors": [
+    {
+      "id": "cGFzc3dvcmRIaXN0b3J5",
+      "properties":[
+        {"name":"passwordHistory.count","value":"10"},{"name":"passwordHistory.enable","value":"true"}
+      ]
+    },
+    {
+      "id": "cGFzc3dvcmRFeHBpcnlWMg",
+      "properties":[
+        {"name":"passwordExpiry.enablePasswordExpiry","value":"true"},
+        {"name":"passwordExpiry.passwordExpiryInDays","value":"20"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds integration tests for the newly introduced api endpoint for updating multiple governance connectors.

### Related PR

- https://github.com/wso2/identity-api-server/pull/476

### Related Issue

- https://github.com/wso2-enterprise/asgardeo-product/issues/18833