### PR TITLE
Fix AdaptiveScriptTemporaryClaimPersistenceTestCase failure due to NPE exception when getting claim list

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/util/Utils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/util/Utils.java
@@ -376,7 +376,9 @@ public class Utils {
         if (firstIndex != -1 && secondIndex != -1) {
             String claimString = resultPage.substring(firstIndex, secondIndex);
             String[] dataArray = StringUtils.substringsBetween(claimString, labelOpenTag, labelCloseTag);
-            Collections.addAll(attributeList, dataArray);
+            if (dataArray != null) {
+                Collections.addAll(attributeList, dataArray);
+            }
         }
         // Check if there's only one occurrence, it can be either OIDC scopes or API Resource scopes.
         else if (firstIndex != -1) {
@@ -385,7 +387,9 @@ public class Utils {
             // If label is available, it should be OIDC scopes. Hence, extract the labels to get the claims list.
             if (labelAvailable) {
                 String[] dataArray = StringUtils.substringsBetween(claimString, labelOpenTag, labelCloseTag);
-                Collections.addAll(attributeList, dataArray);
+                if (dataArray != null) {
+                    Collections.addAll(attributeList, dataArray);
+                }
             }
         }
         return attributeList;

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -228,7 +228,7 @@
     <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
             <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>
-<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>
             <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>
             <!-- This test has a restart-->
             <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />


### PR DESCRIPTION
This PR fixes the extract claim logic in Integration tests to support new API Resource scopes. This fix resolves NPE exception when getting the claim list from the consent page when there are API Resource scopes in the consent page.