### PR TITLE
Fix integration tests to support crud operations on sms provider configurations in super tenant

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v1/NotificationSenderFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v1/NotificationSenderFailureTest.java
@@ -169,24 +169,14 @@ public class NotificationSenderFailureTest extends NotificationSenderTestBase {
         String body = readResource("add-sms-sender.json");
         Response response =
                 getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_CREATED)
-                    .header(HttpHeaders.LOCATION, notNullValue());
-            String location = response.getHeader(HttpHeaders.LOCATION);
-            assertNotNull(location);
-            smsNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
-            assertNotNull(smsNotificationSenderName);
-            response = getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
-            validateErrorResponse(response, HttpStatus.SC_CONFLICT, "NSM-60002");
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        response.then().log().ifValidationFails().assertThat().statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+        smsNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
+        assertNotNull(smsNotificationSenderName);
+        response = getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_CONFLICT, "NSM-60002");
     }
 
     @Test
@@ -195,14 +185,8 @@ public class NotificationSenderFailureTest extends NotificationSenderTestBase {
         String body = readResource("add-sms-sender-2.json");
         Response response =
                 getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "NSM-60001");
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "NSM-60001");
     }
 
     @Test
@@ -211,14 +195,8 @@ public class NotificationSenderFailureTest extends NotificationSenderTestBase {
         String body = readResource("add-sms-sender-invalid-provider.json");
         Response response =
                 getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60004");
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60004");
     }
 
     @Test
@@ -227,14 +205,7 @@ public class NotificationSenderFailureTest extends NotificationSenderTestBase {
         Response response = getResponseOfGet(
                 NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH + PATH_SEPARATOR +
                         "randomName");
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "NSM-60006");
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "NSM-60006");
     }
 
     @Test
@@ -243,13 +214,6 @@ public class NotificationSenderFailureTest extends NotificationSenderTestBase {
         Response response = getResponseOfDelete(
                 NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH + PATH_SEPARATOR +
                         "randomName");
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "NSM-60006");
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        validateErrorResponse(response, HttpStatus.SC_NOT_FOUND, "NSM-60006");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v1/NotificationSenderSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v1/NotificationSenderSuccessTest.java
@@ -215,22 +215,12 @@ public class NotificationSenderSuccessTest extends NotificationSenderTestBase {
         String body = readResource("add-sms-sender.json");
         Response response =
                 getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_CREATED)
-                    .header(HttpHeaders.LOCATION, notNullValue());
-            String location = response.getHeader(HttpHeaders.LOCATION);
-            assertNotNull(location);
-            smsNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
-            assertNotNull(smsNotificationSenderName);
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        response.then().log().ifValidationFails().assertThat().statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+        smsNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
+        assertNotNull(smsNotificationSenderName);
     }
 
     @Test(dependsOnMethods = {"testAddSmsSender"})
@@ -239,25 +229,18 @@ public class NotificationSenderSuccessTest extends NotificationSenderTestBase {
         Response response = getResponseOfGet(
                 NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH + PATH_SEPARATOR +
                         smsNotificationSenderName);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_OK)
-                    .body("name", equalTo("SMSPublisher"))
-                    .body("provider", equalTo("Vonage"))
-                    .body("providerURL", equalTo("https://webhook.site/9b79bebd-445a-4dec-ad5e-622b856fa184"))
-                    .body("key", equalTo("1234"))
-                    .body("secret", equalTo("12345"))
-                    .body("sender", equalTo("073923902"))
-                    .body("contentType", equalTo("JSON"))
-                    .body("properties", notNullValue());
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("name", equalTo("SMSPublisher"))
+                .body("provider", equalTo("Vonage"))
+                .body("providerURL", equalTo("https://webhook.site/9b79bebd-445a-4dec-ad5e-622b856fa184"))
+                .body("key", equalTo("1234"))
+                .body("secret", equalTo("12345"))
+                .body("sender", equalTo("073923902"))
+                .body("contentType", equalTo("JSON"))
+                .body("properties", notNullValue());
     }
 
     @Test(dependsOnMethods = {"testGetSMSSender"})
@@ -267,26 +250,19 @@ public class NotificationSenderSuccessTest extends NotificationSenderTestBase {
                 "find{ it.name == '" + URLDecoder.decode(smsNotificationSenderName, StandardCharsets.UTF_8.name()) +
                         "' }.";
         Response response = getResponseOfGet(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_OK)
-                    .body(baseIdentifier + "name", equalTo("SMSPublisher"))
-                    .body(baseIdentifier + "provider", equalTo("Vonage"))
-                    .body(baseIdentifier + "providerURL",
-                            equalTo("https://webhook.site/9b79bebd-445a-4dec-ad5e-622b856fa184"))
-                    .body(baseIdentifier + "key", equalTo("1234"))
-                    .body(baseIdentifier + "secret", equalTo("12345"))
-                    .body(baseIdentifier + "sender", equalTo("073923902"))
-                    .body(baseIdentifier + "contentType", equalTo("JSON"))
-                    .body(baseIdentifier + "properties", notNullValue());
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(baseIdentifier + "name", equalTo("SMSPublisher"))
+                .body(baseIdentifier + "provider", equalTo("Vonage"))
+                .body(baseIdentifier + "providerURL",
+                        equalTo("https://webhook.site/9b79bebd-445a-4dec-ad5e-622b856fa184"))
+                .body(baseIdentifier + "key", equalTo("1234"))
+                .body(baseIdentifier + "secret", equalTo("12345"))
+                .body(baseIdentifier + "sender", equalTo("073923902"))
+                .body(baseIdentifier + "contentType", equalTo("JSON"))
+                .body(baseIdentifier + "properties", notNullValue());
     }
 
     @Test(dependsOnMethods = {"testGetSMSSenders"})
@@ -295,25 +271,18 @@ public class NotificationSenderSuccessTest extends NotificationSenderTestBase {
         String body = readResource("update-sms-sender.json");
         Response response = getResponseOfPut(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH +
                 PATH_SEPARATOR + smsNotificationSenderName, body);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_OK)
-                    .body("name", equalTo("SMSPublisher"))
-                    .body("provider", equalTo("Clickatell"))
-                    .body("providerURL", equalTo("https://webhook.site/9b79bebd-445a-4dec-ad5e-622b856fa185"))
-                    .body("key", equalTo("123"))
-                    .body("secret", equalTo("123456"))
-                    .body("sender", equalTo("0773923902"))
-                    .body("contentType", equalTo("JSON"))
-                    .body("properties", notNullValue());
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("name", equalTo("SMSPublisher"))
+                .body("provider", equalTo("Clickatell"))
+                .body("providerURL", equalTo("https://webhook.site/9b79bebd-445a-4dec-ad5e-622b856fa185"))
+                .body("key", equalTo("123"))
+                .body("secret", equalTo("123456"))
+                .body("sender", equalTo("0773923902"))
+                .body("contentType", equalTo("JSON"))
+                .body("properties", notNullValue());
     }
 
     @Test(dependsOnMethods = {"testUpdateSMSSender"})
@@ -322,17 +291,10 @@ public class NotificationSenderSuccessTest extends NotificationSenderTestBase {
         Response response =
                 getResponseOfDelete(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH +
                         PATH_SEPARATOR + smsNotificationSenderName);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_NO_CONTENT);
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2419,7 +2419,7 @@
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.13</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.23</identity.user.api.version>
-        <identity.server.api.version>1.2.104</identity.server.api.version>
+        <identity.server.api.version>1.2.105</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.7</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
## Purpose

- Modify integration tests to support updation of sms provider configurations for super tenant.

## Related PRs: Merge this PR after merging below PRs
- https://github.com/wso2-extensions/identity-event-handler-notification/pull/205
- https://github.com/wso2/identity-api-server/pull/514