### PR TITLE
Disable FAPIDCRValidationsTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -368,9 +368,10 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementFailureTest"/>
         </classes>
     </test>
-    <test name="fapi-dcr-validations" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.FAPIDCRValidationsTestCase"/>
-        </classes>
-    </test>
+<!--    Temporarily disabling the test case as the build appears to be hanging with this. -->
+<!--    <test name="fapi-dcr-validations" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.FAPIDCRValidationsTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 </suite>


### PR DESCRIPTION
Disabling the FAPIDCRValidationsTestCase temporarily as it is a possible cause of github action build hanging.
Several build logs show the build stuck on executing this test case.

related https://github.com/wso2/product-is/pull/17047