### PR TITLE
Fix failing integration tests when tenant qualified urls enabled

### DIFF
--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -499,6 +499,7 @@
                         <configuration>
                             <tasks>
                                 <ant antfile="src/test/resources/artifacts/IS/saml/saml-app-build.xml" target="saml-tenant-signingdisabled" />
+                                <ant antfile="src/test/resources/artifacts/IS/saml/saml-supertenant-app-build.xml" target="saml-supertenant-signingdisabled" />
                                 <ant antfile="src/test/resources/artifacts/IS/saml/registrymount/registry-app-build.xml" target="saml-tenant-registrymount" />
                             </tasks>
                         </configuration>

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/TomcatInitializerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/TomcatInitializerTestCase.java
@@ -38,6 +38,7 @@ public class TomcatInitializerTestCase extends ISIntegrationTest {
 
     private static final String[] APPLICATIONS = {
             "travelocity.com",
+            "travelocity.com-saml-supertenantwithoutsigning",
             "travelocity.com-saml-tenantwithoutsigning",
             "travelocity.com-registrymount",
             "avis.com",

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCFederatedIdpInitLogoutTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCFederatedIdpInitLogoutTest.java
@@ -102,7 +102,7 @@ public class OIDCFederatedIdpInitLogoutTest extends AbstractIdentityFederationTe
 
     private static final String SAML_SSO_LOGIN_URL = "http://localhost:8490/%s/samlsso?SAML2.HTTPBinding=%s";
     private static final String FEDERATED_SAML_SSO_URL =
-            "http://localhost:8490/travelocity.com-saml-tenantwithoutsigning/samlsso?SAML2.HTTPBinding=HTTP-Redirect";
+            "http://localhost:8490/travelocity.com-saml-supertenantwithoutsigning/samlsso?SAML2.HTTPBinding=HTTP-Redirect";
     private static final String PRIMARY_SAML_SSO_URL =
             "http://localhost:8490/travelocity.com/samlsso?SAML2.HTTPBinding=HTTP-Redirect";
 
@@ -117,10 +117,10 @@ public class OIDCFederatedIdpInitLogoutTest extends AbstractIdentityFederationTe
     private static final String PRIMARY_IS_SAML_NAME_ID_FORMAT =
             "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
 
-    private static final String FEDERATED_IS_SP_NAME = "travelocity.com-saml-tenantwithoutsigning";
-    private static final String FEDERATED_IS_SAML_ISSUER_NAME = "travelocity.com-saml-tenantwithoutsigning";
+    private static final String FEDERATED_IS_SP_NAME = "travelocity.com-saml-supertenantwithoutsigning";
+    private static final String FEDERATED_IS_SAML_ISSUER_NAME = "travelocity.com-saml-supertenantwithoutsigning";
     private static final String FEDERATED_IS_SAML_ACS_URL =
-            "http://localhost:8490/travelocity.com-saml-tenantwithoutsigning/home.jsp";
+            "http://localhost:8490/travelocity.com-saml-supertenantwithoutsigning/home.jsp";
 
     private static final String PRIMARY_IS_IDP_NAME = "trustedIdP";
     private static final String PRIMARY_IS_IDP_AUTHENTICATOR_NAME_OIDC = "OpenIDConnectAuthenticator";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/AbstractSAMLSSOTestCase.java
@@ -204,6 +204,7 @@ public abstract class AbstractSAMLSSOTestCase extends ISIntegrationTest {
 
         SUPER_TENANT_APP_WITH_SIGNING("travelocity.com", true),
         TENANT_APP_WITHOUT_SIGNING("travelocity.com-saml-tenantwithoutsigning", false),
+        SUPER_TENANT_APP_WITHOUT_SIGNING("travelocity.com-saml-supergtenantwithoutsigning", false),
         SUPER_TENANT_APP_WITH_SAMLARTIFACT_CONFIG("travelocity.com-saml-artifactresolving", false),
         TENANT_APP_WITH_SAMLARTIFACT_CONFIG("travelocity.com-saml-tenant-artifactresolving", false),
         ECP_APP("https://localhost/ecp-sp", false);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSLOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSLOTestCase.java
@@ -54,7 +54,7 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
     private static final String APPLICATION_ONE = "SAML-TestApplication-01";
     private static final String APPLICATION_TWO = "SAML-TestApplication-02";
     private static final String SAML_APP_ONE_ACS_URL = "http://localhost:8490/travelocity.com/home.jsp";
-    private static final String SAML_APP_TWO_ACS_URL = "http://localhost:8490/travelocity.com-saml-tenantwithoutsigning/home.jsp";
+    private static final String SAML_APP_TWO_ACS_URL = "http://localhost:8490/travelocity.com-saml-supertenantwithoutsigning/home.jsp";
 
     private final SAMLConfig samlConfigOne;
     private final SAMLConfig samlConfigTwo;
@@ -85,7 +85,7 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
                 {new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_POST,
                         ClaimType.LOCAL, App.SUPER_TENANT_APP_WITH_SIGNING),
                         new SAMLConfig(TestUserMode.SUPER_TENANT_ADMIN, User.SUPER_TENANT_USER, HttpBinding.HTTP_POST,
-                                ClaimType.LOCAL, App.TENANT_APP_WITHOUT_SIGNING)},
+                                ClaimType.LOCAL, App.SUPER_TENANT_APP_WITHOUT_SIGNING)},
         };
     }
 
@@ -224,7 +224,7 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
             boolean requestTwoSentLogFound = checkForLog(logViewer,
                     "single logout request is sent to : " + SAML_APP_TWO_ACS_URL + " is returned with OK");
             Assert.assertTrue(requestTwoSentLogFound, "System Log not found. Single logout request is not " +
-                    "sent to travelocity.com-saml-tenantwithoutsigning app.");
+                    "sent to travelocity.com-saml-supertenantwithoutsigning app.");
 
             boolean responseOneReceivedLogFound = checkForLog(logViewer,
                     "Logout response received for issuer: travelocity.com for tenant domain: carbon.super");
@@ -232,10 +232,10 @@ public class SAMLIdPInitiatedSLOTestCase extends AbstractSAMLSSOTestCase {
                     "received for issuer travelocity.com");
 
             boolean responseTwoReceivedLogFound = checkForLog(logViewer,
-                    "Logout response received for issuer: travelocity.com-saml-tenantwithoutsigning for " +
+                    "Logout response received for issuer: travelocity.com-saml-supertenantwithoutsigning for " +
                             "tenant domain: carbon.super");
             Assert.assertTrue(responseTwoReceivedLogFound, "System Log not found. Logout response is not " +
-                    "received for issuer travelocity.com-saml-tenantwithoutsigning");
+                    "received for issuer travelocity.com-saml-supertenantwithoutsigning");
         } catch (Exception e) {
             Assert.fail("SAML IdP initiated SLO test failed for " + samlConfigOne.getApp().getArtifact()
                     + " & " + samlConfigTwo.getApp().getArtifact(), e);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLQueryProfileTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLQueryProfileTestCase.java
@@ -188,7 +188,7 @@ public class SAMLQueryProfileTestCase extends AbstractSAMLSSOTestCase {
 
             if (config.getHttpBinding() == AbstractSAMLSSOTestCase.HttpBinding.HTTP_POST){
                 String samlRequest = Utils.extractDataFromResponse(response, CommonConstants.SAML_REQUEST_PARAM, 5);
-                response = super.sendSAMLMessage(tenantedSamlSSOUrl, CommonConstants.SAML_REQUEST_PARAM, samlRequest, config);
+                response = super.sendSAMLMessage(SAML_SSO_URL, CommonConstants.SAML_REQUEST_PARAM, samlRequest, config);
                 EntityUtils.consume(response.getEntity());
 
                 response = Utils.sendRedirectRequest(response, USER_AGENT, ACS_URL, config.getApp().getArtifact(),

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenant-saml-app-build.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenant-saml-app-build.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project name="travelocity-app-seperation-supertenant" default="saml-supertenant-signingdisabled" basedir="../../../../../../">
+    <description>
+        This script builds a war file for the travelocity app for super tenant sso with signature validation disabled
+    </description>
+    <!-- set global properties for this build -->
+    <property name="build" location="${basedir}/target/test-classes/samples"/>
+    <property name="travelocity.webapp"
+              location="${basedir}/target/test-classes/samples/org.wso2.sample.is.sso.agent"/>
+    <property name="travelocity.webapp.classes" location="${travelocity.webapp}/WEB-INF/classes"/>
+    <property name="travelocity.webapp.lib" location="${travelocity.webapp}/WEB-INF/lib"/>
+    <property name="travelocity.properties" location="${basedir}/src/test/resources/artifacts/IS/saml/"/>
+    <property name="travelocity.properties.supertenantwithoutsigning" location="${travelocity.properties}/supertenantwithoutsigning"/>
+
+    <target name="saml-supertenant-signingdisabled">
+        <delete
+                file="${travelocity.webapp.classes}/travelocity.properties"/>
+        <copy file="${travelocity.properties.supertenantwithoutsigning}/travelocity.properties"
+              tofile="${travelocity.webapp.classes}/travelocity.properties"/>
+        <war destfile="${build}/travelocity.com-saml-supertenantwithoutsigning.war"
+             webxml="${travelocity.webapp}/WEB-INF/web.xml">
+            <fileset
+                    dir="${travelocity.webapp}/">
+                <exclude name="**/WEB-INF/**"/>
+            </fileset>
+            <lib
+                    dir="${travelocity.webapp.lib}/" />
+            <classes
+                    dir="${travelocity.webapp.classes}/">
+            </classes>
+        </war>
+    </target>
+
+</project>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenant-saml-app-build.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenant-saml-app-build.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  WSO2 LLC. licenses this file to you under the Apache License,
   ~  Version 2.0 (the "License"); you may not use this file except
   ~  in compliance with the License.
   ~  You may obtain a copy of the License at

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenantwithoutsigning/travelocity.properties
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenantwithoutsigning/travelocity.properties
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+EnableSAML2SSOLogin=true
+EnableOpenIDLogin=true
+EnableOAuth2SAML2Grant=false
+
+#Url to do send SAML2 SSO AuthnRequest
+SAML2SSOURL=samlsso
+
+#Url to do initiate OAuth2 SAML2 Grant Request
+OAuth2SAML2GrantURL=token
+
+#Url to initiate OpenID Authentication Request
+OpenIdURL=openid
+
+#URIs to skip SSOAgentFilter; comma separated values
+SkipURIs=/travelocity.com-saml-supertenantwithoutsigning/index.jsp
+
+#A unique identifier for this SAML 2.0 Service Provider application
+SAML2.SPEntityId=travelocity.com-saml-supertenantwithoutsigning
+
+#The URL of the SAML 2.0 Assertion Consumer
+SAML2.AssertionConsumerURL=http://localhost:8490/travelocity.com-saml-supertenantwithoutsigning/home.jsp
+
+#A unique identifier for this SAML 2.0 Service Provider application
+SAML2.IdPEntityId=localhost
+
+#The URL of the SAML 2.0 Identity Provider
+SAML2.IdPURL=https://localhost:9853/samlsso
+
+#Identifier given for the Service Provider for SAML 2.0 attributes
+#exchange
+#SAML2.AttributeConsumingServiceIndex=1701087467
+
+#Specify if SingleLogout is enabled/disabled
+SAML2.EnableSLO=true
+
+#This is the URL that is used for SLO
+SAML2.SLOURL=logout
+
+#Specify if SAMLResponse element is signed
+SAML2.EnableResponseSigning=false
+
+#Specify if SAMLAssertion element is signed
+SAML2.EnableAssertionSigning=false
+
+#Specify if SAMLAssertion element is encrypted
+SAML2.EnableAssertionEncryption=false
+
+#Specify if AuthnRequests and LogoutRequests should be signed
+SAML2.EnableRequestSigning=true
+
+SAML2.ArtifactResolveUrl=https://localhost:9853/samlartresolve
+
+SAML2.EnableArtifactResolveSigning=true
+
+#Password of the KeyStore for SAML and OpenID
+KeyStorePassword=wso2carbon
+
+#Alias of the IdP's public certificate
+IdPPublicCertAlias=wso2carbon
+
+#Alias of the SP's private key
+PrivateKeyAlias=wso2carbon
+
+#Private key password to retrieve the private key used to sign
+#AuthnRequest and LogoutRequest messages
+PrivateKeyPassword=wso2carbon
+
+#OAuth2 token endpoint URL
+SAML2.OAuth2TokenURL=https://localhost:9853/oauth2/token
+
+#OAuth2 Client ID
+SAML2.OAuth2ClientId=Qn5DQHCYfshxeZh6R9SL1HM2lsMa
+
+#OAuth2 Client Secret
+SAML2.OAuth2ClientSecret=cbkAs1gajdwPAMbrSR54hPAIcz0a
+
+#OpenId Provider Url
+OpenId.ProviderURL=https://localhost:9853/openid/
+
+#openid.return_to parameter
+OpenId.ReturnToURL=http://localhost:8490/travelocity.com-saml-supertenantwithoutsigning/home.jsp
+
+#Custom SAML post binding request page
+#SAML.PostBinding.RequestPage=path/to/the/html
+
+#Additional request parameters
+#SAML.Request.Query.Param=&forceAuth=true
+
+#Specify whether the consumer requests user attributes from the provider
+OpenId.EnableAttributeExchange=true
+
+#Specify whether the consumer runs in dumb mode
+OpenId.EnableDumbMode=false

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenantwithoutsigning/travelocity.properties
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/supertenantwithoutsigning/travelocity.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
 #
-#  WSO2 Inc. licenses this file to you under the Apache License,
-#  Version 2.0 (the "License"); you may not use this file except
-#  in compliance with the License.
-#  You may obtain a copy of the License at
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/16999

When tenanted qualified urls are enabled, the Integration tests are failing due to using tenanted saml app for super tenant testing context. Add a new app for super tenant and use it corresponding tests.