### PR TITLE
Add support for role v2 management 

### DIFF
--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -301,6 +301,9 @@
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.role.mgt.core.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.role.v2.mgt.core.server.feature:${carbon.identity.framework.version}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.secret.mgt.core.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
                                 <!-- Features related to Cloud Identity -->
@@ -800,6 +803,10 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.role.mgt.core.server.feature.group</id>
+                                    <version>${carbon.identity.framework.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.role.v2.mgt.core.server.feature.group</id>
                                     <version>${carbon.identity.framework.version}</version>
                                 </feature>
                                 <feature>

--- a/pom.xml
+++ b/pom.xml
@@ -2298,7 +2298,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.416</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.420</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
With Support application roles for Identity Server and support RBAC for apps (https://github.com/wso2/product-is/issues/16363) we have introduce role v2 management. This PR will pack the role v2 mgt to IS. 