### PR TITLE
Improve Tenanted URL Resolving Logic of Integration Tests

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/identity/integration/common/utils/ISIntegrationTest.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/identity/integration/common/utils/ISIntegrationTest.java
@@ -179,7 +179,7 @@ public class ISIntegrationTest {
      * @param tenantDomain              Tenanted domain.
      * @return Tenant qualified URL without hostname.
      */
-    public String getTenantedRelativePath(String endpointURLWithHostname, String tenantDomain) {
+    public static String getTenantedRelativePath(String endpointURLWithHostname, String tenantDomain) {
 
         if(!tenantDomain.isBlank() && !tenantDomain.equalsIgnoreCase(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
             endpointURLWithHostname = TENANTED_URL_PATH_SPECIFIER + tenantDomain + endpointURLWithHostname;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ScopesTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ScopesTestCase.java
@@ -58,7 +58,8 @@ public class OAuth2ScopesTestCase extends ISIntegrationTest {
     public void testInit() throws Exception {
         super.init();
         String isServerBackendUrl = isServer.getContextUrls().getWebAppURLHttps();
-        scopeEndpoint = isServerBackendUrl + "/t/" + isServer.getContextTenant().getDomain() + SCOPE_ENDPOINT_SUFFIX;
+        scopeEndpoint = isServerBackendUrl +
+                getTenantedRelativePath(SCOPE_ENDPOINT_SUFFIX, isServer.getContextTenant().getDomain());
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
@@ -97,7 +97,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
     private static final String USERS_PATH = "users";
     private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----\n";
     private static final String END_CERTIFICATE = "\n-----END CERTIFICATE-----";
-    private static final String JWKS_BASE_PATH = "t/%s/oauth2/jwks";
+    private static final String JWKS_BASE_PATH = "/oauth2/jwks";
     private static final String COUNTRY_CLAIM_VALUE = "USA";
     private static final String COUNTRY_OIDC_CLAIM = "country";
     private static final String COUNTRY_NEW_OIDC_CLAIM = "customclaim";
@@ -517,7 +517,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
      */
     private String getEncodedCertificate() throws Exception {
         CloseableHttpClient client = HttpClients.createDefault();
-        String jwksEndpoint = serverURL + String.format(JWKS_BASE_PATH, tenantInfo.getDomain());
+        String jwksEndpoint = serverURL + getTenantedRelativePath(JWKS_BASE_PATH, tenantInfo.getDomain());
         String certificate = BEGIN_CERTIFICATE + getPublicCertificate(client, jwksEndpoint) + END_CERTIFICATE;
 
         return new String(Base64.getEncoder().encode(certificate.getBytes(StandardCharsets.UTF_8)),

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
@@ -79,7 +79,6 @@ public class RESTTestBase extends ISIntegrationTest {
             + File.separator + "deployment" + File.separator + "server" + File.separator + "webapps" + File
             .separator + "api" + File.separator + "WEB-INF" + File.separator
             + "lib" + File.separator;
-    protected static final String TENANT_CONTEXT_IN_URL = "/t/%s";
     private static final String JAR_EXTENSION = ".jar";
     protected static final String SERVICES = "/services";
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/common/RESTAPIServerTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/common/RESTAPIServerTestBase.java
@@ -17,6 +17,7 @@
 package org.wso2.identity.integration.test.rest.api.server.common;
 
 import org.apache.axis2.AxisFault;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
 import java.rmi.RemoteException;
@@ -29,15 +30,13 @@ public class RESTAPIServerTestBase extends RESTTestBase {
 
     protected static final String API_SERVER_BASE_PATH = "/api/server/%s";
     protected static final String API_SERVER_BASE_PATH_IN_SWAGGER = "/t/\\{tenant-domain\\}" + API_SERVER_BASE_PATH;
-    protected static final String API_SERVER_BASE_PATH_WITH_TENANT_CONTEXT =
-            TENANT_CONTEXT_IN_URL + API_SERVER_BASE_PATH;
 
     protected void testInit(String apiVersion, String apiDefinition, String tenantDomain)
             throws RemoteException {
 
         String basePathInSwagger = String.format(API_SERVER_BASE_PATH_IN_SWAGGER, apiVersion);
-        String basePath = String.format(API_SERVER_BASE_PATH_WITH_TENANT_CONTEXT,
-                tenantDomain, apiVersion);
+        String basePath = ISIntegrationTest.getTenantedRelativePath(String.format(API_SERVER_BASE_PATH, apiVersion),
+                tenantDomain);
         super.init(apiDefinition, basePathInSwagger, basePath);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v1/UserAuthorizedAppsBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v1/UserAuthorizedAppsBaseTest.java
@@ -38,7 +38,7 @@ public class UserAuthorizedAppsBaseTest extends RESTAPIUserTestBase {
     static String API_PACKAGE_NAME = "org.wso2.carbon.identity.rest.api.user.authorized.apps.v1";
 
     public static final String AUTHORIZED_APPS_ENDPOINT_URI = "/%s/authorized-apps/";
-    public static final String DCR_ENDPOINT_PATH_URI = "/t/%s/api/identity/oauth2/dcr/v1.1/register/";
+    public static final String DCR_ENDPOINT_PATH_URI = "/api/identity/oauth2/dcr/v1.1/register/";
 
     protected String userAuthorizedAppsEndpointUri;
     protected String dcrEndpointUri;
@@ -58,7 +58,7 @@ public class UserAuthorizedAppsBaseTest extends RESTAPIUserTestBase {
     void initUrls(String pathParam) {
 
         this.userAuthorizedAppsEndpointUri = String.format(AUTHORIZED_APPS_ENDPOINT_URI, pathParam);
-        this.dcrEndpointUri = String.format(DCR_ENDPOINT_PATH_URI, tenant);
+        this.dcrEndpointUri = getTenantedRelativePath(DCR_ENDPOINT_PATH_URI, tenant);
         this.tokenEndpointUri = getTenantedRelativePath("/oauth2/token", tenant);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v2/UserAuthorizedAppsBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/authorized/apps/v2/UserAuthorizedAppsBaseTest.java
@@ -42,7 +42,7 @@ public class UserAuthorizedAppsBaseTest extends RESTAPIUserTestBase {
 
     public static final String AUTHORIZED_APPS_ENDPOINT_URI = "/%s/authorized-apps/";
     public static final String APPLICATION_ENDPOINT_URI = "/authorized-apps/%s/tokens";
-    public static final String DCR_ENDPOINT_PATH_URI = "/t/%s/api/identity/oauth2/dcr/v1.1/register/";
+    public static final String DCR_ENDPOINT_PATH_URI = "/api/identity/oauth2/dcr/v1.1/register/";
 
     protected String userAuthorizedAppsEndpointUri;
     protected String userApplicationEndpointUri;
@@ -64,7 +64,7 @@ public class UserAuthorizedAppsBaseTest extends RESTAPIUserTestBase {
 
         this.userAuthorizedAppsEndpointUri = String.format(AUTHORIZED_APPS_ENDPOINT_URI, pathParam);
         this.userApplicationEndpointUri = APPLICATION_ENDPOINT_URI;
-        this.dcrEndpointUri = String.format(DCR_ENDPOINT_PATH_URI, tenant);
+        this.dcrEndpointUri = getTenantedRelativePath(DCR_ENDPOINT_PATH_URI, tenant);
         this.tokenEndpointUri = getTenantedRelativePath("/oauth2/token", tenant);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/RESTAPIUserTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/RESTAPIUserTestBase.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvide
 import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProviderProperty;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
 import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
 /**
@@ -34,7 +35,6 @@ public class RESTAPIUserTestBase extends RESTTestBase {
 
     protected static final String API_USERS_BASE_PATH = "/api/users/%s";
     protected static final String API_USERS_BASE_PATH_IN_SWAGGER = "/t/\\{tenant-domain\\}" + API_USERS_BASE_PATH;
-    protected static final String API_USERS_BASE_PATH_WITH_TENANT_CONTEXT = TENANT_CONTEXT_IN_URL + API_USERS_BASE_PATH;
     private static final String ADMIN = "admin";
     private IdentityProviderMgtServiceClient superTenantIDPMgtClient;
     private IdentityProviderMgtServiceClient tenantIDPMgtClient;
@@ -45,8 +45,8 @@ public class RESTAPIUserTestBase extends RESTTestBase {
             throws XPathExpressionException, RemoteException {
 
         String basePathInSwagger = String.format(API_USERS_BASE_PATH_IN_SWAGGER, apiVersion);
-        String basePath = String.format(API_USERS_BASE_PATH_WITH_TENANT_CONTEXT,
-                tenantDomain, apiVersion);
+        String basePath = ISIntegrationTest.getTenantedRelativePath(String.format(API_USERS_BASE_PATH, apiVersion),
+                tenantDomain);
         super.init(apiDefinition, basePathInSwagger, basePath);
     }
 
@@ -64,8 +64,8 @@ public class RESTAPIUserTestBase extends RESTTestBase {
             throws XPathExpressionException, RemoteException {
 
         String basePathInSwagger = String.format(apiUserBasePathInSwagger, apiVersion);
-        String basePath = String.format(apiUserBasePathWithTenantContext,
-                tenantDomain, apiVersion);
+        String basePath = ISIntegrationTest.getTenantedRelativePath(String.format(apiUserBasePathWithTenantContext,
+                apiVersion), tenantDomain);
         super.init(apiDefinition, basePathInSwagger, basePath);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/liteUserRegister/LiteUserRegisterTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/liteUserRegister/LiteUserRegisterTestCase.java
@@ -39,15 +39,13 @@ public class LiteUserRegisterTestCase extends LiteUserRegisterTestBase {
     protected static final String API_LITE_USER_REGISTER_BASE_PATH = "/api/identity/user/%s";
     protected static final String API_LITE_USER_REGISTER_BASE_PATH_IN_SWAGGER =
             "/t/\\{tenant-domain\\}" + API_LITE_USER_REGISTER_BASE_PATH;
-    protected static final String API_LITE_USER_REGISTER_BASE_PATH_WITH_TENANT_CONTEXT =
-            TENANT_CONTEXT_IN_URL + API_LITE_USER_REGISTER_BASE_PATH;
     protected static final String API_VERSION_LITE_USER = "v1.0";
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
 
         super.testInit(API_VERSION_LITE_USER, swaggerDefinitionLiteUserRegister, tenant,
-                API_LITE_USER_REGISTER_BASE_PATH_IN_SWAGGER, API_LITE_USER_REGISTER_BASE_PATH_WITH_TENANT_CONTEXT);
+                API_LITE_USER_REGISTER_BASE_PATH_IN_SWAGGER, API_LITE_USER_REGISTER_BASE_PATH);
     }
 
     @BeforeMethod(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTenantedTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTenantedTestCase.java
@@ -46,7 +46,7 @@ public class SelfRegisterTenantedTestCase extends SelfRegisterTestBase {
         this.tenant = context.getContextTenant().getDomain();
 
         super.testInit(API_VERSION_SELF_REGISTER, swaggerDefinitionSelfRegister, tenant,
-                API_SELF_REGISTER_BASE_PATH_IN_SWAGGER, API_SELF_REGISTER_BASE_PATH_WITH_TENANT_CONTEXT);
+                API_SELF_REGISTER_BASE_PATH_IN_SWAGGER, API_SELF_REGISTER_BASE_PATH);
         selfRegisterUserInfo = readResource("self-register-tenanted-user-request-body.json");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestBase.java
@@ -35,8 +35,6 @@ public class SelfRegisterTestBase extends RESTAPIUserTestBase {
     protected static final String API_SELF_REGISTER_BASE_PATH = "/api/identity/user/%s";
     protected static final String API_SELF_REGISTER_BASE_PATH_IN_SWAGGER =
             "/t/\\{tenant-domain\\}" + API_SELF_REGISTER_BASE_PATH;
-    protected static final String API_SELF_REGISTER_BASE_PATH_WITH_TENANT_CONTEXT =
-            TENANT_CONTEXT_IN_URL + API_SELF_REGISTER_BASE_PATH;
     protected static final String API_VERSION_SELF_REGISTER = "v1.0";
 
     static {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/selfRegister/SelfRegisterTestCase.java
@@ -46,7 +46,7 @@ public class SelfRegisterTestCase extends SelfRegisterTestBase {
         this.tenant = context.getContextTenant().getDomain();
 
         super.testInit(API_VERSION_SELF_REGISTER, swaggerDefinitionSelfRegister, tenant,
-                API_SELF_REGISTER_BASE_PATH_IN_SWAGGER, API_SELF_REGISTER_BASE_PATH_WITH_TENANT_CONTEXT);
+                API_SELF_REGISTER_BASE_PATH_IN_SWAGGER, API_SELF_REGISTER_BASE_PATH);
         selfRegisterUserInfo = readResource("self-register-request-body.json");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ChallengeQuestionsRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ChallengeQuestionsRestClient.java
@@ -25,6 +25,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.challenge.v1.model.UserChallengeAnswer;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
@@ -57,8 +58,8 @@ public class ChallengeQuestionsRestClient extends RestBaseClient {
                                            UserChallengeAnswer challengeAsnwerObj) throws Exception {
 
         String jsonRequest = toJSONString(challengeAsnwerObj);
-        String endPointUrl = serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR +
-                String.format(CHALLENGE_QUESTION_BASE_PATH, userId) + PATH_SEPARATOR +  questionSetId;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(String.format(
+                CHALLENGE_QUESTION_BASE_PATH, userId) + PATH_SEPARATOR +  questionSetId, tenantDomain);
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ClaimManagementRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ClaimManagementRestClient.java
@@ -29,6 +29,7 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.claim.management.v1.model.ExternalClaimReq;
 
 import javax.servlet.http.HttpServletResponse;
@@ -36,7 +37,6 @@ import java.io.IOException;
 
 public class ClaimManagementRestClient extends RestBaseClient {
 
-    private static final String TENANT_PATH = "t/%s";
     private static final String API_SERVER_BASE_PATH = "/api/server/v1";
     private static final String CLAIM_DIALECTS_ENDPOINT_URI = "/claim-dialects";
 
@@ -54,7 +54,7 @@ public class ClaimManagementRestClient extends RestBaseClient {
 
         String tenantDomain = tenantInfo.getContextUser().getUserDomain();
 
-        serverBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH;
+        serverBasePath = backendURL + ISIntegrationTest.getTenantedRelativePath(API_SERVER_BASE_PATH, tenantDomain);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/EmailTemplatesRestClient.java
@@ -29,11 +29,12 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+
 import java.io.IOException;
 
 public class EmailTemplatesRestClient extends RestBaseClient {
 
-    private static final String TENANT_PATH = "t/%s";
     private static final String API_SERVER_BASE_PATH = "/api/server/v1";
     private static final String EMAIL_TEMPLATES_EMAIL_BASE_PATH = "/email";
     private static final String EMAIL_TEMPLATE_TYPES_PATH = "/template-types";
@@ -51,8 +52,8 @@ public class EmailTemplatesRestClient extends RestBaseClient {
 
         String tenantDomain = tenantInfo.getContextUser().getUserDomain();
 
-        emailTemplateApiBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
-                EMAIL_TEMPLATES_EMAIL_BASE_PATH + EMAIL_TEMPLATE_TYPES_PATH;
+        emailTemplateApiBasePath = backendURL + ISIntegrationTest.getTenantedRelativePath(API_SERVER_BASE_PATH
+                + EMAIL_TEMPLATES_EMAIL_BASE_PATH + EMAIL_TEMPLATE_TYPES_PATH, tenantDomain);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
@@ -30,6 +30,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
 
 import javax.servlet.http.HttpServletResponse;
@@ -37,7 +38,6 @@ import java.io.IOException;
 
 public class IdentityGovernanceRestClient extends RestBaseClient {
 
-    private static final String TENANT_PATH = "t/%s";
     private static final String API_SERVER_BASE_PATH = "/api/server/v1";
     private static final String IDENTITY_GOVERNANCE_BASE_PATH = "/identity-governance";
     private static final String CONNECTORS_BASE_PATH = "/connectors";
@@ -54,8 +54,8 @@ public class IdentityGovernanceRestClient extends RestBaseClient {
 
         String tenantDomain = tenantInfo.getContextUser().getUserDomain();
 
-        identityGovernanceApiBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
-                IDENTITY_GOVERNANCE_BASE_PATH;
+        identityGovernanceApiBasePath = backendURL + ISIntegrationTest.getTenantedRelativePath(
+                API_SERVER_BASE_PATH + IDENTITY_GOVERNANCE_BASE_PATH, tenantDomain);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdpMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdpMgtRestClient.java
@@ -27,6 +27,7 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Claims;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.IdentityProviderPOSTRequest;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -38,7 +39,7 @@ public class IdpMgtRestClient extends RestBaseClient {
     private static final String CLAIMS_PATH = "/claims";
     private static final String FEDERATED_AUTHENTICATORS_PATH = "/federated-authenticators/";
     private final String serverUrl;
-    private final String IDENTITY_PROVIDER_BASE_PATH = "t/%s/api/server/v1/identity-providers";
+    private final String IDENTITY_PROVIDER_BASE_PATH = "/api/server/v1/identity-providers";
     private final String tenantDomain;
     private final String username;
     private final String password;
@@ -58,7 +59,7 @@ public class IdpMgtRestClient extends RestBaseClient {
      */
     public String createIdentityProvider(IdentityProviderPOSTRequest idpCreateReqObj) throws Exception {
         String jsonRequest = toJSONString(idpCreateReqObj);
-        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain);
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(IDENTITY_PROVIDER_BASE_PATH, tenantDomain);
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
@@ -76,8 +77,8 @@ public class IdpMgtRestClient extends RestBaseClient {
      * @return JSONObject with Federated Authenticator details.
      */
     public JSONObject getIdpFederatedAuthenticator(String idpId, String federatedAuthenticatorId) throws Exception {
-        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain)+ PATH_SEPARATOR + 
-                idpId + FEDERATED_AUTHENTICATORS_PATH + federatedAuthenticatorId;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(IDENTITY_PROVIDER_BASE_PATH,
+                tenantDomain) + PATH_SEPARATOR + idpId + FEDERATED_AUTHENTICATORS_PATH + federatedAuthenticatorId;
 
         try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
             String responseBody = EntityUtils.toString(response.getEntity());
@@ -93,8 +94,8 @@ public class IdpMgtRestClient extends RestBaseClient {
      */
     public void updateIdpClaimConfig(String idpId, Claims idpClaims) throws IOException {
         String jsonRequest = toJSONString(idpClaims);
-        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain) + PATH_SEPARATOR +
-                idpId + CLAIMS_PATH;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(IDENTITY_PROVIDER_BASE_PATH,
+                tenantDomain) + PATH_SEPARATOR + idpId + CLAIMS_PATH;
 
         try (CloseableHttpResponse response = getResponseOfHttpPut(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
@@ -108,8 +109,8 @@ public class IdpMgtRestClient extends RestBaseClient {
      * @param idpId Identity Provider Id
      */
     public void deleteIdp(String idpId) throws IOException {
-        String endPointUrl = serverUrl + String.format(IDENTITY_PROVIDER_BASE_PATH, tenantDomain) + PATH_SEPARATOR +
-                idpId;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(IDENTITY_PROVIDER_BASE_PATH,
+                tenantDomain) + PATH_SEPARATOR + idpId;
 
         try (CloseableHttpResponse response = getResponseOfHttpDelete(endPointUrl, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_NO_CONTENT,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/KeystoreMgtRestClient.java
@@ -25,6 +25,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.model.CertificateRequest;
 
 import javax.servlet.http.HttpServletResponse;
@@ -32,7 +33,7 @@ import java.io.IOException;
 
 public class KeystoreMgtRestClient extends RestBaseClient {
 
-    private static final String KEYSTORE_BASE_PATH = "t/%s/api/server/v1/keystores/certs";
+    private static final String KEYSTORE_BASE_PATH = "/api/server/v1/keystores/certs";
     private final String serverUrl;
     private final String tenantDomain;
     private final String username;
@@ -53,7 +54,7 @@ public class KeystoreMgtRestClient extends RestBaseClient {
      */
     public void importCertToStore(CertificateRequest certificateRequest) throws Exception {
         String jsonRequest = toJSONString(certificateRequest);
-        String endPointUrl = serverUrl + String.format(KEYSTORE_BASE_PATH, tenantDomain);
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(KEYSTORE_BASE_PATH, tenantDomain);
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
@@ -68,7 +69,8 @@ public class KeystoreMgtRestClient extends RestBaseClient {
      * @return Boolean status of certificate availability in tenant keystore.
      */
     public Boolean checkCertInStore(String alias) throws Exception {
-        String endPointUrl = serverUrl + String.format(KEYSTORE_BASE_PATH, tenantDomain) + PATH_SEPARATOR + alias;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(KEYSTORE_BASE_PATH, tenantDomain)
+                + PATH_SEPARATOR + alias;
 
         try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
             return response.getStatusLine().getStatusCode() == HttpServletResponse.SC_OK;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OIDCScopeMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OIDCScopeMgtRestClient.java
@@ -29,6 +29,7 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.model.ScopeUpdateRequest;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
@@ -37,7 +38,7 @@ import java.io.IOException;
 
 public class OIDCScopeMgtRestClient extends RestBaseClient {
     private final String serverUrl;
-    private final String OIDC_SCOPE_MGT_BASE_PATH = "t/%s/api/server/v1/oidc/scopes";
+    private final String OIDC_SCOPE_MGT_BASE_PATH = "/api/server/v1/oidc/scopes";
     private final String tenantDomain;
     private final String username;
     private final String password;
@@ -57,8 +58,8 @@ public class OIDCScopeMgtRestClient extends RestBaseClient {
      * @return Scope object.
      */
     public JSONObject getScope(String scopeId) throws Exception {
-        String endPointUrl = serverUrl + String.format(OIDC_SCOPE_MGT_BASE_PATH, tenantDomain) +
-                PATH_SEPARATOR +  scopeId;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(OIDC_SCOPE_MGT_BASE_PATH,
+                tenantDomain) + PATH_SEPARATOR +  scopeId;
 
         try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
             return getJSONObject(EntityUtils.toString(response.getEntity()));
@@ -73,8 +74,8 @@ public class OIDCScopeMgtRestClient extends RestBaseClient {
      */
     public void updateScope(String scopeId, ScopeUpdateRequest scopeUpdateObj) throws Exception {
         String jsonRequest = toJSONString(scopeUpdateObj);
-        String endPointUrl = serverUrl + String.format(OIDC_SCOPE_MGT_BASE_PATH, tenantDomain) +
-                PATH_SEPARATOR +  scopeId;
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(OIDC_SCOPE_MGT_BASE_PATH,
+                tenantDomain) + PATH_SEPARATOR +  scopeId;
 
         try (CloseableHttpResponse response = getResponseOfHttpPut(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UserStoreMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UserStoreMgtRestClient.java
@@ -32,13 +32,13 @@ import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.identity.user.store.configuration.stub.dto.UserStoreDTO;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.user.store.v1.model.UserStoreReq;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class UserStoreMgtRestClient extends RestBaseClient {
-    private static final String TENANT_PATH = "t/%s";
     private static final String API_SERVER_BASE_PATH = "/api/server/v1";
     public static final String USER_STORES_ENDPOINT_URI = "/userstores";
     private final CloseableHttpClient client;
@@ -53,8 +53,8 @@ public class UserStoreMgtRestClient extends RestBaseClient {
         this.password = tenantInfo.getContextUser().getPassword();
         String tenantDomain = tenantInfo.getContextUser().getUserDomain();
 
-        userStoreBasePath = backendURL + String.format(TENANT_PATH, tenantDomain) + API_SERVER_BASE_PATH +
-                USER_STORES_ENDPOINT_URI;
+        userStoreBasePath = backendURL + ISIntegrationTest.getTenantedRelativePath(API_SERVER_BASE_PATH
+                + USER_STORES_ENDPOINT_URI, tenantDomain);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2BaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2BaseTest.java
@@ -23,6 +23,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 
 import java.io.File;
@@ -38,7 +39,6 @@ public class SCIM2BaseTest extends RESTTestBase {
     protected static String swaggerDefinition;
     protected static final String SCIM_CONTENT_TYPE = "application/scim+json";
     protected static final String SCIM2_BASE_PATH_IN_SWAGGER = "/t/\\{tenant-domain\\}" + SCIM2_ENDPOINT;
-    protected static final String SCIM2_BASE_PATH_WITH_TENANT_CONTEXT = TENANT_CONTEXT_IN_URL + SCIM2_ENDPOINT;
     public static final String FILE_BASE_PATH = (System.getProperty("basedir", "."))
             + File.separator + "src" + File.separator + "test"
             + File.separator + "resources" + File.separator;
@@ -59,8 +59,7 @@ public class SCIM2BaseTest extends RESTTestBase {
         if ("carbon.super".equals(tenantDomain)) {
             basePath = String.format(SCIM2_ENDPOINT);
         } else {
-            basePath = String.format(SCIM2_BASE_PATH_WITH_TENANT_CONTEXT,
-                    tenantDomain);
+            basePath = ISIntegrationTest.getTenantedRelativePath(SCIM2_ENDPOINT, tenantDomain);
         }
         super.init(apiDefinition, SCIM2_BASE_PATH_IN_SWAGGER, basePath);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2SchemasTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2SchemasTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -194,7 +195,7 @@ public class SCIM2SchemasTest extends SCIM2BaseTest {
         if (CARBON_SUPER.equals(tenant)) {
             return API_SERVER_BASE_CONTEXT;
         } else {
-            return String.format(TENANT_CONTEXT_IN_URL, tenant) + API_SERVER_BASE_CONTEXT;
+            return ISIntegrationTest.getTenantedRelativePath(API_SERVER_BASE_CONTEXT, tenant);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2320,7 +2320,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.11.26</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.11.155</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.160</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.9.5</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.10.17</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.4</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
This PR uses the `getTenantedRelativePath` method to build the tenanted urls for endpoints used in integration tests. With this method, for super tenant the tenant will not be appended to the path and for all other cases the tenant domain will be appended to the URL as `/t/<tenant>`.

Related issue: https://github.com/wso2/product-is/issues/16999