### PR TITLE
Integration tests for the fix for issue in claim mapping for token exchange and jwt grant flow

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
@@ -214,14 +214,12 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
 
         addFederatedIdentityProvider();
         OIDCTokens oidcTokens = makeJWTBearerGrantRequest();
-        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_NEW_OIDC_CLAIM),
-                "User claims is returned back without mappings in SP and IDP side when ConvertToOIDCDialect is "
-                        + "set to true in identity.xml");
-        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM),
-                "User claims is returned back without mappings in SP and IDP side when ConvertToOIDCDialect is "
-                        + "set to true in identity.xml");
-        Assert.assertNull(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_LOCAL_CLAIM_URI),
-                "User claims is returned back when IDP claim mapping is not set and with only SP Claim mapping");
+        Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(COUNTRY_NEW_OIDC_CLAIM),
+                COUNTRY_CLAIM_VALUE, "User claims is not returned back with SP claim mapping set and " +
+                        "no IDP claim mapping when ConvertToOIDCDialect is set to true in identity.xml");
+        Assert.assertEquals(oidcTokens.getIDToken().getJWTClaimsSet().getClaim(EMAIL_OIDC_CLAIM), EMAIL_CLAIM_VALUE,
+                "User claims is not returned back with SP claim mapping set and " +
+                        "no IDP claim mapping when ConvertToOIDCDialect is set to true in identity.xml");
     }
 
     @Test(description = "This test case tests the behaviour when ConvertOIDCDialect is set to true in identity.xml "


### PR DESCRIPTION
### Related PR

- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2270


The above PR fixes a bug in the claim mapping of the token exchange flow and the jwt grant flow. Previously claim mapping was not happening for SP requested claims if the IDP mapping was not present. This was fixed and this PR is to update the integration tests to reflect the fix.

