### PR TITLE
Bump framework dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2313,7 +2313,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.507</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.514</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Bump framework dependency. This version of the framework was released with https://github.com/wso2/carbon-identity-framework/pull/5165 which passed the integration test run https://github.com/wso2/carbon-identity-framework/pull/5165#pullrequestreview-1733869321