### PR TITLE
Fix dependency updater to update conditional.authentication.functions.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1605,11 +1605,6 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.conditional.auth.functions</groupId>
-                <artifactId>org.wso2.carbon.identity.conditional.auth.functions.cookie</artifactId>
-                <version>${conditional.authentication.functions.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.conditional.auth.functions</groupId>
                 <artifactId>org.wso2.carbon.identity.conditional.auth.functions.analytics</artifactId>
                 <version>${conditional.authentication.functions.version}</version>
             </dependency>


### PR DESCRIPTION
Since ${conditional.authentication.functions.version} used for multiple dependencies, all dependencies need to be satisfiable for a particular version of that. If even one dependency cannot be satisfied with the newer version, the plugin would not update the version at all.

The following artifact no longer gets released.

- org.wso2.carbon.identity.conditional.auth.functions.cookie
https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/carbon/identity/conditional/auth/functions/org.wso2.carbon.identity.conditional.auth.functions.cookie/


Since this artifact is no longer being released, its latest version would not correspond to the newer version of conditional.authentication.functions.version. As a result, the plugin recognizes that updating the conditional.authentication.functions.version would lead to dependency resolution failures and would not update the property at all.

This PR removes these dependencies so that the mvn version plugin would update the ${conditional.authentication.functions.version}

