### PR TITLE
Fix test failures due to new send-otp-in-email configuration

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-VXNlciBPbmJvYXJkaW5n-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-VXNlciBPbmJvYXJkaW5n-response.json
@@ -22,6 +22,36 @@
           "description": "Lock self registered user account until e-mail verification."
         },
         {
+          "name": "SelfRegistration.OTP.SendOTPInEmail",
+          "value": "false",
+          "displayName": "Send OTP in e-mail",
+          "description": "Enable to send OTP in verification e-mail instead of confirmation code."
+        },
+        {
+          "name": "SelfRegistration.OTP.UseUppercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include uppercase characters in OTP",
+          "description": "Enable to include uppercase characters in SMS and e-mail OTPs."
+        },
+        {
+          "name": "SelfRegistration.OTP.UseLowercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include lowercase characters in OTP",
+          "description": "Enable to include lowercase characters in SMS and e-mail OTPs."
+        },
+        {
+          "name": "SelfRegistration.OTP.UseNumbersInOTP",
+          "value": "true",
+          "displayName": "Include numbers in OTP",
+          "description": "Enable to include numbers in SMS and e-mail OTPs."
+        },
+        {
+          "name": "SelfRegistration.OTP.OTPLength",
+          "value": "6",
+          "displayName": "OTP length",
+          "description": "Length of the OTP for SMS and e-mail verifications. OTP length must be 4-10."
+        },
+        {
           "name": "SelfRegistration.SendConfirmationOnCreation",
           "value": "false",
           "displayName": "Enable Account Confirmation On Creation",
@@ -50,12 +80,6 @@
           "value": "1",
           "displayName": "User self registration SMS OTP expiry time",
           "description": "Specify the expiry time in minutes for the SMS OTP."
-        },
-        {
-          "name": "SelfRegistration.SMSOTP.Regex",
-          "value": "[a-zA-Z0-9]{6}",
-          "displayName": "User self registration SMS OTP regex",
-          "description": "Regex for SMS OTP in format [allowed characters]{length}. Supported character ranges are a-z, A-Z, 0-9. Minimum OTP length is 4"
         },
         {
           "name": "SelfRegistration.CallbackRegex",
@@ -142,6 +166,36 @@
           "value": "false",
           "displayName": "Enable user email verification",
           "description": "A verification notification will be triggered during user creation."
+        },
+        {
+          "name": "EmailVerification.OTP.SendOTPInEmail",
+          "value": "false",
+          "displayName": "Send OTP in e-mail",
+          "description": "Enable to send OTP in verification e-mail instead of confirmation code."
+        },
+        {
+          "name": "EmailVerification.OTP.UseUppercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include uppercase characters in OTP",
+          "description": "Enable to include uppercase characters in SMS and e-mail OTPs."
+        },
+        {
+          "name": "EmailVerification.OTP.UseLowercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include lowercase characters in OTP",
+          "description": "Enable to include lowercase characters in SMS and e-mail OTPs."
+        },
+        {
+          "name": "EmailVerification.OTP.UseNumbersInOTP",
+          "value": "true",
+          "displayName": "Include numbers in OTP",
+          "description": "Enable to include numbers in SMS and e-mail OTPs."
+        },
+        {
+          "name": "EmailVerification.OTP.OTPLength",
+          "value": "6",
+          "displayName": "OTP length",
+          "description": "Length of the OTP for SMS and e-mail verifications. OTP length must be 4-10."
         },
         {
           "name": "EmailVerification.LockOnCreation",

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
@@ -11,6 +11,26 @@
         "value": "true"
       },
       {
+        "name": "SelfRegistration.OTP.SendOTPInEmail",
+        "value": "false"
+      },
+      {
+        "name": "SelfRegistration.OTP.UseUppercaseCharactersInOTP",
+        "value": "true"
+      },
+      {
+        "name": "SelfRegistration.OTP.UseLowercaseCharactersInOTP",
+        "value": "true"
+      },
+      {
+        "name": "SelfRegistration.OTP.UseNumbersInOTP",
+        "value": "true"
+      },
+      {
+        "name": "SelfRegistration.OTP.OTPLength",
+        "value": "6"
+      },
+      {
         "name": "SelfRegistration.SendConfirmationOnCreation",
         "value": "false"
       },
@@ -29,10 +49,6 @@
       {
         "name": "SelfRegistration.VerificationCode.SMSOTP.ExpiryTime",
         "value": "1"
-      },
-      {
-        "name": "SelfRegistration.SMSOTP.Regex",
-        "value": "[a-zA-Z0-9]{6}"
       },
       {
         "name": "SelfRegistration.CallbackRegex",
@@ -58,6 +74,26 @@
       {
         "name": "EmailVerification.Enable",
         "value": "false"
+      },
+      {
+        "name": "EmailVerification.OTP.SendOTPInEmail",
+        "value": "false"
+      },
+      {
+        "name": "EmailVerification.OTP.UseUppercaseCharactersInOTP",
+        "value": "true"
+      },
+      {
+        "name": "EmailVerification.OTP.UseLowercaseCharactersInOTP",
+        "value": "true"
+      },
+      {
+        "name": "EmailVerification.OTP.UseNumbersInOTP",
+        "value": "true"
+      },
+      {
+        "name": "EmailVerification.OTP.OTPLength",
+        "value": "6"
       },
       {
         "name": "EmailVerification.LockOnCreation",

--- a/pom.xml
+++ b/pom.xml
@@ -2309,7 +2309,7 @@
         <carbon.consent.mgt.version>2.5.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.8.82</identity.governance.version>
+        <identity.governance.version>1.8.83</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.8.5</identity.carbon.auth.saml2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2298,7 +2298,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.450</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.451</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
### Purpose
- The `IdentityGovernanceSuccessTest` test case is failing due to introduction of new properties related to sending OTP in email and removing SMSOTP.Regex property in governance connectors.
- This PR fixes this by removing the `SelfRegistration.SMSOTP.Regex` adding new properties in the test responses.


### Related Issue
- https://github.com/wso2/product-is/issues/14808

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/776
- https://github.com/wso2/carbon-identity-framework/pull/4256