### PR TITLE
Bump registry version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2392,7 +2392,7 @@
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.12.20</carbon.deployment.version>
         <carbon.commons.version>4.10.7</carbon.commons.version>
-        <carbon.registry.version>4.8.15</carbon.registry.version>
+        <carbon.registry.version>4.8.24</carbon.registry.version>
         <carbon.multitenancy.version>4.11.19</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.analytics-common.version>5.2.58</carbon.analytics-common.version>


### PR DESCRIPTION
$Subject

Fix the https://github.com/wso2/product-is/issues/19658 
Registry's Guava version was bumped by https://github.com/wso2/carbon-registry/commit/38965523a108134ed6614ed0aa068eed791b7ee4
guava jar packing from the registry is fixed by this PR