### PR TITLE
Fix integration tests related to request object flow

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -81,6 +81,8 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 	protected static final String EMAIL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
 	private static final String GIVEN_NAME_CLAIM_URI = "http://wso2.org/claims/givenname";
 	protected static final String COUNTRY_CLAIM_URI = "http://wso2.org/claims/country";
+	private static final String customClaimURI1 = "http://wso2.org/claims/department";
+	private static final String customClaimURI2 = "http://wso2.org/claims/stateorprovince";
 	private static final String GRANT_TYPE_PASSWORD = "password";
 	private static final String SCOPE_PRODUCTION = "PRODUCTION";
 	public static final String OIDC = "oidc";
@@ -352,6 +354,12 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 
 		claimConfiguration.addClaimMappingsItem(getClaimMapping(COUNTRY_CLAIM_URI));
 		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(COUNTRY_CLAIM_URI));
+
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(customClaimURI1));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(customClaimURI1));
+
+		claimConfiguration.addClaimMappingsItem(getClaimMapping(customClaimURI2));
+		claimConfiguration.addRequestedClaimsItem(getRequestedClaim(customClaimURI2));
 
 		return claimConfiguration;
 	}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase.java
@@ -97,6 +97,8 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
     private static final String emailClaimURI = "http://wso2.org/claims/emailaddress";
     private static final String givenNameClaimURI = "http://wso2.org/claims/givenname";
     private static final String countryClaimURI = "http://wso2.org/claims/country";
+    private static final String customClaimURI1 = "http://wso2.org/claims/department";
+    private static final String customClaimURI2 = "http://wso2.org/claims/stateorprovince";
     private static final String externalClaimURI1 = "externalClaim1";
     private static final String externalClaimURI2 = "externalClaim2";
     private static final String USER_EMAIL = "abcrqo@wso2.com";
@@ -158,6 +160,8 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         claimManagementRestClient = new ClaimManagementRestClient(serverURL, tenantInfo);
 
         addAdminUser();
+        claimId1 = addOIDCClaims(externalClaimURI1, customClaimURI1);
+        claimId2 = addOIDCClaims(externalClaimURI2, customClaimURI2);
 
     }
 
@@ -208,8 +212,7 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         urlParameters.add(new BasicNameValuePair("authorizeEndpoint", OAuth2Constant.APPROVAL_URL
                 + "?request=" + REQUEST));
         urlParameters.add(new BasicNameValuePair("authorize", OAuth2Constant.AUTHORIZE_PARAM));
-        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID + " " +
-                OAuth2Constant.OAUTH2_SCOPE_EMAIL + " " + OAuth2Constant.OAUTH2_SCOPE_PROFILE));
+        urlParameters.add(new BasicNameValuePair("scope", OAuth2Constant.OAUTH2_SCOPE_OPENID));
 
         HttpResponse response =
                 sendPostRequestWithParameters(client, urlParameters,
@@ -351,13 +354,14 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         Object obj = JSONValue.parse(rd);
         String email = ((JSONObject) obj).get("email").toString();
         String givenName = ((JSONObject) obj).get("given_name").toString();
+        Object externalClaim1 = ((JSONObject) obj).get("externalClaim1");
+        Object externalClaim2 = ((JSONObject) obj).get("externalClaim2");
 
         EntityUtils.consume(response.getEntity());
         Assert.assertEquals(USER_EMAIL, email, "Incorrect email claim value");
         Assert.assertEquals(GIVEN_NAME, givenName, "Incorrect given_name claim value");
-        // externalClaim1 and externalClaim2 are not included in the requested scopes.
-        Assert.assertNull(((JSONObject) obj).get("externalClaim1"));
-        Assert.assertNull(((JSONObject) obj).get("externalClaim2"));
+        Assert.assertEquals(CUSTOM_CLAIM1, externalClaim1, "Incorrect externalClaim1 claim value");
+        Assert.assertNull(externalClaim2, "A value for externalClaim2 claim is present in the response.");
     }
 
     @Test(groups = "wso2.is", description = "Validate Token Expiration Time",
@@ -380,7 +384,6 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         Assert.assertNotNull(tokenResponse.get("scope"), "'scope' is not included");
 
         String scopes = tokenResponse.get("scope").toString();
-        Assert.assertTrue(scopes.contains("email"), "Invalid JWT Token scope Value");
         Assert.assertTrue(scopes.contains("openid"), "Invalid JWT Token scope Value");
     }
 
@@ -423,7 +426,12 @@ public class OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase extends OAuth
         userInfo.setPassword(PASSWORD);
         userInfo.setName(new Name().givenName(GIVEN_NAME));
         userInfo.addEmail(new Email().value(USER_EMAIL));
-        userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().country(COUNTRY));
+
+        ScimSchemaExtensionEnterprise scimSchemaExtensionEnterprise = new ScimSchemaExtensionEnterprise();
+        scimSchemaExtensionEnterprise.setCountry(COUNTRY);
+        scimSchemaExtensionEnterprise.setDepartment(CUSTOM_CLAIM1);
+        scimSchemaExtensionEnterprise.setStateorprovince(CUSTOM_CLAIM2);
+        userInfo.setScimSchemaExtensionEnterprise(scimSchemaExtensionEnterprise);
 
         userId = scim2RestClient.createUser(userInfo);
         String roleId = scim2RestClient.getRoleIdByName("admin");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/ScimSchemaExtensionEnterprise.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/ScimSchemaExtensionEnterprise.java
@@ -29,6 +29,8 @@ public class ScimSchemaExtensionEnterprise {
     private String employeeNumber;
     private Boolean accountLocked;
     private String country;
+    private String department;
+    private String stateorprovince;
 
     /**
      *
@@ -110,6 +112,28 @@ public class ScimSchemaExtensionEnterprise {
         this.country = country;
     }
 
+    @ApiModelProperty(example = "Western")
+    @JsonProperty("stateorprovince")
+    @Valid
+    public String getStateorprovince() {
+        return stateorprovince;
+    }
+
+    public void setStateorprovince(String stateorprovince) {
+        this.stateorprovince = stateorprovince;
+    }
+
+    @ApiModelProperty(example = "Engineering")
+    @JsonProperty("department")
+    @Valid
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
     @Override
     public boolean equals(Object o) {
 
@@ -123,7 +147,9 @@ public class ScimSchemaExtensionEnterprise {
         return Objects.equals(this.manager, scimSchemaExtensionEnterprise.manager) &&
                 Objects.equals(this.employeeNumber, scimSchemaExtensionEnterprise.employeeNumber) &&
                 Objects.equals(this.accountLocked, scimSchemaExtensionEnterprise.accountLocked) &&
-                Objects.equals(this.country, scimSchemaExtensionEnterprise.country);
+                Objects.equals(this.country, scimSchemaExtensionEnterprise.country) &&
+                Objects.equals(this.department, scimSchemaExtensionEnterprise.department) &&
+                Objects.equals(this.stateorprovince, scimSchemaExtensionEnterprise.stateorprovince);
     }
 
     @Override
@@ -139,6 +165,8 @@ public class ScimSchemaExtensionEnterprise {
                 "    employeeNumber: " + toIndentedString(employeeNumber) + "\n" +
                 "    accountLocked: " + toIndentedString(accountLocked) + "\n" +
                 "    country: " + toIndentedString(country) + "\n" +
+                "    department: " + toIndentedString(department) + "\n" +
+                "    stateorprovince: " + toIndentedString(stateorprovince) + "\n" +
                 "}";
     }
 


### PR DESCRIPTION
This PR reverts the changes from https://github.com/wso2/product-is/pull/12707

The request object flow was broken with the changes from https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1698 and the integration tests related to request object flow were altered to support that behaviour with https://github.com/wso2/product-is/pull/12707. 

Request object flow will be fixed with the PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2405 and  the related changes to fix the integration tests by reverting the previous PR will be added by this PR.

Related issue: https://github.com/wso2/product-is/issues/19817