### PR TITLE
Fix test failure

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
@@ -68,6 +68,10 @@
         "value": "true"
       },
       {
+        "name": "EmailVerification.AskPassword.AccountActivation",
+        "value": "true"
+      },
+      {
         "name": "EmailVerification.ExpiryTime",
         "value": "1440"
       },

--- a/pom.xml
+++ b/pom.xml
@@ -2283,7 +2283,7 @@
         <carbon.consent.mgt.version>2.5.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.8.63</identity.governance.version>
+        <identity.governance.version>1.8.65</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.8.5</identity.carbon.auth.saml2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2294,7 +2294,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.11.23</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.11.117</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.118</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.9.5</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.10.16</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.3</identity.inbound.provisioning.scim.version>
@@ -2372,7 +2372,7 @@
         <authenticator.office365.version>2.1.2</authenticator.office365.version>
         <authenticator.smsotp.version>3.3.11</authenticator.smsotp.version>
         <authenticator.magiclink.version>1.1.12</authenticator.magiclink.version>
-        <authenticator.emailotp.version>4.1.16</authenticator.emailotp.version>
+        <authenticator.emailotp.version>4.1.17</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.0.3</authenticator.local.auth.emailotp.version>
         <authenticator.twitter.version>1.1.1</authenticator.twitter.version>
         <authenticator.x509.version>3.1.11</authenticator.x509.version>


### PR DESCRIPTION
With this fix https://github.com/wso2-extensions/identity-governance/pull/650, new identity governance property introduced to disable account activation confirmation email notification. This PR contains the fix to resolve the integration test failure.