### PR TITLE
Add X509CertificateAuthenticationValve into Dropins

### DIFF
--- a/modules/connectors/pom.xml
+++ b/modules/connectors/pom.xml
@@ -168,6 +168,29 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>download_x509_valve</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
+                                    <artifactId>
+                                        org.wso2.carbon.extension.identity.x509Certificate.valve
+                                    </artifactId>
+                                    <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/target/authenticatorCopied/jar
+                                    </outputDirectory>
+                                    <includes>**/*.jar</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -106,6 +106,7 @@
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{http_access_log.directory}}"
                        prefix="{{http_access_log.prefix}}" suffix="{{http_access_log.suffix}}" pattern="{{http_access_log.pattern}}"/>
                 {% endif %}
+                <Valve className="org.wso2.carbon.extension.identity.x509Certificate.valve.X509CertificateAuthenticationValve"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve" threshold="600"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CompositeValve"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1864,6 +1864,11 @@
                 <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
+                <artifactId>org.wso2.carbon.extension.identity.x509Certificate.valve</artifactId>
+                <version>${org.wso2.carbon.extension.identity.x509certificate.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.conditional.auth.functions</groupId>
                 <artifactId>org.wso2.carbon.identity.conditional.auth.functions.server.feature</artifactId>
                 <version>${conditional.authentication.functions.version}</version>


### PR DESCRIPTION
### Purpose
- $Subject

### Additional Context
- This x509 authentication valve is needed for x509 Certification based authentication to pass when a load balancer is configured with SSL-termination (when the x509 authenticator is proxied through 443 port) [1].

### Related Issues
- https://github.com/wso2/product-is/pull/4829
- https://github.com/wso2/product-is/issues/18437

[1] - https://github.com/wso2-extensions/identity-x509-commons/pull/6