### PR TITLE
Bump Framework version and re-enable OrganizationManagementSuccessTest

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -213,8 +213,7 @@
             <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>
-            <!-- Temporarily disabling the test since manual flow is working and found the issue related to test failure-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>
         </classes>
     </test>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2253,7 +2253,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.606</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.609</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 6.0.0]</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
### Purpose
Bump the framework version and re-enable the OrganizationManagementSuccessTest since https://github.com/wso2/product-is/issues/18509 is fixed.