### PR TITLE
Update cipher-tool version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2473,7 +2473,7 @@
         <carbon.healthcheck.version>1.3.0</carbon.healthcheck.version>
 
         <!-- Common tool Versions -->
-        <cipher-tool.version>1.2.4</cipher-tool.version>
+        <cipher-tool.version>1.1.21</cipher-tool.version>
         <securevault.wso2.version>1.1.7</securevault.wso2.version>
 
         <!-- Feature dependency Versions -->


### PR DESCRIPTION
Wso2IS is using cipher tool 1.1.x versions. This had been changed in https://github.com/wso2/product-is/pull/15959. Will need to fix that.