### PR TITLE
Bump framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2313,7 +2313,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.546</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.551</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
### Description
Bump framework version to 5.25.551

### Related PR
- https://github.com/wso2/carbon-identity-framework/pull/5203