### PR TITLE
Improve integration test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -913,7 +913,7 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 		apiIdentifiers.stream().forEach(apiIdentifier -> {
 			try {
 				List<APIResourceListItem> filteredAPIResource =
-						restClient.getAPIResourcesWithFiltering("type+eq+SYSTEM+and+identifier+eq+" + apiIdentifier);
+						restClient.getAPIResourcesWithFiltering("identifier+eq+" + apiIdentifier);
 				if (filteredAPIResource == null || filteredAPIResource.isEmpty()) {
 					return;
 				}


### PR DESCRIPTION
Improve integration tests to select System APIs without using type as `SYSTEM` due to changes being introduced in following PR https://github.com/wso2/carbon-identity-framework/pull/5108