### PR TITLE
Add org management service dependency

### DIFF
--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -868,6 +868,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.user.ws</groupId>
             <artifactId>org.wso2.carbon.um.ws.api.stub</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2040,6 +2040,11 @@
                 <version>${identity.organization.login.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${identity.org.mgt.core.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.extension.identity.oauth2.grantType.organizationswitch</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth2.grant.organizationswitch.server.feature</artifactId>
                 <version>${identity.oauth2.grant.organizationswitch.version}</version>


### PR DESCRIPTION
### Purpose
- Add `org.wso2.carbon.identity.organization.management.service` dependency as a test dependency to fix the integration test failures that will occur after merging https://github.com/wso2/carbon-identity-framework/pull/5184 PR