### PR TITLE
Fix integration test failures due to adding back sms OTP regex configuration

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-VXNlciBPbmJvYXJkaW5n-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-VXNlciBPbmJvYXJkaW5n-response.json
@@ -82,6 +82,12 @@
           "description": "Specify the expiry time in minutes for the SMS OTP."
         },
         {
+          "name": "SelfRegistration.SMSOTP.Regex",
+          "value": "[a-zA-Z0-9]{6}",
+          "displayName": "User self registration SMS OTP regex",
+          "description": "Regex for SMS OTP in format [allowed characters]{length}. Supported character ranges are a-z, A-Z, 0-9. Minimum OTP length is 4"
+        },
+        {
           "name": "SelfRegistration.CallbackRegex",
           "value": "[https://localhost:9443].*[/authenticationendpoint/login.do]",
           "displayName": "User self registration callback URL regex",

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-properties-without-property-name-response.json
@@ -51,6 +51,10 @@
         "value": "1"
       },
       {
+        "name": "SelfRegistration.SMSOTP.Regex",
+        "value": "[a-zA-Z0-9]{6}"
+      },
+      {
         "name": "SelfRegistration.CallbackRegex",
         "value": "https:\\/\\/localhost:9853\\/.*"
       },

--- a/pom.xml
+++ b/pom.xml
@@ -2283,7 +2283,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.596</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.597</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2294,7 +2294,7 @@
         <carbon.consent.mgt.version>2.5.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.8.96</identity.governance.version>
+        <identity.governance.version>1.8.97</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.8.5</identity.carbon.auth.saml2.version>


### PR DESCRIPTION
### Proposed changes in this pull request
With the following PRs, SMS OTP regex configuration has been added back to keep backward compatibility.
1. https://github.com/wso2-extensions/identity-governance/pull/790
2. https://github.com/wso2/carbon-identity-framework/pull/5278

This PR adds back the removed sms OTP regex related test configurations removed with
- https://github.com/wso2/product-is/pull/17203