### PR TITLE
Add Integration tests for Custom Text Management API

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementFailureTest.java
@@ -252,6 +252,9 @@ public class BrandingPreferenceManagementFailureTest extends BrandingPreferenceM
 
         Response response = getResponseOfDelete(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
                 String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
-        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "BPM-60006");
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementFailureTest.java
@@ -167,4 +167,91 @@ public class BrandingPreferenceManagementFailureTest extends BrandingPreferenceM
         Response response = getResponseOfDelete(BRANDING_PREFERENCE_API_BASE_PATH);
         validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "BPM-60002");
     }
+
+    @Test
+    public void testAddCustomTextPreferenceWithEmptyJsonPreference() throws IOException {
+
+        String body = readResource("add-empty-custom-text-preference.json");
+        Response response = getResponseOfPost(CUSTOM_TEXT_API_BASE_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "BPM-60005");
+    }
+
+    @Test
+    public void testAddCustomTextPreferenceConflict() throws IOException {
+
+        String body = readResource("add-custom-text.json");
+        // Add Custom Text Preference.
+        Response response = getResponseOfPost(CUSTOM_TEXT_API_BASE_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+
+        // Add conflicting Custom Text Preference.
+        response = getResponseOfPost(CUSTOM_TEXT_API_BASE_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_CONFLICT, "BPM-60007");
+
+        // Delete Custom Text Preference.
+        response = getResponseOfDelete(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void testGetNotExistingCustomTextPreference() {
+
+        Response response = getResponseOfGet(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "BPM-60006");
+    }
+
+    @Test
+    public void testUpdateNotExistingCustomTextPreference() throws IOException {
+
+        String body = readResource("update-custom-text.json");
+        Response response = getResponseOfPut(CUSTOM_TEXT_API_BASE_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "BPM-60006");
+    }
+
+    @Test
+    public void testUpdateCustomTextPreferenceWithEmptyJsonPreference() throws IOException {
+
+        String body = readResource("add-custom-text.json");
+        // Add Custom Text Preference.
+        Response response = getResponseOfPost(CUSTOM_TEXT_API_BASE_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+
+        // Update Custom Text Preference with empty JSON preference.
+        body = readResource("add-empty-custom-text-preference.json");
+        response = getResponseOfPut(CUSTOM_TEXT_API_BASE_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "BPM-60005");
+
+        // Delete Custom Text Preference.
+        response = getResponseOfDelete(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void testDeleteNotExistingCustomTextPreference() {
+
+        Response response = getResponseOfDelete(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "BPM-60006");
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementSuccessTest.java
@@ -318,4 +318,126 @@ public class BrandingPreferenceManagementSuccessTest extends BrandingPreferenceM
                 .assertThat()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
+
+    @Test
+    public void testAddCustomTextPreference() throws IOException, JSONException {
+
+        String body = readResource("add-custom-text.json");
+        Response response = getResponseOfPost(CUSTOM_TEXT_API_BASE_PATH, body);
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+
+        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("add-custom-text.json")).
+                get("preference").toString());
+        JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
+                get("preference").toString());
+        Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
+                "The custom text preference schema of the Response is incorrect");
+    }
+
+    @Test(dependsOnMethods = {"testAddCustomTextPreference"})
+    public void testGetCustomTextPreference() throws IOException, JSONException {
+
+        Response response = getResponseOfGet(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("type", equalTo(ORGANIZATION_TYPE))
+                .body("name", equalTo(tenant))
+                .body("screen", equalTo(LOGIN_SCREEN))
+                .body("locale", equalTo(DEFAULT_LOCALE));
+
+        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("add-custom-text.json")).
+                get("preference").toString());
+        JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
+                get("preference").toString());
+        Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
+                "The custom text preference schema of the Response is incorrect");
+    }
+
+    @Test(dependsOnMethods = {"testGetCustomTextPreference"})
+    public void testGetCustomTextPreferenceByQueryParams() throws IOException, JSONException {
+
+        Response response = getResponseOfGet(CUSTOM_TEXT_API_BASE_PATH + String.format
+                (CUSTOM_TEXT_COMPONENT_WITH_QUERY_PARAM, ORGANIZATION_TYPE, tenant, LOGIN_SCREEN, DEFAULT_LOCALE));
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("type", equalTo(ORGANIZATION_TYPE))
+                .body("name", equalTo(tenant))
+                .body("screen", equalTo(LOGIN_SCREEN))
+                .body("locale", equalTo(DEFAULT_LOCALE));
+
+        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("add-custom-text.json")).
+                get("preference").toString());
+        JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
+                get("preference").toString());
+        Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
+                "The custom text preference schema of the Response is incorrect");
+    }
+
+    @Test(dependsOnMethods = {"testGetCustomTextPreferenceByQueryParams"})
+    public void testUpdateCustomTextPreference() throws IOException, JSONException {
+
+        String body = readResource("update-custom-text.json");
+        Response response = getResponseOfPut(CUSTOM_TEXT_API_BASE_PATH, body);
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("type", equalTo(ORGANIZATION_TYPE))
+                .body("name", equalTo(tenant))
+                .body("screen", equalTo(LOGIN_SCREEN))
+                .body("locale", equalTo(DEFAULT_LOCALE));
+
+        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("update-custom-text.json")).
+                get("preference").toString());
+        JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
+                get("preference").toString());
+        Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
+                "The custom text preference schema of the Response is incorrect");
+    }
+
+    @Test(dependsOnMethods = {"testUpdateCustomTextPreference"})
+    public void testGetCustomTextPreferenceAfterUpdate() throws IOException, JSONException {
+
+        Response response = getResponseOfGet(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("type", equalTo(ORGANIZATION_TYPE))
+                .body("name", equalTo(tenant))
+                .body("screen", equalTo(LOGIN_SCREEN))
+                .body("locale", equalTo(DEFAULT_LOCALE));
+
+        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("update-custom-text.json")).
+                get("preference").toString());
+        JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
+                get("preference").toString());
+        Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
+                "The custom text preference schema of the Response is incorrect");
+    }
+
+    @Test(dependsOnMethods = {"testGetCustomTextPreferenceAfterUpdate"})
+    public void testDeleteCustomTextPreference() {
+
+        Response response = getResponseOfDelete(CUSTOM_TEXT_API_BASE_PATH + QUERY_PARAM_SEPARATOR +
+                String.format(SCREEN_QUERY_PARAM, LOGIN_SCREEN));
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementSuccessTest.java
@@ -333,12 +333,11 @@ public class BrandingPreferenceManagementSuccessTest extends BrandingPreferenceM
         String location = response.getHeader(HttpHeaders.LOCATION);
         assertNotNull(location);
 
-        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("add-custom-text.json")).
-                get("preference").toString());
+        JSONObject expectedPreference = new JSONObject(new JSONObject(body).get("preference").toString());
         JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
                 get("preference").toString());
         Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
-                "The custom text preference schema of the Response is incorrect");
+                "The custom text preference schema of the Response is incorrect.");
     }
 
     @Test(dependsOnMethods = {"testAddCustomTextPreference"})
@@ -360,7 +359,7 @@ public class BrandingPreferenceManagementSuccessTest extends BrandingPreferenceM
         JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
                 get("preference").toString());
         Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),
-                "The custom text preference schema of the Response is incorrect");
+                "The custom text preference schema of the Response is incorrect.");
     }
 
     @Test(dependsOnMethods = {"testGetCustomTextPreference"})
@@ -400,8 +399,7 @@ public class BrandingPreferenceManagementSuccessTest extends BrandingPreferenceM
                 .body("screen", equalTo(LOGIN_SCREEN))
                 .body("locale", equalTo(DEFAULT_LOCALE));
 
-        JSONObject expectedPreference = new JSONObject(new JSONObject(readResource("update-custom-text.json")).
-                get("preference").toString());
+        JSONObject expectedPreference = new JSONObject(new JSONObject(body).get("preference").toString());
         JSONObject receivedPreference = new JSONObject(new JSONObject(response.asString()).
                 get("preference").toString());
         Assert.assertTrue(areJSONObjectsEqual(expectedPreference, receivedPreference),

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/BrandingPreferenceManagementTestBase.java
@@ -38,15 +38,19 @@ public class BrandingPreferenceManagementTestBase extends RESTAPIServerTestBase 
     public static final String API_PACKAGE_NAME =
             "org.wso2.carbon.identity.api.server.branding.preference.management.v1";
     public static final String BRANDING_PREFERENCE_API_BASE_PATH = "/branding-preference";
+    public static final String CUSTOM_TEXT_API_BASE_PATH = "/branding-preference/text";
     public static final String PATH_SEPARATOR = "/";
     public static final String QUERY_PARAM_SEPARATOR = "?";
     public static final String ORGANIZATION_TYPE = "ORG";
     public static final String APPLICATION_TYPE = "APP";
     public static final String CUSTOM_TYPE = "CUSTOM";
     public static final String DEFAULT_LOCALE = "en-US";
+    public static final String LOGIN_SCREEN = "login";
     public static final String PREFERENCE_COMPONENT_WITH_QUERY_PARAM = "?type=%s&name=%s&locale=%s";
+    public static final String CUSTOM_TEXT_COMPONENT_WITH_QUERY_PARAM = "?type=%s&name=%s&screen=%s&locale=%s";
     public static final String TYPE_QUERY_PARAM = "type=%s";
     public static final String LOCALE_QUERY_PARAM = "locale=%s";
+    public static final String SCREEN_QUERY_PARAM = "screen=%s";
 
     protected static String swaggerDefinition;
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/add-custom-text.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/add-custom-text.json
@@ -1,0 +1,16 @@
+{
+  "type": "ORG",
+  "name": "WSO2",
+  "locale": "en-US",
+  "screen": "login",
+  "preference": {
+    "login": "Sign In",
+    "welcome": "Welcome",
+    "account.linking": "Account Linking",
+    "username": "Username",
+    "email.username": "Email address",
+    "back.to.sign.in": "Back to Sign In",
+    "or": "Or",
+    "dont.have.an.account": "Don't have an account?"
+  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/add-empty-custom-text-preference.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/add-empty-custom-text-preference.json
@@ -1,0 +1,7 @@
+{
+  "type": "ORG",
+  "name": "organization-name",
+  "locale": "en-US",
+  "screen": "login",
+  "preference": {  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/update-custom-text.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/update-custom-text.json
@@ -1,0 +1,22 @@
+{
+  "type": "ORG",
+  "name": "WSO2",
+  "locale": "en-US",
+  "screen": "login",
+  "preference": {
+    "login": "Sign In",
+    "welcome": "Welcome",
+    "account.linking": "Account Linking",
+    "username": "Username",
+    "email.username": "Email address",
+    "back.to.sign.in": "Back to Sign In",
+    "or": "Or",
+    "dont.have.an.account": "Don't have an account?",
+    "password": "Password",
+    "confirm.password": "Confirm Password",
+    "email": "Email",
+    "enter.your.email": "Enter your email",
+    "enter.your.username": "Enter your username",
+    "enter.your.password": "Enter your password"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2298,7 +2298,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.375</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.378</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2414,12 +2414,12 @@
         <hashprovider.pbkdf2.version>0.1.4</hashprovider.pbkdf2.version>
 
         <!-- Identity Branding Preference Management Versions -->
-        <identity.branding.preference.management.version>1.0.7</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.0.8</identity.branding.preference.management.version>
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.13</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.22</identity.user.api.version>
-        <identity.server.api.version>1.2.86</identity.server.api.version>
+        <identity.server.api.version>1.2.87</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.7</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
## Purpose

Add Integration tests for the Custom-Text Management API.


##TODO

- [x] Bump framework version
- [x] Bump branding-prefernce-management version
- [x] Bump api-server version