### PR TITLE
Fix app native authentication related integration test failure

### DIFF
--- a/modules/distribution/src/repository/resources/conf/log4j2.properties
+++ b/modules/distribution/src/repository/resources/conf/log4j2.properties
@@ -389,7 +389,7 @@ logger.org-wso2-carbon-identity-application.name=org.wso2.carbon.identity.applic
 logger.org-wso2-carbon-identity-application.level=INFO
 
 logger.org-wso2-carbon-identity-application-authentication-framework.name=org.wso2.carbon.identity.application.authentication.framework
-logger.org-wso2-carbon-identity-application-authentication-framework.level=INFO
+logger.org-wso2-carbon-identity-application-authentication-framework.level=DEBUG
 
 #logger.org-wso2-carbon-identity-mgt.name=org.wso2.carbon.identity.mgt
 #logger.org-wso2-carbon-identity-mgt.level=DEBUG

--- a/modules/distribution/src/repository/resources/conf/log4j2.properties
+++ b/modules/distribution/src/repository/resources/conf/log4j2.properties
@@ -389,7 +389,7 @@ logger.org-wso2-carbon-identity-application.name=org.wso2.carbon.identity.applic
 logger.org-wso2-carbon-identity-application.level=INFO
 
 logger.org-wso2-carbon-identity-application-authentication-framework.name=org.wso2.carbon.identity.application.authentication.framework
-logger.org-wso2-carbon-identity-application-authentication-framework.level=DEBUG
+logger.org-wso2-carbon-identity-application-authentication-framework.level=INFO
 
 #logger.org-wso2-carbon-identity-mgt.name=org.wso2.carbon.identity.mgt
 #logger.org-wso2-carbon-identity-mgt.level=DEBUG

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
@@ -49,6 +49,8 @@ import org.wso2.identity.integration.test.rest.api.server.application.management
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -89,6 +91,7 @@ import static org.wso2.identity.integration.test.applicationNativeAuthentication
 import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.TEST_USER_NAME;
 import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.TRACE_ID;
 import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.UTF_8;
+import static org.wso2.identity.integration.test.utils.CommonConstants.BASIC_AUTHENTICATOR;
 
 /**
  * Integration test class for testing the native authentication flow in an OAuth 2.0-enabled application.
@@ -284,6 +287,13 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
 
         application.setInboundProtocolConfiguration(inboundProtocolsConfig);
         application.setName(TEST_APP_NAME);
+        application.authenticationSequence(new AuthenticationSequence()
+                .type(AuthenticationSequence.TypeEnum.USER_DEFINED)
+                .addStepsItem(new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep()
+                        .id(1)
+                        .addOptionsItem(new Authenticator()
+                                .idp("LOCAL")
+                                .authenticator(BASIC_AUTHENTICATOR))));
 
         String appId = addApplication(application);
         return getApplication(appId);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
@@ -243,7 +243,7 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
         System.out.println("Authenticator ID: " + authenticatorId);
         ApplicationResponseModel application = getApplication(appId);
         System.out.println("App authenticator: " + application.getAuthenticationSequence().getSteps().toString());
-        System.out.println("App id: " + application.getInboundProtocols().toString());
+        System.out.println("App id: " + application);
         Response authnResponse = getResponseOfJSONPost( href, body, new HashMap<>());
         ExtractableResponse<Response> extractableResponse = authnResponse.then()
                 .log().ifValidationFails()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
@@ -214,13 +214,14 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
         EntityUtils.consume(response.getEntity());
         JSONParser parser = new JSONParser();
         JSONObject json = (org.json.simple.JSONObject) parser.parse(responseString);
+        System.out.println("Init response: " + json.toJSONString());
         Assert.assertNotNull(json, "Client Native Authentication Init response is null.");
         validInitClientNativeAuthnResponse(json);
     }
 
     @Test(groups = "wso2.is", description = "Send Basic authentication POST request.",
             dependsOnMethods = "testSendInitAuthRequestPost")
-    public void testSendBasicAuthRequestPost() {
+    public void testSendBasicAuthRequestPost() throws Exception {
 
         String body = "{\n" +
                 "    \"flowId\": \"" + flowId + "\",\n" +
@@ -233,6 +234,9 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
                 "    }\n" +
                 "}";
 
+        System.out.println("Authenticator ID: " + authenticatorId);
+        ApplicationResponseModel application = getApplication(appId);
+        System.out.println("App authenticator: " + application.getAuthenticationSequence().getSteps().toString());
         Response authnResponse = getResponseOfJSONPost( href, body, new HashMap<>());
         ExtractableResponse<Response> extractableResponse = authnResponse.then()
                 .log().ifValidationFails()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/ApplicationNativeAuthenticationTestCase.java
@@ -160,6 +160,7 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
 
         OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(application.getId());
         consumerKey = oidcConfig.getClientId();
+        System.out.println("Registering app: " + consumerKey);
         Assert.assertNotNull(consumerKey, "Application creation failed.");
 
         appId = application.getId();
@@ -174,6 +175,8 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
 
         HttpResponse response = sendPostRequestWithParameters(client, buildOAuth2Parameters(consumerKey),
                 OAuth2Constant.AUTHORIZE_ENDPOINT_URL);
+        System.out.println("Default test app: " + consumerKey);
+
         Assert.assertNotNull(response, "Authorization request failed. Authorized response is null.");
 
         String responseString = EntityUtils.toString(response.getEntity(), UTF_8);
@@ -208,6 +211,8 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
 
         HttpResponse response = sendPostRequestWithParameters(client, buildOAuth2Parameters(consumerKey),
                 OAuth2Constant.AUTHORIZE_ENDPOINT_URL);
+        System.out.println("Init request app: " + consumerKey);
+
         Assert.assertNotNull(response, "Authorization request failed. Authorized response is null.");
 
         String responseString = EntityUtils.toString(response.getEntity(), UTF_8);
@@ -234,9 +239,11 @@ public class ApplicationNativeAuthenticationTestCase extends OAuth2ServiceAbstra
                 "    }\n" +
                 "}";
 
+        System.out.println("Flow id: " + flowId);
         System.out.println("Authenticator ID: " + authenticatorId);
         ApplicationResponseModel application = getApplication(appId);
         System.out.println("App authenticator: " + application.getAuthenticationSequence().getSteps().toString());
+        System.out.println("App id: " + application.getInboundProtocols().toString());
         Response authnResponse = getResponseOfJSONPost( href, body, new HashMap<>());
         ExtractableResponse<Response> extractableResponse = authnResponse.then()
                 .log().ifValidationFails()

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -29,111 +29,111 @@
 
     <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2PushedAuthRequestTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ResponseModeTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCMetadataTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2JWKSEndpointTestCase"/>-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>-->
-<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>&ndash;&gt;-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2PushedAuthRequestTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ResponseModeTestCase"/>
+            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
+            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OIDCMetadataTest"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2JWKSEndpointTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />
+            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />
+            <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>
+            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
+            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>
+            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>-->
 
-<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.store.LegacyJDBCUserStoreAddingTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>
+            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.store.LegacyJDBCUserStoreAddingTestCase"/>
 
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>
 
-<!--            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServicePasswordGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServicePasswordGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>
 
-<!--            &lt;!&ndash;TODO Remove following open id tests since deprecated&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>-->
-<!--            &lt;!&ndash;TODO End of openid tests&ndash;&gt;-->
+            <!--TODO Remove following open id tests since deprecated-->
+            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />
+            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />
+            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>
+            <!--TODO End of openid tests-->
 
-<!--            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />-->
-<!--            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />-->
+            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
+            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
+            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>
+            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
+            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />
+            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />
 
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCRPInitiatedLogoutTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCCustomScopesLoginTest"/>-->
-<!--            &lt;!&ndash; <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase"/> &ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSLOTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSSOTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOConsentTestCase"/>-->
-<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.postAuthnHandler.ChallengeQuestionPostAuthnHandlerTestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.functions.library.mgt.FunctionLibraryManagementTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithRevokedAccessToken" />-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationAfterAccountDisablingTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>-->
-<!--&lt;!&ndash;            Temporarily Coomenting out following test case cause, its not running on JDK 11&ndash;&gt;-->
-<!--&lt;!&ndash;            Ref : https://github.com/wso2/product-is/issues/14041&ndash;&gt;-->
-<!--&lt;!&ndash;            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>-->
-<!--&lt;!&ndash;            Temporarily commenting out following test case cause due to intermittent error&ndash;&gt;-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>
+            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCRPInitiatedLogoutTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OIDCCustomScopesLoginTest"/>
+            <!-- <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase"/> -->
+            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />
+            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>
+            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSLOTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSSOTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLSSOConsentTestCase"/>
+            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.postAuthnHandler.ChallengeQuestionPostAuthnHandlerTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/>
+            <class name="org.wso2.identity.integration.test.functions.library.mgt.FunctionLibraryManagementTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithRevokedAccessToken" />
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationAfterAccountDisablingTestCase" />
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />
+            <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>
+<!--            Temporarily Coomenting out following test case cause, its not running on JDK 11-->
+<!--            Ref : https://github.com/wso2/product-is/issues/14041-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>-->
+            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>
+<!--            Temporarily commenting out following test case cause due to intermittent error-->
             <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>
         </classes>
     </test>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -134,7 +134,7 @@
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>
 <!--            Temporarily commenting out following test case cause due to intermittent error-->
-<!--            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>
         </classes>
     </test>
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -138,243 +138,243 @@
         </classes>
     </test>
 
-<!--    <test name="is-test-rest-api" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            &lt;!&ndash;Test cases for user REST APIs&ndash;&gt;-->
-<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeSuccessTest"/>&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeNegativeTest"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeSuccessTestBase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeNegativeTestBase"/>-->
-<!--            &lt;!&ndash;Disabling since the workflow is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsNegativeTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsNegativeTest"/>-->
-<!--            &lt;!&ndash;TODO: Temporary disabled MeAuthorizedAppsScopeTest. Enable after fixing https://github.com/wso2/product-is/issues/13230. &ndash;&gt;-->
-<!--            &lt;!&ndash; <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsScopeTest"/> &ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsNegativeTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionAdminSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationFailureTest"/>-->
-<!--            &lt;!&ndash;Test cases for server REST APIs&ndash;&gt;-->
-<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.challenge.v1.ServerChallengeTestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesPositiveTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesNegativeTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesPositiveTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesNegativeTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationMetadataPositiveTest"/>-->
-<!--            &lt;!&ndash; Disabling /user/{user-id}/* type of API tests as they will not be exposed in 5.9.0 &ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserSuccessTest"/>&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserNegativeTest"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.permission.management.v1.PermissionManagementTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>-->
-<!--            &lt;!&ndash;Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>&ndash;&gt;-->
-<!--            &lt;!&ndash;Disabling the test until the application templates are restructured.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderFailureTest"/>-->
-<!--            &lt;!&ndash; Disabling the SecretManagement api tests as the api is removed from the access control &ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementSuccessTest"/>&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementFailureTest"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-test-rest-api" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!--Test cases for user REST APIs-->
+            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeSuccessTest"/>-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeNegativeTest"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeSuccessTestBase"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeNegativeTestBase"/>
+            <!--Disabling since the workflow is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsNegativeTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsNegativeTest"/>
+            <!--TODO: Temporary disabled MeAuthorizedAppsScopeTest. Enable after fixing https://github.com/wso2/product-is/issues/13230. -->
+            <!-- <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsScopeTest"/> -->
+            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsNegativeTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionAdminSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationFailureTest"/>
+            <!--Test cases for server REST APIs-->
+            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.server.challenge.v1.ServerChallengeTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesPositiveTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesNegativeTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesPositiveTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesNegativeTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationMetadataPositiveTest"/>
+            <!-- Disabling /user/{user-id}/* type of API tests as they will not be exposed in 5.9.0 -->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserSuccessTest"/>-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserNegativeTest"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.permission.management.v1.PermissionManagementTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>
+            <!--Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>-->
+            <!--Disabling the test until the application templates are restructured.-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderFailureTest"/>
+            <!-- Disabling the SecretManagement api tests as the api is removed from the access control -->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementSuccessTest"/>-->
+            <!--<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementFailureTest"/>-->
+            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>
+        </classes>
+    </test>
 
-<!--    <test name="is-tests-scim2" preserve-order="true" parallel="false">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2RoleTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2SchemasTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaMeTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-tests-scim2" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2RoleTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>
+            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2SchemasTest"/>
+            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaMeTestCase"/>
+        </classes>
+    </test>
 
-<!--    <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>-->
-<!--            &lt;!&ndash; This test has a restart&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>
+            <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>
+            <!-- This test has a restart-->
+            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />
+        </classes>
+    </test>
 
-<!--    <test name="is-tests-default-configuration-ldap" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.base.LDAPUserStoreInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-tests-default-configuration-ldap" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.base.LDAPUserStoreInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>
+        </classes>
+    </test>
 
-<!--    <test name="is-tests-uuid-user-store" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            &lt;!&ndash; This initializer test should run before running other tests. This will copy the relevant services that-->
-<!--                 needs to run the new test cases.&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-tests-uuid-user-store" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!-- This initializer test should run before running other tests. This will copy the relevant services that
+                 needs to run the new test cases.-->
+            <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>
+        </classes>
+    </test>
 
-<!--    &lt;!&ndash;-->
-<!--    ====================================================================================================================-->
-<!--        IMPORTANT : All the tests below this section, should be the ones that requires additional Identity Server-->
-<!--        instance.-->
+    <!--
+    ====================================================================================================================
+        IMPORTANT : All the tests below this section, should be the ones that requires additional Identity Server
+        instance.
 
-<!--        To minimize the number of restarts, at each test, additional instance is started before all the tests in the-->
-<!--        below tag and stopped at the end.-->
-<!--    ====================================================================================================================-->
-<!--    &ndash;&gt;-->
+        To minimize the number of restarts, at each test, additional instance is started before all the tests in the
+        below tag and stopped at the end.
+    ====================================================================================================================
+    -->
 
-<!--    <test name="is-tests-federation" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationFederationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTSFederation"/>-->
-<!--            &lt;!&ndash;TODO: Temporary disabled ConditionalAuthenticationTestCase. Enable after fixing the issues. &ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" />&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/>-->
-<!--            &lt;!&ndash;Disabling since the workflow is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCIdentityFederationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCFederatedIdpInitLogoutTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenExchangeGrantTypeTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingIDPConfigDisabledTestCase" />-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-tests-federation" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationFederationTestCase"/>
+            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTSFederation"/>
+            <!--TODO: Temporary disabled ConditionalAuthenticationTestCase. Enable after fixing the issues. -->
+            <!--<class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" />-->
+            <class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/>
+            <!--Disabling since the workflow is provided as a connector and it does not exist in the product by default.-->
+            <!--<class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.oidc.OIDCIdentityFederationTestCase"/>
+            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCFederatedIdpInitLogoutTest"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenExchangeGrantTypeTestCase" />
+            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingTestCase" />
+            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingIDPConfigDisabledTestCase" />
+        </classes>
+    </test>
 
-<!--    &lt;!&ndash;-->
-<!--    ====================================================================================================================-->
-<!--        IMPORTANT : All the tests below this section, should be the ones that requires configuration changes and-->
-<!--        restarts.-->
+    <!--
+    ====================================================================================================================
+        IMPORTANT : All the tests below this section, should be the ones that requires configuration changes and
+        restarts.
 
-<!--        To minimize the number of restarts, at each test, do the configuration update and restart. Then do the test-->
-<!--        and finally restore the configuration without restarting. The next test will perform the restart with the-->
-<!--        configuration changes required for it.-->
+        To minimize the number of restarts, at each test, do the configuration update and restart. Then do the test
+        and finally restore the configuration without restarting. The next test will perform the restart with the
+        configuration changes required for it.
 
-<!--        If multiple tests can be run with one configuration change, group them into a test group and do the above at-->
-<!--        @BeforeTest, and @AfterTest. See 'is-tests-jdbc-userstore' for example.-->
-<!--    ====================================================================================================================-->
-<!--    &ndash;&gt;-->
+        If multiple tests can be run with one configuration change, group them into a test group and do the above at
+        @BeforeTest, and @AfterTest. See 'is-tests-jdbc-userstore' for example.
+    ====================================================================================================================
+    -->
 
-<!--    <test name="is-tests-federation-restart" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.base.JDBCUserStoreInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="is-tests-read-only-userstore" preserve-order="true" parallel="false" group-by-instances="true" >-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.base.ReadOnlyUserStoreInitializerTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateReadOnlyTest"/>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="is-tests-oauth-jwt-token-gen-enabled" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>-->
-<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>&ndash;&gt;-->
-<!--            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.rest.api.user.liteUserRegister.LiteUserRegisterTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenScopeValidatorTestCase" />-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOForAdminLoginTestCase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuthAppsWithSameClientIdTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-tests-federation-restart" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.base.JDBCUserStoreInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-read-only-userstore" preserve-order="true" parallel="false" group-by-instances="true" >
+        <classes>
+            <class name="org.wso2.identity.integration.test.base.ReadOnlyUserStoreInitializerTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateReadOnlyTest"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-oauth-jwt-token-gen-enabled" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
+            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>
+            <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>
+            <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>
+            <class name="org.wso2.identity.integration.test.rest.api.user.liteUserRegister.LiteUserRegisterTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenScopeValidatorTestCase" />
+            <class name="org.wso2.identity.integration.test.saml.SAMLSSOForAdminLoginTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuthAppsWithSameClientIdTestCase"/>
+        </classes>
+    </test>
 
-<!--    <test name="is-tests-saml-query-profile" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestBase"/>-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="is-tests-default-encryption" preserve-order="true" parallel="false" group-by-instances="true">-->
-<!--        <classes>-->
-<!--            <class name="org.wso2.identity.integration.test.encryption.EventPublisherPasswordEncryptionTestCase"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <test name="is-tests-saml-query-profile" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestBase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-default-encryption" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.encryption.EventPublisherPasswordEncryptionTestCase"/>
+        </classes>
+    </test>
 </suite>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -29,352 +29,352 @@
 
     <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2PushedAuthRequestTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ResponseModeTestCase"/>
-            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
-            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OIDCMetadataTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2JWKSEndpointTestCase"/>
-            <!--<class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />
-            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />
-            <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>
-            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
-            <!--<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
-            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2PushedAuthRequestTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ResponseModeTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCMetadataTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2JWKSEndpointTestCase"/>-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>&ndash;&gt;-->
 
-            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>
-            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.LegacyJDBCUserStoreAddingTestCase"/>
+<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.LegacyJDBCUserStoreAddingTestCase"/>-->
 
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>-->
 
-            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServicePasswordGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>
+<!--            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServicePasswordGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>-->
 
-            <!--TODO Remove following open id tests since deprecated-->
-            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />
-            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />
-            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>
-            <!--TODO End of openid tests-->
+<!--            &lt;!&ndash;TODO Remove following open id tests since deprecated&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>-->
+<!--            &lt;!&ndash;TODO End of openid tests&ndash;&gt;-->
 
-            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
-            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
-            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>
-            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />
+<!--            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />-->
 
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>
-            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCRPInitiatedLogoutTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OIDCCustomScopesLoginTest"/>
-            <!-- <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase"/> -->
-            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />
-            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>
-            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSLOTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSSOTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLSSOConsentTestCase"/>
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.postAuthnHandler.ChallengeQuestionPostAuthnHandlerTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/>
-            <class name="org.wso2.identity.integration.test.functions.library.mgt.FunctionLibraryManagementTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithRevokedAccessToken" />
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationAfterAccountDisablingTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />
-            <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>
-<!--            Temporarily Coomenting out following test case cause, its not running on JDK 11-->
-<!--            Ref : https://github.com/wso2/product-is/issues/14041-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>-->
-            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>
-<!--            Temporarily commenting out following test case cause due to intermittent error-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCRPInitiatedLogoutTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCCustomScopesLoginTest"/>-->
+<!--            &lt;!&ndash; <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase"/> &ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSLOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSSOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOConsentTestCase"/>-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.postAuthnHandler.ChallengeQuestionPostAuthnHandlerTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.functions.library.mgt.FunctionLibraryManagementTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithRevokedAccessToken" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationAfterAccountDisablingTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>-->
+<!--&lt;!&ndash;            Temporarily Coomenting out following test case cause, its not running on JDK 11&ndash;&gt;-->
+<!--&lt;!&ndash;            Ref : https://github.com/wso2/product-is/issues/14041&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>-->
+<!--&lt;!&ndash;            Temporarily commenting out following test case cause due to intermittent error&ndash;&gt;-->
             <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>
         </classes>
     </test>
 
-    <test name="is-test-rest-api" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <!--Test cases for user REST APIs-->
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeSuccessTest"/>-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeNegativeTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeSuccessTestBase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeNegativeTestBase"/>
-            <!--Disabling since the workflow is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsNegativeTest"/>
-            <!--TODO: Temporary disabled MeAuthorizedAppsScopeTest. Enable after fixing https://github.com/wso2/product-is/issues/13230. -->
-            <!-- <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsScopeTest"/> -->
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionAdminSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationFailureTest"/>
-            <!--Test cases for server REST APIs-->
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.challenge.v1.ServerChallengeTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesPositiveTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesPositiveTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationMetadataPositiveTest"/>
-            <!-- Disabling /user/{user-id}/* type of API tests as they will not be exposed in 5.9.0 -->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserSuccessTest"/>-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserNegativeTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.permission.management.v1.PermissionManagementTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>
-            <!--Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>-->
-            <!--Disabling the test until the application templates are restructured.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderFailureTest"/>
-            <!-- Disabling the SecretManagement api tests as the api is removed from the access control -->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementSuccessTest"/>-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementFailureTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>
-        </classes>
-    </test>
+<!--    <test name="is-test-rest-api" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            &lt;!&ndash;Test cases for user REST APIs&ndash;&gt;-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeSuccessTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeNegativeTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeSuccessTestBase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeNegativeTestBase"/>-->
+<!--            &lt;!&ndash;Disabling since the workflow is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsNegativeTest"/>-->
+<!--            &lt;!&ndash;TODO: Temporary disabled MeAuthorizedAppsScopeTest. Enable after fixing https://github.com/wso2/product-is/issues/13230. &ndash;&gt;-->
+<!--            &lt;!&ndash; <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsScopeTest"/> &ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionAdminSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationFailureTest"/>-->
+<!--            &lt;!&ndash;Test cases for server REST APIs&ndash;&gt;-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.challenge.v1.ServerChallengeTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesPositiveTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesPositiveTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationMetadataPositiveTest"/>-->
+<!--            &lt;!&ndash; Disabling /user/{user-id}/* type of API tests as they will not be exposed in 5.9.0 &ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserSuccessTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserNegativeTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.permission.management.v1.PermissionManagementTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>-->
+<!--            &lt;!&ndash;Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;Disabling the test until the application templates are restructured.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderFailureTest"/>-->
+<!--            &lt;!&ndash; Disabling the SecretManagement api tests as the api is removed from the access control &ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementSuccessTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementFailureTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-scim2" preserve-order="true" parallel="false">
-        <classes>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2RoleTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2SchemasTest"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaMeTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-scim2" preserve-order="true" parallel="false">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2RoleTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2SchemasTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaMeTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>
-            <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>
-            <!-- This test has a restart-->
-            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />
-        </classes>
-    </test>
+<!--    <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>-->
+<!--            &lt;!&ndash; This test has a restart&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-default-configuration-ldap" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.LDAPUserStoreInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-default-configuration-ldap" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.LDAPUserStoreInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-uuid-user-store" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <!-- This initializer test should run before running other tests. This will copy the relevant services that
-                 needs to run the new test cases.-->
-            <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-uuid-user-store" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            &lt;!&ndash; This initializer test should run before running other tests. This will copy the relevant services that-->
+<!--                 needs to run the new test cases.&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <!--
-    ====================================================================================================================
-        IMPORTANT : All the tests below this section, should be the ones that requires additional Identity Server
-        instance.
+<!--    &lt;!&ndash;-->
+<!--    ====================================================================================================================-->
+<!--        IMPORTANT : All the tests below this section, should be the ones that requires additional Identity Server-->
+<!--        instance.-->
 
-        To minimize the number of restarts, at each test, additional instance is started before all the tests in the
-        below tag and stopped at the end.
-    ====================================================================================================================
-    -->
+<!--        To minimize the number of restarts, at each test, additional instance is started before all the tests in the-->
+<!--        below tag and stopped at the end.-->
+<!--    ====================================================================================================================-->
+<!--    &ndash;&gt;-->
 
-    <test name="is-tests-federation" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationFederationTestCase"/>
-            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTSFederation"/>
-            <!--TODO: Temporary disabled ConditionalAuthenticationTestCase. Enable after fixing the issues. -->
-            <!--<class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" />-->
-            <class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/>
-            <!--Disabling since the workflow is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.oidc.OIDCIdentityFederationTestCase"/>
-            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCFederatedIdpInitLogoutTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenExchangeGrantTypeTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingIDPConfigDisabledTestCase" />
-        </classes>
-    </test>
+<!--    <test name="is-tests-federation" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationFederationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTSFederation"/>-->
+<!--            &lt;!&ndash;TODO: Temporary disabled ConditionalAuthenticationTestCase. Enable after fixing the issues. &ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" />&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/>-->
+<!--            &lt;!&ndash;Disabling since the workflow is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCIdentityFederationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCFederatedIdpInitLogoutTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenExchangeGrantTypeTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingIDPConfigDisabledTestCase" />-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <!--
-    ====================================================================================================================
-        IMPORTANT : All the tests below this section, should be the ones that requires configuration changes and
-        restarts.
+<!--    &lt;!&ndash;-->
+<!--    ====================================================================================================================-->
+<!--        IMPORTANT : All the tests below this section, should be the ones that requires configuration changes and-->
+<!--        restarts.-->
 
-        To minimize the number of restarts, at each test, do the configuration update and restart. Then do the test
-        and finally restore the configuration without restarting. The next test will perform the restart with the
-        configuration changes required for it.
+<!--        To minimize the number of restarts, at each test, do the configuration update and restart. Then do the test-->
+<!--        and finally restore the configuration without restarting. The next test will perform the restart with the-->
+<!--        configuration changes required for it.-->
 
-        If multiple tests can be run with one configuration change, group them into a test group and do the above at
-        @BeforeTest, and @AfterTest. See 'is-tests-jdbc-userstore' for example.
-    ====================================================================================================================
-    -->
+<!--        If multiple tests can be run with one configuration change, group them into a test group and do the above at-->
+<!--        @BeforeTest, and @AfterTest. See 'is-tests-jdbc-userstore' for example.-->
+<!--    ====================================================================================================================-->
+<!--    &ndash;&gt;-->
 
-    <test name="is-tests-federation-restart" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.JDBCUserStoreInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-read-only-userstore" preserve-order="true" parallel="false" group-by-instances="true" >
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.ReadOnlyUserStoreInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateReadOnlyTest"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-oauth-jwt-token-gen-enabled" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
-            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>
-            <!--<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>
-            <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>
-            <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.liteUserRegister.LiteUserRegisterTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenScopeValidatorTestCase" />
-            <class name="org.wso2.identity.integration.test.saml.SAMLSSOForAdminLoginTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuthAppsWithSameClientIdTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-federation-restart" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.JDBCUserStoreInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-read-only-userstore" preserve-order="true" parallel="false" group-by-instances="true" >-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.ReadOnlyUserStoreInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateReadOnlyTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-oauth-jwt-token-gen-enabled" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.liteUserRegister.LiteUserRegisterTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenScopeValidatorTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOForAdminLoginTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuthAppsWithSameClientIdTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-saml-query-profile" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestBase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-default-encryption" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.encryption.EventPublisherPasswordEncryptionTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-saml-query-profile" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestBase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-default-encryption" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.encryption.EventPublisherPasswordEncryptionTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.1.19</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.1.20</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.1.12</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.1.19</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Uncomment the `ApplicationNativeAuthenticationTestCase` test which was commented due to intermittent test failures.