### PR TITLE
Update inbound scim2 version to the latest 3.4.73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2288,7 +2288,7 @@
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.5</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.72</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.73</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.8</identity.user.account.association.version>


### PR DESCRIPTION
## Changes in this PR
- Bumped the inbound scim2 version to 3.4.73 to get the changes of PR [1] to the product.
- Diff of 3.4.72 and 3.4.73 contains only the PR [1] and the PR builder is passed in [1].

[1] https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/539