### PR TITLE
[FAPI] Enable PAR profiles in FAPI Conformance github action

### DIFF
--- a/oidc-fapi-conformance-tests/test_runner_fapi.sh
+++ b/oidc-fapi-conformance-tests/test_runner_fapi.sh
@@ -24,19 +24,19 @@ echo
 python3 $CONFORMANCE_SUITE_PATH/scripts/run-test-plan.py fapi1-advanced-final-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=by_value] $PATH_TO_SCRIPTS/config/IS_config_fapi_mtls.json 2>&1 | tee fapi-testplan-mtls-log.txt
 echo
 
-# echo
-# echo "FAPI Basic test plan - private_key_jwt, plain_fapi, plain_response, pushed"
-# echo "-----------------------------"
-# echo
-# python3 $CONFORMANCE_SUITE_PATH/scripts/run-test-plan.py fapi1-advanced-final-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=pushed] $PATH_TO_SCRIPTS/config/IS_config_fapi_pvtkeyjwt_par.json 2>&1 | tee fapi-testplan-pvtkeyjwt-par-log.txt
-# echo
+ echo
+ echo "FAPI Basic test plan - private_key_jwt, plain_fapi, plain_response, pushed"
+ echo "-----------------------------"
+ echo
+ python3 $CONFORMANCE_SUITE_PATH/scripts/run-test-plan.py fapi1-advanced-final-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=pushed] $PATH_TO_SCRIPTS/config/IS_config_fapi_pvtkeyjwt_par.json 2>&1 | tee fapi-testplan-pvtkeyjwt-par-log.txt
+ echo
 
-# echo
-# echo "FAPI Basic test plan - mtls, plain_fapi, plain_response, pushed"
-# echo "-----------------------------"
-# echo
-# python3 $CONFORMANCE_SUITE_PATH/scripts/run-test-plan.py fapi1-advanced-final-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=pushed] $PATH_TO_SCRIPTS/config/IS_config_fapi_mtls_par.json 2>&1 | tee fapi-testplan-mtls-par-log.txt
-# echo
+ echo
+ echo "FAPI Basic test plan - mtls, plain_fapi, plain_response, pushed"
+ echo "-----------------------------"
+ echo
+ python3 $CONFORMANCE_SUITE_PATH/scripts/run-test-plan.py fapi1-advanced-final-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=pushed] $PATH_TO_SCRIPTS/config/IS_config_fapi_mtls_par.json 2>&1 | tee fapi-testplan-mtls-par-log.txt
+ echo
 
 # echo
 # echo "FAPI Basic test plan - private_key_jwt, plain_fapi, jarm, by_value"


### PR DESCRIPTION
This PR enables both PAR with private-key-jwt and PAR with mtls profiles in the FAPI Conformance github action.