### PR TITLE
Set subject attribute in EmailOTPTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/EmailOTPTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/EmailOTPTestCase.java
@@ -340,6 +340,7 @@ public class EmailOTPTestCase extends ISIntegrationTest {
         // This will add basic authentication as the first step for authentication.
         AuthenticationStep authenticationStepOne = new AuthenticationStep();
         authenticationStepOne.setStepOrder(1);
+        authenticationStepOne.setAttributeStep(true);
         LocalAuthenticatorConfig localConfig = new LocalAuthenticatorConfig();
         localConfig.setName(CommonConstants.BASIC_AUTHENTICATOR);
         localConfig.setDisplayName("basicauth");


### PR DESCRIPTION
Enable subject identifier in first step of 2FA from EmailOTPTestCase