### PR TITLE
Bump identity.inbound.provisioning.scim version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2277,7 +2277,7 @@
         <identity.inbound.auth.oauth.version>7.0.11</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.10.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.4</identity.inbound.auth.sts.version>
-        <identity.inbound.provisioning.scim.version>5.7.6</identity.inbound.provisioning.scim.version>
+        <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>
         <identity.inbound.provisioning.scim2.version>3.4.66</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->


### PR DESCRIPTION
### Purpose

Bump identity.inbound.provisioning.scim version to v5.7.7

### Related PR:
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim/pull/128