### PR TITLE
Update PR builder for identity-extension-utils

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -126,6 +126,11 @@ else
       echo "Checking out for 5.2.x branch in carbon-analytics-common..."
       echo "=========================================================="
       git checkout 5.2.x
+  elif [ "$REPO" = "identity-extension-utils" ]; then
+      echo ""
+      echo "Checking out for 1.0.x branch in identity-extension-utils..."
+      echo "=========================================================="
+      git checkout 1.0.x
   fi
   DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
   echo "Dependency Version: $DEPENDENCY_VERSION"


### PR DESCRIPTION
### Purpose

product-is packs the components of [wso2-extensions/identity-extension-utils](https://github.com/wso2-extensions/identity-extension-utils/tree/master) from the `1.0.x` branch instead of the master branch. This needs to be updated in the PR builder.