### PR TITLE
Bump framework version 7.0.93

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.0.91</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.0.93</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Bumping the framework version to 7.0.93 to incorporate federated token sharing feature.

- https://github.com/wso2/carbon-identity-framework/pull/5563