### PR TITLE
Re: "Add integration tests for inbound auth config APIs"

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigFailureTest.java
@@ -120,4 +120,13 @@ public class ConfigFailureTest extends ConfigTestBase {
         Response response = getResponseOfPatch(CORS_CONFIGS_API_BASE_PATH, body);
         validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "CNF-60003", "Unsupported patch operation");
     }
+
+    @Test
+    public void testUpdateSAMLInboundAuthConfigsWithEmptyDestinationUrls() throws IOException {
+
+        String body = readResource("update-saml-inbound-auth-configs-invalid.json");
+        Response response = getResponseOfPatch(SAML_INBOUND_AUTH_CONFIG_API_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "CNF-60003",
+                "One of the given inputs is invalid. Should contain at least one destination URL.");
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigSuccessTest.java
@@ -325,7 +325,10 @@ public class ConfigSuccessTest extends ConfigTestBase {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("enableRequestSigning", equalTo(false))
-                .body("passiveSTSUrl", equalTo(PASSIVE_STS_URL));
+                .body("passiveSTSUrl",
+                        MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(context.getContextTenant().getDomain())
+                                ? equalTo(PASSIVE_STS_URL_SUPER_TENANT)
+                                : equalTo(PASSIVE_STS_URL_TENANT));
     }
 
     @Test(dependsOnMethods = {"testGetPassiveSTSInboundAuthConfigs"})

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
@@ -40,6 +40,14 @@ public class ConfigTestBase extends RESTAPIServerTestBase {
     public static final String CONFIGS_INBOUND_SCIM_API_BASE_PATH = "/configs/provisioning/inbound/scim";
     public static final String CORS_CONFIGS_API_BASE_PATH = "/configs/cors";
     public static final String HOME_REALM_IDENTIFIERS_API_BASE_PATH = "/configs/home-realm-identifiers";
+    public static final String SAML_INBOUND_AUTH_CONFIG_API_PATH = "/configs/authentication/inbound/saml2";
+    public static final String PASSIVE_STS_INBOUND_AUTH_CONFIG_API_PATH = "/configs/authentication/inbound/passivests";
+    public static final String SAML_METADATA_ENDPOINT_SUPER_TENANT = "https://localhost:9853/identity/metadata/saml2";
+    public static final String SAML_METADATA_ENDPOINT_TENANT =
+            "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
+    public static final String SAML_SSO_URL_SUPER_TENANT = "https://localhost:9853/samlsso";
+    public static final String SAML_SSO_URL_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
+    public static final String PASSIVE_STS_URL = "https://localhost:9853/passivests";
 
     public static final String PATH_SEPARATOR = "/";
     public static final String SAMPLE_AUTHENTICATOR_ID = "QmFzaWNBdXRoZW50aWNhdG9y";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
@@ -46,7 +46,7 @@ public class ConfigTestBase extends RESTAPIServerTestBase {
     public static final String SAML_METADATA_ENDPOINT_TENANT =
             "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
     public static final String SAML_SSO_URL_SUPER_TENANT = "https://localhost:9853/samlsso";
-    public static final String SAML_SSO_URL_TENANT = "https://localhost:9853/samlsso?tenantDomain=wso2.com";
+    public static final String SAML_SSO_URL_TENANT = "https://localhost:9853/t/wso2.com/samlsso";
     public static final String PASSIVE_STS_URL = "https://localhost:9853/passivests";
 
     public static final String PATH_SEPARATOR = "/";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigTestBase.java
@@ -47,7 +47,8 @@ public class ConfigTestBase extends RESTAPIServerTestBase {
             "https://localhost:9853/t/wso2.com/identity/metadata/saml2";
     public static final String SAML_SSO_URL_SUPER_TENANT = "https://localhost:9853/samlsso";
     public static final String SAML_SSO_URL_TENANT = "https://localhost:9853/t/wso2.com/samlsso";
-    public static final String PASSIVE_STS_URL = "https://localhost:9853/passivests";
+    public static final String PASSIVE_STS_URL_SUPER_TENANT = "https://localhost:9853/passivests";
+    public static final String PASSIVE_STS_URL_TENANT = "https://localhost:9853/t/wso2.com/passivests";
 
     public static final String PATH_SEPARATOR = "/";
     public static final String SAMPLE_AUTHENTICATOR_ID = "QmFzaWNBdXRoZW50aWNhdG9y";

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/update-passive-sts-inbound-auth-configs.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/update-passive-sts-inbound-auth-configs.json
@@ -1,0 +1,3 @@
+{
+  "enableRequestSigning": true
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/update-saml-inbound-auth-configs-invalid.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/update-saml-inbound-auth-configs-invalid.json
@@ -1,0 +1,5 @@
+{
+  "destinationURLs": [],
+  "metadataValidityPeriod": 120,
+  "enableMetadataSigning": true
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/update-saml-inbound-auth-configs.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/update-saml-inbound-auth-configs.json
@@ -1,0 +1,7 @@
+{
+  "destinationURLs": [
+    "https://localhost:9853/test/updated"
+  ],
+  "metadataValidityPeriod": 120,
+  "enableMetadataSigning": true
+}


### PR DESCRIPTION
Add integration tests originally added with https://github.com/wso2/product-is/pull/16925 which were reverted with https://github.com/wso2/product-is/pull/17088.

This PR contains the fixes for the tenant qualified URLs enabled mode.