### PR TITLE
Refactor: Switching to Service Account JSON Credentials

### DIFF
--- a/.github/workflows/migration-automation.yml
+++ b/.github/workflows/migration-automation.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
-
+        continue-on-error: true
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -277,6 +277,7 @@ jobs:
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+        continue-on-error: true
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -326,6 +327,9 @@ jobs:
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+        continue-on-error: true
+      - name: Persist Logs
+        run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
           cp ${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts/
         if: ${{ always() }}

--- a/.github/workflows/migration-automation.yml
+++ b/.github/workflows/migration-automation.yml
@@ -118,10 +118,7 @@ jobs:
               chmod +x  ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
               sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt" 
         continue-on-error: true
-      - name: Remove creds.json file
-        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
-
-      
+   
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -149,10 +146,7 @@ jobs:
             chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
             sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
-      - name: Remove creds.json file
-        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
-
-        
+      
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -208,8 +202,6 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
-      - name: Remove creds.json file
-        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - name: Persist Logs
         run: |
@@ -238,8 +230,6 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
-      - name: Remove creds.json file
-        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - name: Persist Logs
         run: |
@@ -290,8 +280,6 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
-      - name: Remove creds.json file
-        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - name: Persist Logs
         run: |
@@ -343,8 +331,6 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
-      - name: Remove creds.json file
-        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - name: Persist Logs
         run: |

--- a/.github/workflows/migration-automation.yml
+++ b/.github/workflows/migration-automation.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Save service account JSON credentials to a file
+        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
       - name: Setup Docker environment
         run: |
           # Get the ID of the workflow from the GitHub API using curl and jq
@@ -114,7 +116,7 @@ jobs:
       - name: Execute Migration Automation Script Ubuntu
         run: |
               chmod +x  ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
-              sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" "${{ secrets.GCP_CLIENT_ID }}" "${{ secrets.GCP_CLIENT_SECRET }}" "${{ secrets.GCP_REFRESH_TOKEN }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+              sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt" 
         continue-on-error: true
       
       - name: Persist Logs
@@ -137,10 +139,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Save service account JSON credentials to a file
+        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
       - name: Execute Migration Automation Script Ubuntu
         run: |
             chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
-            sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" "${{ secrets.GCP_CLIENT_ID }}" "${{ secrets.GCP_CLIENT_SECRET }}" "${{ secrets.GCP_REFRESH_TOKEN }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+            sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
         
       - name: Persist Logs
@@ -173,6 +177,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Save service account JSON credentials to a file
+        run: echo '${{ secrets.JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - name: Create MS SQL Database
         run: |
@@ -194,8 +200,7 @@ jobs:
       - name: Execute Migration Automation Script Ubuntu
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" "${{ secrets.GCP_CLIENT_ID }}" "${{ secrets.GCP_CLIENT_SECRET }}" "${{ secrets.GCP_REFRESH_TOKEN }}" | tee ${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt
-        continue-on-error: true
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
 
       - name: Persist Logs
         run: |
@@ -216,11 +221,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Save service account JSON credentials to a file
+        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - name: Execute Migration Automation Script Mac
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" "${{ secrets.GCP_CLIENT_ID }}" "${{ secrets.GCP_CLIENT_SECRET }}" "${{ secrets.GCP_REFRESH_TOKEN }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
       - name: Persist Logs
         run: |
@@ -241,6 +248,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Save service account JSON credentials to a file
+        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
       - name: Set up PostgreSQL
         env:
            PGDATA: /usr/local/var/postgres
@@ -267,8 +276,7 @@ jobs:
       - name: Execute Migration Automation Script Mac
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" "${{ secrets.GCP_CLIENT_ID }}" "${{ secrets.GCP_CLIENT_SECRET }}" "${{ secrets.GCP_REFRESH_TOKEN }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
-        continue-on-error: true
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -288,6 +296,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Save service account JSON credentials to a file
+        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
 
       - uses: potatoqualitee/mssqlsuite@v1.7
         with:
@@ -315,10 +325,7 @@ jobs:
       - name: Execute Migration Automation Script Mac
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" "${{ secrets.GCP_CLIENT_ID }}" "${{ secrets.GCP_CLIENT_SECRET }}" "${{ secrets.GCP_REFRESH_TOKEN }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
-        continue-on-error: true
-      - name: Persist Logs
-        run: |
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
           cp ${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts/
         if: ${{ always() }}

--- a/.github/workflows/migration-automation.yml
+++ b/.github/workflows/migration-automation.yml
@@ -118,6 +118,9 @@ jobs:
               chmod +x  ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
               sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt" 
         continue-on-error: true
+      - name: Remove creds.json file
+        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+
       
       - name: Persist Logs
         run: |
@@ -146,6 +149,9 @@ jobs:
             chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
             sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
+      - name: Remove creds.json file
+        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+
         
       - name: Persist Logs
         run: |
@@ -202,6 +208,9 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
+      - name: Remove creds.json file
+        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -229,6 +238,9 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
+      - name: Remove creds.json file
+        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -278,6 +290,9 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
+      - name: Remove creds.json file
+        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts
@@ -328,6 +343,9 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
           sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
+      - name: Remove creds.json file
+        run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+
       - name: Persist Logs
         run: |
           mkdir -p ${{ github.workspace }}/.github/migration-tester/migration-automation/artifacts

--- a/.github/workflows/migration-automation.yml
+++ b/.github/workflows/migration-automation.yml
@@ -54,8 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Save service account JSON credentials to a file
-        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+      - name: Set JSON credentials as an environment variable
+        run: echo "MIGRATION_JSON_ENCODED=$(echo '${{ secrets.MIGRATION_JSON }}' | base64 -w0)" >> $GITHUB_ENV
       - name: Setup Docker environment
         run: |
           # Get the ID of the workflow from the GitHub API using curl and jq
@@ -116,7 +116,7 @@ jobs:
       - name: Execute Migration Automation Script Ubuntu
         run: |
               chmod +x  ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
-              sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt" 
+              sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt" 
         continue-on-error: true
       - name: Remove creds.json file
         run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
@@ -142,12 +142,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Save service account JSON credentials to a file
-        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+      - name: Set JSON credentials as an environment variable
+        run: echo "MIGRATION_JSON_ENCODED=$(echo '${{ secrets.MIGRATION_JSON }}' | base64 -w0)" >> $GITHUB_ENV
       - name: Execute Migration Automation Script Ubuntu
         run: |
             chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
-            sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+            sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
       - name: Remove creds.json file
         run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
@@ -183,8 +183,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Save service account JSON credentials to a file
-        run: echo '${{ secrets.JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+      - name: Set JSON credentials as an environment variable
+        run: echo "MIGRATION_JSON_ENCODED=$(echo '${{ secrets.MIGRATION_JSON }}' | base64 -w0)" >> $GITHUB_ENV
 
       - name: Create MS SQL Database
         run: |
@@ -206,7 +206,7 @@ jobs:
       - name: Execute Migration Automation Script Ubuntu
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/ubuntu-os/migration-script-ubuntu.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
       - name: Remove creds.json file
         run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
@@ -230,13 +230,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Save service account JSON credentials to a file
-        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+      - name: Set JSON credentials as an environment variable
+        run: echo "MIGRATION_JSON_ENCODED=$(echo '${{ secrets.MIGRATION_JSON }}' | base64 -w0)" >> $GITHUB_ENV
 
       - name: Execute Migration Automation Script Mac
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
       - name: Remove creds.json file
         run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
@@ -260,8 +260,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Save service account JSON credentials to a file
-        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+      - name: Set JSON credentials as an environment variable
+        run: echo "MIGRATION_JSON_ENCODED=$(echo '${{ secrets.MIGRATION_JSON }}' | base64 -w0)" >> $GITHUB_ENV
       - name: Set up PostgreSQL
         env:
            PGDATA: /usr/local/var/postgres
@@ -288,7 +288,7 @@ jobs:
       - name: Execute Migration Automation Script Mac
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
       - name: Remove creds.json file
         run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
@@ -312,8 +312,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Save service account JSON credentials to a file
-        run: echo '${{ secrets.MIGRATION_JSON }}' > ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json
+      - name: Set JSON credentials as an environment variable
+        run: echo "MIGRATION_JSON_ENCODED=$(echo '${{ secrets.MIGRATION_JSON }}' | base64 -w0)" >> $GITHUB_ENV
 
       - uses: potatoqualitee/mssqlsuite@v1.7
         with:
@@ -341,7 +341,7 @@ jobs:
       - name: Execute Migration Automation Script Mac
         run: |
           chmod +x ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh 
-          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" creds.json | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
+          sh ${{ github.workspace }}/.github/migration-tester/migration-automation/mac-os/migration-script-mac.sh "${{ github.event.inputs.urlOld }}" "${{ github.event.inputs.urlNew }}" "${{ github.event.inputs.currentVersion }}" "${{ github.event.inputs.migratingVersion }}" "${{ github.event.inputs.database }}" "${{ github.event.inputs.os }}" "${{ secrets.MIGRATION_EMAIL }}" "${{ secrets.MIGRATION_PASSWORD }}" "${{ secrets.MIGRATION_PAT }}" | tee "${{ github.workspace }}/.github/migration-tester/migration-automation/logs.txt"
         continue-on-error: true
       - name: Remove creds.json file
         run: rm -f ${{ github.workspace }}/.github/migration-tester/migration-automation/creds.json


### PR DESCRIPTION
**Description:**

This pull request introduces a pivotal enhancement to the GitHub environment's mechanism for downloading GA packs from Google Drive during migration automation

**Changes Made:**

1.Transition to Service Account JSON Credentials:

The method for accessing Google Drive has been revamped. Instead of using a GCP API key, we now leverage a Service Account to download files. This is a more secure approach to handle file downloads from Google Drive. For this purpose, a dedicated file (creds.json) has been created temporarily to securely store the Service Account JSON credentials. creds.json  is deleted immediately after its intended use. This ensures that the credentials cannot be accessed post-operation, safeguarding against potential vulnerabilities.

2.Removal of Old GCP Credentials:

The older method of using the GCP API key, represented by the secrets GCP_CLIENT_ID, GCP_CLIENT_SECRET, and GCP_REFRESH_TOKEN, has been deprecated and removed from the workflow. This change aligns with the shift towards utilizing the Service Account for the file download operations.