### PR TITLE
Add Idle account identification API artifacts

### DIFF
--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/beans.xml
@@ -141,6 +141,10 @@
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+            <bean class="org.wso2.carbon.identity.api.dispatcher.core.JsonProcessingExceptionMapper"/>
+            <bean class="org.wso2.carbon.identity.api.dispatcher.core.APIErrorExceptionMapper"/>
+            <bean class="org.wso2.carbon.identity.api.dispatcher.core.InputValidationExceptionMapper"/>
+            <bean class="org.wso2.carbon.identity.api.dispatcher.core.DefaultExceptionMapper"/>
         </jaxrs:providers>
     </jaxrs:server>
     <jaxrs:server id="users" address="/users/v1">


### PR DESCRIPTION
Related Issue:
- https://github.com/wso2/product-is/issues/16356

Add following provider beans for Idle account identification API
- org.wso2.carbon.identity.api.dispatcher.core.JsonProcessingExceptionMapper
- org.wso2.carbon.identity.api.dispatcher.core.APIErrorExceptionMapper
- org.wso2.carbon.identity.api.dispatcher.core.InputValidationExceptionMapper
- org.wso2.carbon.identity.api.dispatcher.core.DefaultExceptionMapper