### PR TITLE
Fix dependency updater to update carbon.identity.framework.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1126,11 +1126,6 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.template.mgt.endpoint</artifactId>
-                <version>${carbon.identity.framework.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.auth.saml2</groupId>
                 <artifactId>org.wso2.carbon.identity.sso.saml.stub</artifactId>
                 <version>${identity.inbound.auth.saml.version}</version>
@@ -1907,11 +1902,6 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.unique.claim.mgt.server.feature</artifactId>
-                <version>${carbon.identity.framework.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.userstore.configuration.server.feature</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Since ${carbon.identity.framework.version} used for multiple dependencies, all dependencies need to be satisfiable for a particular version of that. If even one dependency cannot be satisfied with the newer version, the plugin would not update the version at all.

The following artifacts no longer get released.

- org.wso2.carbon.identity.template.mgt.endpoint
https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/carbon/identity/framework/org.wso2.carbon.identity.template.mgt.endpoint/

- org.wso2.carbon.identity.userstore.configuration.server.feature
no release artifacts

Since these two artifacts are no longer being released, their latest versions would not correspond to the newer version of carbon.identity.framework.version. As a result, the plugin recognizes that updating the carbon.identity.framework.version would lead to dependency resolution failures and would not update the property at all.

This PR removes these dependencies so that the mvn version plugin would update the ${carbon.identity.framework.version}

