### PR TITLE
Fix IDP count issue due to system reserved idps are hidden

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
@@ -443,7 +443,7 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
         List<IdentityProvider> idpList = idpMgtServiceClient.getPaginatedIdPsInfo(filter, pageNumber);
         Assert.assertNotNull(idpList);
         if (idpList.size() > 0) {
-            Assert.assertEquals(idpList.size(), 3, "filtered identity provider size not matched" +
+            Assert.assertEquals(idpList.size(), 2, "filtered identity provider size not matched" +
                     " with the expected while testing getPaginatedIdPsInfo() with empty filter");
         } else {
             Assert.fail("Unable to find filtered identity provider while testing getPaginatedIdPsInfo(). Paginated " +

--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.1.30</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.1.32</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
### Purpose
- The system reserved idps are hidden from the idp listing calls from the https://github.com/wso2/carbon-identity-framework/pull/5644
- Update the test according to that
- The expected idp count is increased due to default sso idp from https://github.com/wso2/product-is/pull/17372, now that idp is hidden from the listing apis and test is updated.
