### PR TITLE
Exclude identity-extension-utils from dependency-updater.yml

### DIFF
--- a/.github/workflows/dependency-updater.yml
+++ b/.github/workflows/dependency-updater.yml
@@ -79,7 +79,7 @@ jobs:
           echo ""
           echo 'Updating dependencies'
           echo "=========================================================="
-          mvn versions:update-properties -U -DgenerateBackupPoms=false -DallowMajorUpdates=false -Dincludes=org.wso2.carbon.identity.*,org.wso2.carbon.extension.identity.*,org.wso2.identity.*,org.wso2.carbon.consent.*,org.wso2.carbon.healthcheck.*,org.wso2.carbon.utils,org.wso2.charon,org.apache.rampart.wso2,org.apache.ws.security.wso2,org.wso2.carbon.identity.framework:*
+          mvn versions:update-properties -U -DgenerateBackupPoms=false -DallowMajorUpdates=false -Dincludes=org.wso2.carbon.identity.*,org.wso2.carbon.extension.identity.*,org.wso2.identity.*,org.wso2.carbon.consent.*,org.wso2.carbon.healthcheck.*,org.wso2.carbon.utils,org.wso2.charon,org.apache.rampart.wso2,org.apache.ws.security.wso2,org.wso2.carbon.identity.framework:* -Dexcludes=org.wso2.carbon.extension.identity.authenticator.utils
           echo ""
           echo 'Available updates'
           echo "=========================================================="


### PR DESCRIPTION
Refer: https://github.com/wso2/product-is/issues/19955#issuecomment-1983333636

Edit excluding the org.wso2.carbon.extension.identity.authenticator.utils from being bump with dependency updater temporary, until https://github.com/wso2/product-is/issues/19955 is fixed.
Note: This version bump is added to dependency updater with https://github.com/wso2/product-is/pull/19734 which is 3 days ago.