### PR TITLE
Bump identity-apps-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2377,7 +2377,7 @@
         <!-- Identity Portal Versions -->
         <identity.apps.console.version>2.11.10</identity.apps.console.version>
         <identity.apps.myaccount.version>2.3.4</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.0.126</identity.apps.core.version>
+        <identity.apps.core.version>2.0.127</identity.apps.core.version>
         <identity.apps.tests.version>1.6.373</identity.apps.tests.version>
 
         <!-- Charon -->


### PR DESCRIPTION
## Purpose 

Need to bump the identity-apps-core version to 2.0.127 [1] to include the fix for https://github.com/wso2/product-is/issues/18309.

This will not affect the functionality as the change is only a text modification.

https://github.com/wso2/identity-apps/releases/tag/%40wso2is%2Fidentity-apps-core%402.0.127