### PR TITLE
Disable deprecated and not promoted features

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -19,7 +19,12 @@
     "identity_mgt_emailtemplate_menu",
     "identity_security_questions_menu",
     "metrics_menu",
-    "shutdown_restart_menu"
+    "shutdown_restart_menu",
+    "user_mgt_menu_add",
+    "identity_providers_menu",
+    "identity_admin_advisory_banner_menu",
+    "server-roles-mgt_menu",
+    "logging_config_menu"
   ],
   "http_access_log.directory": "${carbon.home}/repository/logs",
   "http_access_log.prefix": "http_access_",
@@ -51,5 +56,6 @@
   "user_store.properties.UsernameJavaScriptRegEx": "^[^\\s*?%]{3,50}$",
 
   "default_management_ui.path": "console",
-  "legacy_authz_runtime.enable": false
+  "legacy_authz_runtime.enable": false,
+  "resident_identity_provider.enable": "false"
 }

--- a/modules/distribution/src/repository/resources/conf/infer.json
+++ b/modules/distribution/src/repository/resources/conf/infer.json
@@ -31,5 +31,23 @@
       "authentication.endpoint.redirect_params.parameters": ["sessionDataKey", "sessionDataKeyConsent", "errorKey",
         "tenantDomain", "t"]
     }
+  },
+  "resident_identity_provider.enable": {
+    "true": {
+      "server.hide_menu_items": [
+        "claim_mgt_menu",
+        "remote_fetch_providers_menu",
+        "identity_mgt_emailtemplate_menu",
+        "identity_security_questions_menu",
+        "metrics_menu",
+        "shutdown_restart_menu",
+        "user_mgt_menu_add",
+        "identity_providers_add",
+        "identity_providers_list",
+        "identity_admin_advisory_banner_menu",
+        "server-roles-mgt_menu",
+        "logging_config_menu"
+      ]
+    }
   }
 }

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -165,7 +165,7 @@
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.event.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.mgt.feature:${carbon.identity.framework.version}
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.mgt.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.template.mgt.feature:${carbon.identity.framework.version}
@@ -177,7 +177,7 @@
                                     org.wso2.carbon.identity.event.handler.accountlock:org.wso2.carbon.identity.handler.event.account.lock.feature:${identity.event.handler.account.lock.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity.event.handler.notification:org.wso2.carbon.email.mgt.feature:${identity.event.handler.notification.version}
+                                    org.wso2.carbon.identity.event.handler.notification:org.wso2.carbon.email.mgt.server.feature:${identity.event.handler.notification.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.event.handler.notification:org.wso2.carbon.event.handler.notification.server.feature:${identity.event.handler.notification.version}
@@ -210,7 +210,7 @@
                                     org.wso2.carbon.identity.saml.common:org.wso2.carbon.identity.saml.common.util.feature:${saml.common.util.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.application.mgt.feature:${carbon.identity.framework.version}
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.application.mgt.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.functions.library.mgt.feature:${carbon.identity.framework.version}
@@ -501,9 +501,6 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.extension.identity.verification:org.wso2.carbon.extension.identity.verification.provider.feature:${identity.verification.version}
                                 </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.extension.identity.verification:org.wso2.carbon.extension.identity.verification.ui.feature:${identity.verification.version}
-                                </featureArtifactDef>
                                 <!-- input validation related features -->
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.input.validation.mgt.server.feature:${carbon.identity.framework.version}
@@ -654,11 +651,11 @@
                                     <version>${identity.event.handler.account.lock.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.mgt.server.feature.group</id>
                                     <version>${carbon.identity.framework.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.email.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.email.mgt.server.feature.group</id>
                                     <version>${identity.event.handler.notification.version}</version>
                                 </feature>
                                 <feature>
@@ -694,7 +691,7 @@
                                     <version>${saml.common.util.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.application.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.application.mgt.server.feature.group</id>
                                     <version>${carbon.identity.framework.version}</version>
                                 </feature>
                                 <feature>
@@ -1124,10 +1121,6 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.extension.identity.verification.mgt.feature.group</id>
-                                    <version>${identity.verification.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.extension.identity.verification.ui.feature.group</id>
                                     <version>${identity.verification.version}</version>
                                 </feature>
                                 <feature>


### PR DESCRIPTION
Hide following items from the management console menu

- User Management (Role management will be available)
- Service Providers
- Identity Verification Providers
- Identity Providers (Resident IdP section can be enabled based on a config)
- Email Templates
- Admin Advisory
- Remote Logging
- Server Roles

### Related Issue
https://github.com/wso2/product-is/issues/18950
