### PR TITLE
Bump framework and identity inbound versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.1.44</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.1.45</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2284,7 +2284,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.11.41</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>7.0.58</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.59</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.5</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
This PR bumps dependencies for identity-framework and identity-inbound-oauth