### PR TITLE
Fix test failures due to new authz runtime

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SystemScopePermissionValidationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SystemScopePermissionValidationTestCase.java
@@ -40,29 +40,20 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.utils.CarbonUtils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
-import java.io.ByteArrayInputStream;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.wso2.identity.integration.test.utils.DataExtractUtil.KeyValue;
 
@@ -79,7 +70,6 @@ public class SystemScopePermissionValidationTestCase extends OAuth2ServiceAbstra
     private final TestUserMode testUserMode;
 
     private static final String SYSTEM_SCOPE = "SYSTEM";
-    private static final String ENABLE_LEGACY_AUTHZ_RUNTIME_CONFIG = "EnableLegacyAuthzRuntime";
     private static boolean isLegacyRuntimeEnabled;
     private String applicationId;
 
@@ -107,7 +97,7 @@ public class SystemScopePermissionValidationTestCase extends OAuth2ServiceAbstra
 
         setSystemproperties();
         client = HttpClientBuilder.create().build();
-        isLegacyRuntimeEnabled = isLegacyAuthzRuntimeEnabled();
+        isLegacyRuntimeEnabled = CarbonUtils.isLegacyAuthzRuntimeEnabled();
     }
 
     @AfterClass(alwaysRun = true)
@@ -247,31 +237,5 @@ public class SystemScopePermissionValidationTestCase extends OAuth2ServiceAbstra
             Assert.assertFalse(scope.contains("internal_modify_tenants"), "Scope should not contain " +
                         "`internal_modify_tenants` scope");
         }
-    }
-
-    private static boolean isLegacyAuthzRuntimeEnabled() throws Exception {
-
-        String carbonHome = System.getProperty("carbon.home");
-        String carbonXMLFilePath = carbonHome + "/repository/conf/carbon.xml";
-        Path filePath = Paths.get(carbonXMLFilePath);
-        String xmlContent = new String(Files.readAllBytes(filePath));
-
-        // Parse the XML content
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        Document document = builder.parse(new ByteArrayInputStream(xmlContent.getBytes()));
-
-        // Get the root element
-        Element root = document.getDocumentElement();
-
-        // Find the element with the EnableLegacyAuthzRuntime tag.
-        NodeList nodeList = root.getElementsByTagName(ENABLE_LEGACY_AUTHZ_RUNTIME_CONFIG);
-
-        if (nodeList.getLength() > 0) {
-            // Get the value of EnableLegacyAuthzRuntime
-            String enableLegacyAuthzRuntimeValue = nodeList.item(0).getTextContent();
-            return Boolean.parseBoolean(enableLegacyAuthzRuntimeValue);
-        }
-        return true;
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/CarbonUtils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/CarbonUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.utils;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class CarbonUtils {
+
+    private static final String ENABLE_LEGACY_AUTHZ_RUNTIME_CONFIG = "EnableLegacyAuthzRuntime";
+    private static Boolean legacyRuntimeEnabled;
+
+    private CarbonUtils() {
+
+    }
+
+    /**
+     * Check whether the legacy authz runtime is enabled.
+     *
+     * @return True if legacy authz runtime is enabled.
+     * @throws Exception If an error occurs while getting the config.
+     */
+    public static boolean isLegacyAuthzRuntimeEnabled() throws Exception {
+
+        if (legacyRuntimeEnabled == null) {
+            legacyRuntimeEnabled = initializeLegacyAuthzRuntime();
+        }
+        return legacyRuntimeEnabled;
+    }
+
+    /**
+     * Set the value of EnableLegacyAuthzRuntime in carbon.xml.
+     *
+     * @return True if the EnableLegacyAuthzRuntime is set to true.
+     * @throws Exception If an error occurs while intializing the config.
+     */
+    private static boolean initializeLegacyAuthzRuntime() throws Exception {
+
+        String carbonXMLContent;
+        // Read the carbon.xml file.
+        try {
+            carbonXMLContent = readCarbonXML();
+        } catch (Exception e) {
+            throw new Exception("Error while reading the carbon.xml file.", e);
+        }
+        // Parse the carbon.xml file.
+        try {
+            return parseLegacyAuthzRuntimeConfig(carbonXMLContent);
+        } catch (Exception e) {
+            throw new Exception("Error while parsing the carbon.xml file.", e);
+        }
+    }
+
+    /**
+     * Read the carbon.xml file.
+     *
+     * @return Carbon XML content.
+     * @throws Exception If an error occurs while reading the carbon.xml file.
+     */
+    private static String readCarbonXML() throws Exception {
+        
+        String carbonHome = System.getProperty("carbon.home");
+        String carbonXMLFilePath = carbonHome + "/repository/conf/carbon.xml";
+        Path filePath = Paths.get(carbonXMLFilePath);
+        return new String(Files.readAllBytes(filePath));
+    }
+
+    /**
+     * Parse the carbon.xml file and get the value of EnableLegacyAuthzRuntime.
+     *
+     * @param xmlContent Carbon XML content.
+     * @return True if the EnableLegacyAuthzRuntime is set to true.
+     * @throws Exception If an error occurs while parsing the carbon.xml file.
+     */
+    private static boolean parseLegacyAuthzRuntimeConfig(String xmlContent) throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new ByteArrayInputStream(xmlContent.getBytes()));
+
+        // Get the root element
+        Element root = document.getDocumentElement();
+        // Find the element with the EnableLegacyAuthzRuntime tag.
+        NodeList nodeList = root.getElementsByTagName(ENABLE_LEGACY_AUTHZ_RUNTIME_CONFIG);
+
+        if (nodeList.getLength() > 0) {
+            // Get the value of EnableLegacyAuthzRuntime
+            String enableLegacyAuthzRuntimeValue = nodeList.item(0).getTextContent();
+            return Boolean.parseBoolean(enableLegacyAuthzRuntimeValue);
+        }
+        return true;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/CarbonUtils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/CarbonUtils.java
@@ -30,10 +30,13 @@ import java.nio.file.Paths;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+/**
+ * Utility class for Carbon related operations.
+ */
 public class CarbonUtils {
 
     private static final String ENABLE_LEGACY_AUTHZ_RUNTIME_CONFIG = "EnableLegacyAuthzRuntime";
-    private static Boolean legacyRuntimeEnabled;
+    private static Boolean isLegacyRuntimeEnabled;
 
     private CarbonUtils() {
 
@@ -47,10 +50,10 @@ public class CarbonUtils {
      */
     public static boolean isLegacyAuthzRuntimeEnabled() throws Exception {
 
-        if (legacyRuntimeEnabled == null) {
-            legacyRuntimeEnabled = initializeLegacyAuthzRuntime();
+        if (isLegacyRuntimeEnabled == null) {
+            isLegacyRuntimeEnabled = initializeLegacyAuthzRuntimeEnabled();
         }
-        return legacyRuntimeEnabled;
+        return isLegacyRuntimeEnabled;
     }
 
     /**
@@ -59,7 +62,7 @@ public class CarbonUtils {
      * @return True if the EnableLegacyAuthzRuntime is set to true.
      * @throws Exception If an error occurs while intializing the config.
      */
-    private static boolean initializeLegacyAuthzRuntime() throws Exception {
+    private static boolean initializeLegacyAuthzRuntimeEnabled() throws Exception {
 
         String carbonXMLContent;
         // Read the carbon.xml file.


### PR DESCRIPTION
This PR,

- Move the isLegacyAuthzRuntimeEnabled() check to a Util class.
- Change the authorization used for introspection from bearer token to basic auth.
- Handle the assertions when requesting invalid internal scopes considering the authz runtime.
