### PR TITLE
Temporary disable tenant qualified disabled test cases

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuthAppsWithSameClientIdTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuthAppsWithSameClientIdTestCase.java
@@ -397,36 +397,36 @@ public class OAuthAppsWithSameClientIdTestCase extends OAuth2ServiceAbstractInte
         Assert.fail("Expected exception not received.");
     }
 
-    @Test(description = "Create an OAuth app in tenant 1 and try to login when tenant qualified urls are disabled.",
-            dependsOnMethods = "testOAuthApplicationLoginIncorrectTenant")
-    public void testOAuthApplicationLoginWhenTenantQualifiedUrlsDisabled() throws Exception {
-
-        // Disable tenant qualified urls/ tenanted sessions and restart the server.
-        changeISConfigurations();
-
-        // Create oauth app and add user.
-        ApplicationResponseModel tenant1App = createApplication(TENANT_1_DOMAIN);
-        Assert.assertNotNull(tenant1App, "OAuth app creation failed for tenant 1.");
-        tenant1UserId = createUser(TENANT_1_DOMAIN);
-
-        // Authenticate.
-        initiateAuthorizationRequest(false);
-        authenticateUser(false, TENANT_1_USER_USERNAME + "@" + TENANT_1_DOMAIN, TENANT_1_USER_PASSWORD,
-                TENANT_1_DOMAIN);
-        performConsentApproval(false, TENANT_1_DOMAIN);
-        generateAuthzCodeAccessToken(false, TENANT_1_DOMAIN);
-        introspectActiveAccessToken(TENANT_1_DOMAIN, TENANT_1_ADMIN_USERNAME, TENANT_1_ADMIN_PASSWORD);
-    }
-
-    private void changeISConfigurations() throws AutomationUtilException, IOException {
-
-        String carbonHome = Utils.getResidentCarbonHome();
-        File defaultTomlFile = getDeploymentTomlFile(carbonHome);
-        File modifiedConfigFile = new File(getISResourceLocation()
-                + File.separator + "tenant.qualified" + File.separator
-                + "tenant_qualified_url_tenanted_sessions_disabled.toml");
-        serverConfigurationManager.applyConfiguration(modifiedConfigFile, defaultTomlFile, true, true);
-    }
+//    @Test(description = "Create an OAuth app in tenant 1 and try to login when tenant qualified urls are disabled.",
+//            dependsOnMethods = "testOAuthApplicationLoginIncorrectTenant")
+//    public void testOAuthApplicationLoginWhenTenantQualifiedUrlsDisabled() throws Exception {
+//
+//        // Disable tenant qualified urls/ tenanted sessions and restart the server.
+//        changeISConfigurations();
+//
+//        // Create oauth app and add user.
+//        ApplicationResponseModel tenant1App = createApplication(TENANT_1_DOMAIN);
+//        Assert.assertNotNull(tenant1App, "OAuth app creation failed for tenant 1.");
+//        tenant1UserId = createUser(TENANT_1_DOMAIN);
+//
+//        // Authenticate.
+//        initiateAuthorizationRequest(false);
+//        authenticateUser(false, TENANT_1_USER_USERNAME + "@" + TENANT_1_DOMAIN, TENANT_1_USER_PASSWORD,
+//                TENANT_1_DOMAIN);
+//        performConsentApproval(false, TENANT_1_DOMAIN);
+//        generateAuthzCodeAccessToken(false, TENANT_1_DOMAIN);
+//        introspectActiveAccessToken(TENANT_1_DOMAIN, TENANT_1_ADMIN_USERNAME, TENANT_1_ADMIN_PASSWORD);
+//    }
+//
+//    private void changeISConfigurations() throws AutomationUtilException, IOException {
+//
+//        String carbonHome = Utils.getResidentCarbonHome();
+//        File defaultTomlFile = getDeploymentTomlFile(carbonHome);
+//        File modifiedConfigFile = new File(getISResourceLocation()
+//                + File.separator + "tenant.qualified" + File.separator
+//                + "tenant_qualified_url_tenanted_sessions_disabled.toml");
+//        serverConfigurationManager.applyConfiguration(modifiedConfigFile, defaultTomlFile, true, true);
+//    }
 
     private void addTenant(String tenantDomain, String adminUsername, String adminPassword,
                            String adminTenantAwareUsername) throws Exception {


### PR DESCRIPTION
With the https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2242, a startup validation will be added to check for the compatibility with client ID tenant unification. However a test added with the original feature requires running the server by disabling tenant qualified URLs and tenanted sessions. With the new change, a DB scheme change is required to start the server in that mode and this PR isto disable that particular fix until that test change is implemented.

### Related issue
- https://github.com/wso2/product-is/issues/17076
- https://github.com/wso2/product-is/issues/17762