### PR TITLE
Fix password grant based token fail to introspect

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -933,4 +933,13 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 			}
 		});
 	}
+
+	public String getRoleV2ResourceId(String roleName, String audienceType, String OrganizationId) throws Exception {
+
+		List<String> roles = restClient.getRoles(roleName, audienceType, OrganizationId);
+		if (roles.size() == 1) {
+			return roles.get(0);
+		}
+		return null;
+	}
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ApplicationPatchModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/ApplicationPatchModel.java
@@ -33,6 +33,7 @@ public class ApplicationPatchModel {
     private String imageUrl;
     private String accessUrl;
     private String templateId;
+    private AssociatedRolesConfig associatedRoles;
     private ClaimConfiguration claimConfiguration;
     private AuthenticationSequence authenticationSequence;
     private AdvancedApplicationConfiguration advancedConfigurations;
@@ -46,11 +47,9 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty(example = "pickup", required = true)
+    @ApiModelProperty(example = "pickup", value = "")
     @JsonProperty("name")
     @Valid
-    @NotNull(message = "Property name cannot be null.")
-    @Pattern(regexp="^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
     public String getName() {
         return name;
     }
@@ -66,7 +65,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty(example = "This is the configuration for Pickup application.")
+    @ApiModelProperty(example = "This is the configuration for Pickup application.", value = "")
     @JsonProperty("description")
     @Valid
     public String getDescription() {
@@ -84,7 +83,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty(example = "https://example.com/logo/my-logo.png")
+    @ApiModelProperty(example = "https://example.com/logo/my-logo.png", value = "")
     @JsonProperty("imageUrl")
     @Valid
     public String getImageUrl() {
@@ -102,7 +101,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty(example = "https://example.com/accessUrl")
+    @ApiModelProperty(example = "https://example.com/login", value = "")
     @JsonProperty("accessUrl")
     @Valid
     public String getAccessUrl() {
@@ -120,7 +119,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty(example = "templateId")
+    @ApiModelProperty(example = "adwefi2429asdfdf94444rraf44", value = "")
     @JsonProperty("templateId")
     @Valid
     public String getTemplateId() {
@@ -132,13 +131,31 @@ public class ApplicationPatchModel {
 
     /**
      **/
+    public ApplicationPatchModel associatedRoles(AssociatedRolesConfig associatedRoles) {
+
+        this.associatedRoles = associatedRoles;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("associatedRoles")
+    @Valid
+    public AssociatedRolesConfig getAssociatedRoles() {
+        return associatedRoles;
+    }
+    public void setAssociatedRoles(AssociatedRolesConfig associatedRoles) {
+        this.associatedRoles = associatedRoles;
+    }
+
+    /**
+     **/
     public ApplicationPatchModel claimConfiguration(ClaimConfiguration claimConfiguration) {
 
         this.claimConfiguration = claimConfiguration;
         return this;
     }
 
-    @ApiModelProperty()
+    @ApiModelProperty(value = "")
     @JsonProperty("claimConfiguration")
     @Valid
     public ClaimConfiguration getClaimConfiguration() {
@@ -156,7 +173,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty()
+    @ApiModelProperty(value = "")
     @JsonProperty("authenticationSequence")
     @Valid
     public AuthenticationSequence getAuthenticationSequence() {
@@ -174,7 +191,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty()
+    @ApiModelProperty(value = "")
     @JsonProperty("advancedConfigurations")
     @Valid
     public AdvancedApplicationConfiguration getAdvancedConfigurations() {
@@ -192,7 +209,7 @@ public class ApplicationPatchModel {
         return this;
     }
 
-    @ApiModelProperty()
+    @ApiModelProperty(value = "")
     @JsonProperty("provisioningConfigurations")
     @Valid
     public ProvisioningConfiguration getProvisioningConfigurations() {
@@ -205,7 +222,7 @@ public class ApplicationPatchModel {
 
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(java.lang.Object o) {
 
         if (this == o) {
             return true;
@@ -219,6 +236,7 @@ public class ApplicationPatchModel {
                 Objects.equals(this.imageUrl, applicationPatchModel.imageUrl) &&
                 Objects.equals(this.accessUrl, applicationPatchModel.accessUrl) &&
                 Objects.equals(this.templateId, applicationPatchModel.templateId) &&
+                Objects.equals(this.associatedRoles, applicationPatchModel.associatedRoles) &&
                 Objects.equals(this.claimConfiguration, applicationPatchModel.claimConfiguration) &&
                 Objects.equals(this.authenticationSequence, applicationPatchModel.authenticationSequence) &&
                 Objects.equals(this.advancedConfigurations, applicationPatchModel.advancedConfigurations) &&
@@ -227,7 +245,7 @@ public class ApplicationPatchModel {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, imageUrl, accessUrl, templateId, claimConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations);
+        return Objects.hash(name, description, imageUrl, accessUrl, templateId, associatedRoles, claimConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations);
     }
 
     @Override
@@ -241,6 +259,7 @@ public class ApplicationPatchModel {
         sb.append("    imageUrl: ").append(toIndentedString(imageUrl)).append("\n");
         sb.append("    accessUrl: ").append(toIndentedString(accessUrl)).append("\n");
         sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    associatedRoles: ").append(toIndentedString(associatedRoles)).append("\n");
         sb.append("    claimConfiguration: ").append(toIndentedString(claimConfiguration)).append("\n");
         sb.append("    authenticationSequence: ").append(toIndentedString(authenticationSequence)).append("\n");
         sb.append("    advancedConfigurations: ").append(toIndentedString(advancedConfigurations)).append("\n");
@@ -253,11 +272,11 @@ public class ApplicationPatchModel {
      * Convert the given object to string with each line indented by 4 spaces
      * (except the first line).
      */
-    private String toIndentedString(Object o) {
+    private String toIndentedString(java.lang.Object o) {
 
         if (o == null) {
             return "null";
         }
-        return o.toString();
+        return o.toString().replace("\n", "\n");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
@@ -18,9 +18,11 @@
 package org.wso2.identity.integration.test.restclients;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -46,6 +48,8 @@ import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class OAuth2RestClient extends RestBaseClient {
@@ -55,8 +59,11 @@ public class OAuth2RestClient extends RestBaseClient {
     private static final String API_RESOURCE_MANAGEMENT_PATH = "/api-resources";
     private static final String INBOUND_PROTOCOLS_BASE_PATH = "/inbound-protocols";
     private static final String AUTHORIZED_API_BASE_PATH = "/authorized-apis";
+    private static final String SCIM_BASE_PATH = "scim2";
+    private static final String ROLE_V2_BASE_PATH = "/v2/Roles";
     private final String applicationManagementApiBasePath;
     private final String apiResourceManagementApiBasePath;
+    private final String roleV2ApiBasePath;
     private final String username;
     private final String password;
 
@@ -67,6 +74,7 @@ public class OAuth2RestClient extends RestBaseClient {
         String tenantDomain = tenantInfo.getContextUser().getUserDomain();
         applicationManagementApiBasePath = getApplicationsPath(backendUrl, tenantDomain);
         apiResourceManagementApiBasePath = getAPIResourcesPath(backendUrl, tenantDomain);
+        roleV2ApiBasePath = getSCIM2RoleV2Path(backendUrl, tenantDomain);
     }
 
     /**
@@ -268,6 +276,15 @@ public class OAuth2RestClient extends RestBaseClient {
         }
     }
 
+    private String getSCIM2RoleV2Path(String serverUrl, String tenantDomain) {
+
+        if (tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return serverUrl + SCIM_BASE_PATH + ROLE_V2_BASE_PATH;
+        } else {
+            return serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR + SCIM_BASE_PATH + ROLE_V2_BASE_PATH;
+        }
+    }
+
     private Header[] getHeaders() {
         Header[] headerList = new Header[3];
         headerList[0] = new BasicHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
@@ -332,6 +349,61 @@ public class OAuth2RestClient extends RestBaseClient {
             APIResourceResponse apiResourceResponse = jsonWriter.readValue(responseBody, APIResourceResponse.class);
             return apiResourceResponse.getScopes();
         }
+    }
+
+    public List<String> getRoles(String roleName, String audienceType, String audienceId) throws Exception {
+
+        String endPointUrl = buildRoleSearchEndpoint(roleName, audienceType, audienceId);
+        try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
+            if (response.getStatusLine().getStatusCode() != 200) {
+                return Collections.emptyList();
+            }
+            String responseBody = EntityUtils.toString(response.getEntity());
+            ObjectMapper objectMapper = new ObjectMapper();
+            // Parse the JSON response.
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+            JsonNode totalResults = jsonNode.get("totalResults");
+            if (totalResults.asInt() <= 0) {
+                return Collections.emptyList();
+            }
+            // Extract the "Resources" array.
+            JsonNode resourcesArray = jsonNode.get("Resources");
+            // Initialize a list to store the "id" values
+            List<String> idList = new ArrayList<>();
+            // Iterate through the "Resources" array and extract "id" values.
+            for (JsonNode resource : resourcesArray) {
+                JsonNode idNode = resource.get("id");
+                if (idNode != null && idNode.isTextual()) {
+                    idList.add(idNode.asText());
+                }
+            }
+            return idList;
+        }
+    }
+
+    private String buildRoleSearchEndpoint(String roleName, String audienceType, String audienceId) {
+
+        StringBuilder filter = new StringBuilder(roleV2ApiBasePath + "?");
+        if (StringUtils.isNotBlank(roleName)) {
+            filter.append("filter=displayName+eq+").append(roleName);
+        }
+        if (StringUtils.isNotBlank(audienceType)) {
+            if (filter.length() > 0) {
+                filter.append("+and+");
+            }
+            filter.append("audience.type+eq+").append(audienceType);
+        }
+        if (StringUtils.isNotBlank(audienceId)) {
+            if (filter.length() > 0) {
+                filter.append("+and+");
+            }
+            filter.append("audience.id+eq+").append(audienceId);
+        }
+        // If no parameters were provided, return the base URL.
+        if (filter.toString().equals(roleV2ApiBasePath + "?")) {
+            return roleV2ApiBasePath;
+        }
+        return filter.toString();
     }
 
     /**


### PR DESCRIPTION
Fix test failures in PermissionBasedScopeValidatorTestCase and SystemScopePermissionValidationTestCase

- Change new scope required for introspection
- in New Authz runtime, subscribe the application to /oauth2/introspect endpoint
- Add admin and everyone role association to the application

Related to new authz runtime introduced with features: https://github.com/wso2/product-is/issues/16363 and https://github.com/wso2/product-is/issues/16344