### PR TITLE
Disable i18n language auto detection in console app

### DIFF
--- a/modules/distribution/src/repository/resources/conf/deployment.toml
+++ b/modules/distribution/src/repository/resources/conf/deployment.toml
@@ -38,6 +38,10 @@ hash= "66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"
 [identity.auth_framework.endpoint]
 app_password= "dashboard"
 
+# Required to keep i18n disabled for console
+[console.i18n_configs]
+langAutoDetectEnabled = false
+
 # The KeyStore which is used for encrypting/decrypting internal data. By default the primary keystore is used as the internal keystore.
 
 #[keystore.internal]


### PR DESCRIPTION
## Purpose

This PR disables i18n language auto detection by default in the console app

## Related Issue

- https://github.com/wso2/product-is/issues/17003