### PR TITLE
Bump carbon identity framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2252,7 +2252,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.0.55</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.0.57</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Contains changes from following two PRs

- 7.0.57 - https://github.com/wso2/carbon-identity-framework/pull/5506 by @Lakshan-Banneheke 
- 7.0.56 -  https://github.com/wso2/carbon-identity-framework/pull/5503 by @DonOmalVindula 

### Related Issue

- https://github.com/wso2/product-is/issues/19481