### PR TITLE
[FAPI Conformance] Use java-17 for fapi conformance guthub action

### DIFF
--- a/.github/workflows/fapi-oidc-conformance-test.yml
+++ b/.github/workflows/fapi-oidc-conformance-test.yml
@@ -36,11 +36,10 @@ jobs:
       with:
         path: './product-is'
       
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
       with:
-        java-version: 17
-        distribution: temurin
+        java-version: 11.0.18+10
     
     - name: Setup Python
       run: |
@@ -178,6 +177,12 @@ jobs:
         cd ./product-is/oidc-fapi-conformance-tests
         python3 ./configure_is_fapi.py ../../$PRODUCT_IS_ZIP
         
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: 17
+        distribution: temurin
+
     - name: Start Conformance Suite server
       run: |
         DOCKER_COMPOSE_FILE=./docker-compose.yml

--- a/.github/workflows/fapi-oidc-conformance-test.yml
+++ b/.github/workflows/fapi-oidc-conformance-test.yml
@@ -36,10 +36,11 @@ jobs:
       with:
         path: './product-is'
       
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
       with:
-        java-version: 11.0.18+10
+        java-version: 17
+        distribution: temurin
     
     - name: Setup Python
       run: |


### PR DESCRIPTION
In conformance suite release version 5.1.14, they have switched the java version to java-17 [1]. With this PR, FAPI github action uses java-17 to run conformance suite. Identity Server compiling and running will use the java-11 as before.

[1] https://gitlab.com/openid/conformance-suite/-/releases/release-v5.1.14