### PR TITLE
Bump identity-apps-core version to 2.0.91

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2381,7 +2381,7 @@
         <!-- Identity Portal Versions -->
         <identity.apps.console.version>2.10.6</identity.apps.console.version>
         <identity.apps.myaccount.version>2.2.56</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.0.74</identity.apps.core.version>
+        <identity.apps.core.version>2.0.91</identity.apps.core.version>
         <identity.apps.tests.version>1.6.373</identity.apps.tests.version>
 
         <!-- Charon -->


### PR DESCRIPTION
### Purpose
- Bump identity-apps-core version to 2.0.91.