### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2320,7 +2320,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.11.23</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.11.130</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.131</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.9.5</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.10.16</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.4</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
### Purpose
- Upgrade Jackson dependencies to 2.15.2

Related PRs
- https://github.com/wso2/identity-rest-dispatcher/pull/407
- https://github.com/wso2/carbon-deployment/pull/388