### PR TITLE
Bump dependencies to upgrade to json version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2305,7 +2305,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.11.29</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>6.11.220</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.222</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.9.5</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.10.19</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.4</identity.inbound.provisioning.scim.version>
@@ -2342,7 +2342,7 @@
         <callhome.version>4.5.x_1.0.14</callhome.version>
 
         <!-- Authenticator Versions -->
-        <identity.outbound.auth.oidc.version>5.11.29</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.11.30</identity.outbound.auth.oidc.version>
         <identity.outbound.auth.oauth2.version>1.0.11</identity.outbound.auth.oauth2.version>
         <identity.outbound.auth.passive.sts.version>5.5.0</identity.outbound.auth.passive.sts.version>
         <identity.outbound.auth.samlsso.version>5.8.7</identity.outbound.auth.samlsso.version>
@@ -2433,10 +2433,10 @@
         <carbon.deployment.version>4.12.20</carbon.deployment.version>
         <carbon.commons.version>4.10.7</carbon.commons.version>
         <carbon.registry.version>4.8.15</carbon.registry.version>
-        <carbon.multitenancy.version>4.11.16</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.11.17</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.business-process.version>4.5.66</carbon.business-process.version>
-        <carbon.analytics-common.version>5.2.53</carbon.analytics-common.version>
+        <carbon.analytics-common.version>5.2.56</carbon.analytics-common.version>
         <carbon.dashboards.version>2.0.27</carbon.dashboards.version>
         <carbon.database.utils.version>2.1.7</carbon.database.utils.version>
         <carbon.healthcheck.version>1.3.0</carbon.healthcheck.version>


### PR DESCRIPTION
### Purpose
$subject

### Changes from this PR
- json version is upgraded due to security vulnerabilities in the `carbon-analytics-common`, `identity-inbound-auth-oauth`,` identity-outbound-auth-oidc` and `carbon-multitenancy` repositories.
- This PR includes the version bumps of the above components