### PR TITLE
Update integration tests for SMS OTP For Password Recovery Feature

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -1074,6 +1074,12 @@
             <filtered>true</filtered>
             <fileMode>644</fileMode>
         </file>
+        <file>
+            <source>src/bin/openssl-tls.sh</source>
+            <outputDirectory>wso2is-${pom.version}/bin/</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
 
         <!-- add carbon.properties with symmetric key cipher -->
         <file>

--- a/modules/distribution/src/bin/openssl-tls.sh
+++ b/modules/distribution/src/bin/openssl-tls.sh
@@ -1,0 +1,328 @@
+#! /bin/sh
+# ----------------------------------------------------------------------------
+#  Copyright 2024 WSO2, LLC. https://www.wso2.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+OPENSSL_VERSION=3.2.1
+LIBOQS_VERSION=0.10.0
+OQS_PROVIDER_VERSION=0.6.0
+TCNATIVE_VERSION=1.3.0
+APR_VERSION=1.7.4
+
+# Parameters
+# $1: The directory where the OpenSSL configuration file should be copied
+# $2: The extension of the library file
+configure_openssl_conf() {
+    echo "Configuring OpenSSL.conf"
+    cd "$1/repository/resources/conf/templates/repository/conf/tomcat" \
+        && wget -O openssl.cnf.j2 https://raw.githubusercontent.com/openssl/openssl/openssl-$OPENSSL_VERSION/apps/openssl.cnf \
+        && echo "[provider_sect]" >> openssl.cnf.j2 \
+        && echo "oqsprovider = oqsprovider_sect" >> openssl.cnf.j2 \
+        && echo "[oqsprovider_sect]" >> openssl.cnf.j2 \
+        && echo "activate = 1" >> openssl.cnf.j2 \
+        && echo "module = $1/lib/oqsprovider.$2" >> openssl.cnf.j2 \
+        && echo "[default_sect]" >> openssl.cnf.j2 \
+        && echo "activate = 1" >> openssl.cnf.j2 \
+        && echo "[openssl_init]" >> openssl.cnf.j2 \
+        && echo "ssl_conf = ssl_sect" >> openssl.cnf.j2 \
+        && echo "[ssl_sect]" >> openssl.cnf.j2 \
+        && echo "system_default = system_default_sect" >> openssl.cnf.j2 \
+        && echo "[system_default_sect]" >> openssl.cnf.j2 \
+        && echo "Groups = {{transport.https.openssl.named_groups}}" >> openssl.cnf.j2
+}
+
+# Parameters
+# $@: The list of dependencies to check
+check_dependencies() {
+    for cmd in "$@"; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            echo "[Error]: $cmd could not be found. Please install it before running this script."
+            exit 1
+        fi
+    done
+}
+
+# Parameters
+# $1: The directory where installation files should be downloaded
+# $2: The directory where OpenSSL should be installed
+install_openssl() {
+    # Download and unpack OpenSSL
+    cd "$1" \
+        && wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz \
+        && tar -xf openssl-$OPENSSL_VERSION.tar.gz
+    echo "Installing OpenSSL"
+    cd "$1/openssl-$OPENSSL_VERSION" \
+        && ./Configure --prefix="$2" --openssldir="$2" \
+        && make \
+        && make install_sw
+}
+
+# Parameters
+# $1: The directory where installation files should be downloaded
+# $2: The directory where OpenSSL is installed
+# $3: The path to the libcrypto library
+install_oqs_provider() {
+    if [ -z "$2" ]; then
+        openssl_root=""
+    else
+        openssl_root="-DOPENSSL_ROOT_DIR=$2"
+    fi
+    if [ -z "$3" ]; then
+        openssl_crypto=""
+    else
+        openssl_crypto="-DOPENSSL_CRYPTO_LIBRARY=$3"
+    fi
+
+    # Download and unpack LibOQS
+    cd "$1" \
+        && wget https://github.com/open-quantum-safe/liboqs/archive/refs/tags/$LIBOQS_VERSION.tar.gz \
+        && tar -xf $LIBOQS_VERSION.tar.gz
+    echo "Installing LibOQS"
+    cd "$1/liboqs-$LIBOQS_VERSION" \
+        && cmake -DCMAKE_INSTALL_PREFIX="$1/liboqs" "$openssl_root" "$openssl_crypto" -S . -B _build \
+        && cmake --build _build \
+        && cmake --install _build
+
+    # Download and unpack OQS Provider
+    cd "$1" \
+        && wget https://github.com/open-quantum-safe/oqs-provider/archive/refs/tags/$OQS_PROVIDER_VERSION.tar.gz \
+        && tar -xf $OQS_PROVIDER_VERSION.tar.gz
+    echo "Install OQS Provider"
+    cd "$1/oqs-provider-${OQS_PROVIDER_VERSION}" \
+        && liboqs_DIR="$1/liboqs" cmake "$openssl_root" "$openssl_crypto" -S . -B _build \
+        && cmake --build _build
+}
+
+# Parameters
+# $1: The directory where installation files should be downloaded
+# $2: The directory where APR should be installed
+install_apr() {
+    # Download APR
+    cd "$1" \
+        && wget https://dlcdn.apache.org//apr/apr-$APR_VERSION.tar.gz \
+        && tar -xf apr-$APR_VERSION.tar.gz
+    echo "Installing APR"
+    cd "$1/apr-$APR_VERSION" \
+        && ./configure --prefix="$2" \
+        && make \
+        && make install
+}
+
+# Parameters
+# $1: The directory where installation files should be downloaded
+# $2: The directory where tcnative should be installed
+# $3: The directory where OpenSSL is installed
+# $4: The directory where APR is installed
+install_tomcat_native() {
+    if [ -z "$4" ]; then
+        apr_config=""
+    else
+        apr_config="--with-apr=$4/bin/apr-1-config"
+    fi
+    if [ -z "$3" ]; then
+        ssl=""
+    else
+        ssl="--with-ssl=$3"
+    fi
+
+    # Download tcnative
+    cd "$1" \
+        && wget https://dlcdn.apache.org/tomcat/tomcat-connectors/native/$TCNATIVE_VERSION/source/tomcat-native-$TCNATIVE_VERSION-src.tar.gz \
+        && tar -xf tomcat-native-$TCNATIVE_VERSION-src.tar.gz
+    echo "Installing tcnative"
+    cd "$1/tomcat-native-$TCNATIVE_VERSION-src/native" \
+        && ./configure "$apr_config" "$ssl" --prefix="$2" \
+        && make \
+        && make install
+
+    echo "Replacing symlinks with binaries"
+    for file in "$2"/lib/libtcnative-1.*; do
+        if [ -L "$file" ]; then
+            target=$(readlink -f "$file")
+            # Create a copy of the original file
+            cp "$target" "$file".copy
+            mv "$file".copy "$file"
+            echo "Copied $target to replace $file"
+        fi
+    done
+}
+
+# =============================== Main Script =====================================================
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Check the OS type
+if [ "$(uname)" = "Darwin" ]; then
+    LIBEXT="dylib"
+else
+    LIBEXT="so"
+fi
+
+# Get standard environment variables
+PRGDIR=$(dirname "$PRG")
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=$(cd "$PRGDIR/.." ; pwd)
+
+# Check if $CARBON_HOME has spaces
+if echo "$CARBON_HOME" | grep -q ' '; then
+    echo "[Error]: Please make sure the absolute path of WSO2 Identity Server does not contain spaces for successful execution of this script."
+    exit 1
+fi
+
+# Check if JAVA_HOME is set
+if [ -z "$JAVA_HOME" ]; then
+    echo "[Error]: JAVA_HOME is not set. Please set it before running this script."
+    exit 1
+fi
+
+BUILD_OPENSSL=false
+BUILD_PQCLIB=false
+
+# Parse command line arguments
+for arg in "$@"; do
+    if [ "$arg" = "--build_openssl" ] || [ "$arg" = "-build_openssl" ] || [ "$arg" = "build_openssl" ]; then
+        BUILD_OPENSSL=true
+        echo "[Mode]: Building OpenSSL"
+    elif [ "$arg" = "--build_pqclib" ] || [ "$arg" = "-build_pqclib" ] || [ "$arg" = "build_pqclib" ]; then
+        BUILD_PQCLIB=true
+        echo "[Mode]: Building OQS Provider"
+    fi
+done
+
+# Check for build dependencies
+check_dependencies make cmake wget tar gcc
+# Check for Perl on RHEL-based systems
+if [ -f "/etc/redhat-release" ]; then
+    check_dependencies perl
+fi
+
+if [ $BUILD_OPENSSL = false ]; then
+    OPENSSL_VERSION=$(openssl version | awk '{print $2}')
+    case "$OPENSSL_VERSION" in
+        3.*)
+            echo "OpenSSL version $OPENSSL_VERSION"
+            ;;
+        *)
+            echo "[Error]: Requires OpenSSL version 3.0.0 or higher. Found version $OPENSSL_VERSION"
+            exit 1
+            ;;
+    esac
+    if [ "$(uname)" != "Darwin" ]; then
+        # Check if libssl-dev is installed
+        if [ -f "/etc/debian_version" ]; then
+            if ! dpkg -s libssl-dev > /dev/null 2>&1; then
+                echo "[Error]: libssl-dev is not installed. Please install it before running this script."
+                exit 1
+            fi
+        else
+            if ! rpm -q openssl-devel > /dev/null 2>&1; then
+                echo "[Error]: openssl-devel is not installed. Please install it before running this script."
+                exit 1
+            fi
+        fi
+        # Check if libapr1-dev is installed
+        if [ -f "/etc/debian_version" ]; then
+            if ! dpkg -s libapr1-dev > /dev/null 2>&1; then
+                echo "[Error]: libapr1-dev is not installed. Please install it before running this script."
+                exit 1
+            fi
+        else
+            if ! rpm -q apr-devel > /dev/null 2>&1; then
+                echo "[Error]: apr-devel is not installed. Please install it before running this script."
+                exit 1
+            fi
+        fi
+    fi
+    check_dependencies apr-1-config
+fi
+
+TMP_DIR="$CARBON_HOME"/openssl-tmp
+if [ -d "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+fi
+mkdir -p "$TMP_DIR"
+
+# =============================== Install OpenSSL ================================================
+
+if [ $BUILD_OPENSSL = true ]; then
+    OPENSSL_INSTALL_DIR="$CARBON_HOME/native/openssl"
+    if [ ! -d "$OPENSSL_INSTALL_DIR" ]; then
+        install_openssl "$TMP_DIR" "$OPENSSL_INSTALL_DIR"
+    else
+        echo "OpenSSL is already installed"
+    fi
+elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "arm64" ]; then
+        # For M1 (ARM) architecture
+        OPENSSL_INSTALL_DIR=$(ls -d '/opt/homebrew/Cellar/openssl@3/'*)
+    else
+        # For Intel (x86_64) architecture
+        OPENSSL_INSTALL_DIR=$(ls -d '/usr/local/Cellar/openssl@3/'*)
+    fi
+fi
+
+# =============================== Install OQS Provider ============================================
+
+if [ $BUILD_PQCLIB = true ]; then
+    if [ -d "$OPENSSL_INSTALL_DIR/lib64" ]; then
+        OPENSSL_LIB_DIR="$OPENSSL_INSTALL_DIR/lib64"
+    else
+        OPENSSL_LIB_DIR="$OPENSSL_INSTALL_DIR/lib"
+    fi
+
+    # Check if OQS Provider is already installed
+    if [ ! -f "$CARBON_HOME/lib/oqsprovider.$LIBEXT" ]; then
+        if [ $BUILD_OPENSSL = true ] || [ "$(uname)" = "Darwin" ]; then
+            install_oqs_provider "$TMP_DIR" "$OPENSSL_INSTALL_DIR" "$OPENSSL_LIB_DIR/libcrypto.$LIBEXT"
+        else
+            install_oqs_provider "$TMP_DIR"
+        fi
+        mv "$TMP_DIR/oqs-provider-$OQS_PROVIDER_VERSION/_build/lib/oqsprovider.$LIBEXT" "$CARBON_HOME/lib"
+    else
+        echo "OQS Provider is already installed"
+    fi
+fi
+
+# =============================== Install APR ====================================================
+
+if [ $BUILD_OPENSSL = true ]; then
+    rm -rf "$CARBON_HOME/native/apr"
+    install_apr "$TMP_DIR" "$CARBON_HOME/native/apr"
+fi
+
+# ============================== Install tcnative ================================================
+
+if [ $BUILD_OPENSSL = true ]; then
+    install_tomcat_native "$TMP_DIR" "$CARBON_HOME" "$OPENSSL_INSTALL_DIR" "$CARBON_HOME/native/apr"
+elif [ ! -e "$CARBON_HOME/lib/libtcnative-1.$LIBEXT" ]; then
+    if [ "$(uname)" = "Darwin" ]; then
+        install_tomcat_native "$TMP_DIR" "$CARBON_HOME" "$OPENSSL_INSTALL_DIR"
+    else
+        install_tomcat_native "$TMP_DIR" "$CARBON_HOME"
+    fi
+else
+    echo "tcnative is already installed"
+fi
+
+# ================================ Configure OpenSSL ==============================================
+
+if [ $BUILD_PQCLIB = true ]; then
+    configure_openssl_conf "$CARBON_HOME" $LIBEXT
+    echo "Post-quantum security mode is installed successfully"
+fi
+
+echo "Cleaning up"
+rm -rf "$TMP_DIR"

--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -48,6 +48,7 @@
 
   "transport.http.enabled" : true,
   "transport.https.enabled" : true,
+  "transport.https.openssl.enabled": false,
 
   "axis2_transport.receiver.http.enabled": true,
   "axis2_transport.receiver.https.enabled": true,

--- a/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -20,8 +20,11 @@
 
 <Server port="8005" shutdown="SHUTDOWN" xmlns:svns="http://org.wso2.securevault/configuration">
 
-    <Service className="org.wso2.carbon.tomcat.ext.service.ExtendedStandardService" name="Catalina">
+    {% if transport.https.openssl.enabled is sameas true %}
+    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    {% endif %}
 
+    <Service className="org.wso2.carbon.tomcat.ext.service.ExtendedStandardService" name="Catalina">
 
        {% for transport in custom_transport %}
         <Connector
@@ -49,7 +52,11 @@
             Added sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2" for poodle vulnerability fix
        -->
        {% if transport.https.enabled is sameas true %}
+       {% if transport.https.openssl.enabled is sameas true %}
+       <Connector protocol="org.apache.coyote.http11.Http11AprProtocol"
+       {% else %}
        <Connector protocol="org.apache.coyote.http11.Http11NioProtocol"
+       {% endif %}
        {% for property_name,property_value in transport.https.properties.items() %}
                   {{property_name}}="{{property_value}}"
                   {% endfor %}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/ChallengeQuestionsUITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/ChallengeQuestionsUITestCase.java
@@ -50,8 +50,10 @@ public class ChallengeQuestionsUITestCase extends OAuth2ServiceAbstractIntegrati
     private static final String RECOVERY_ENDPOINT_QS_CONTENT = "name=\"recoveryOption\" value=\"SECURITY_QUESTIONS\"";
     private static final String RECOVERY_ENDPOINT_NOTIFICATION_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
     private static final String ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY = "Recovery.Question.Password.Enable";
-    private static final String ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY =
-            "Recovery.Notification.Password.Enable";
+    private static final String ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.emailLink.Enable";
+    private static final String ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.smsOtp.Enable";
     private static final String OIDC_APP_NAME = "playground2";
     private IdentityProvider superTenantResidentIDP;
     private ServerConfigurationManager serverConfigurationManager;
@@ -112,7 +114,8 @@ public class ChallengeQuestionsUITestCase extends OAuth2ServiceAbstractIntegrati
     @Test(groups = "wso2.is", description = "Check Password recovery option recovery Page")
     public void testRecovery() throws Exception {
 
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "true");
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
         Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
@@ -495,7 +495,7 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
     public void testGetAllIdPsCount() throws Exception {
 
         int idpCount = idpMgtServiceClient.getAllIdpCount();
-        Assert.assertEquals(idpCount, 3, "Total idp count did not match with the expected.");
+        Assert.assertEquals(idpCount, 2, "Total idp count did not match with the expected.");
     }
 
     @Test(priority = 13, groups = "wso2.is", description = "test getFilteredIdpCount operation with incorrect filter")
@@ -528,7 +528,7 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
 
         String filter = "";
         int idpCount = idpMgtServiceClient.getFilteredIdpCount(filter);
-        if (idpCount != 3) {
+        if (idpCount != 2) {
             Assert.fail("Invalid Idp count found while calling getFilteredIdpCount() with empty filter value ");
         }
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/PreferenceAPIIntegrationUITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/PreferenceAPIIntegrationUITestCase.java
@@ -53,13 +53,16 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
     private static final String ENABLE_SELF_REGISTRATION_PROP_KEY = "SelfRegistration.Enable";
     private static final String ENABLE_USERNAME_RECOVERY_PROP_KEY = "Recovery.Notification.Username.Enable";
     private static final String ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY = "Recovery.Question.Password.Enable";
-    private static final String ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY =
-            "Recovery.Notification.Password.Enable";
+    private static final String ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.emailLink.Enable";
+    private static final String ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.smsOtp.Enable";
     private static final String CALLBACK_URL = "https://localhost/callback";
     private static final String RECOVERY_USERNAME_CONTENT = "id=\"usernameRecoverLink\"";
     private static final String RECOVERY_PASSWORD_CONTENT = "id=\"passwordRecoverLink\"";
     private static final String RECOVERY_ENDPOINT_QS_CONTENT = "name=\"recoveryOption\" value=\"SECURITY_QUESTIONS\"";
-    private static final String RECOVERY_ENDPOINT_NOTIFICATION_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
+    private static final String RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
+    private static final String RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT = "name=\"recoveryOption\" value=\"SMSOTP\"";
     private static final String CREATE_ACCOUNT_CONTENT = "id=\"registerLink\"";
     private static final String RECOVERY_ENDPOINT_URL = "/accountrecoveryendpoint/recoveraccountrouter.do";
 
@@ -123,8 +126,8 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_SELF_REGISTRATION_PROP_KEY, "false");
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_USERNAME_RECOVERY_PROP_KEY, "false");
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "false");
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "false");
-
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "false");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "false");
     }
 
     @Test(groups = "wso2.is", description = "Check Initial Login Page")
@@ -161,9 +164,17 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
     }
 
     @Test(groups = "wso2.is", description = "Check Notification Password recovery Login Page")
-    public void testNotificationPasswordRecovery() throws Exception {
+    public void testNotificationPasswordEmailLinkRecovery() throws Exception {
 
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "true");
+        String content = sendAuthorizeRequest();
+        Assert.assertTrue(content.contains(RECOVERY_PASSWORD_CONTENT));
+    }
+
+    @Test(groups = "wso2.is", description = "Check Notification Password recovery Login Page")
+    public void testNotificationPasswordSMSOTPRecovery() throws Exception {
+
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "true");
         String content = sendAuthorizeRequest();
         Assert.assertTrue(content.contains(RECOVERY_PASSWORD_CONTENT));
     }
@@ -174,16 +185,30 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
         Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
-        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
     }
 
     @Test(groups = "wso2.is", description = "Check Notification recovery option recovery Page")
-    public void testRecoveryNotificationOnly() throws Exception {
+    public void testRecoveryNotificationEmailLinkOnly() throws Exception {
 
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
+        System.out.println(content);
         Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
-        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
+        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+    }
+
+    @Test(groups = "wso2.is", description = "Check Notification recovery option recovery Page")
+    public void testRecoveryNotificationSMSOTPOnly() throws Exception {
+
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "true");
+        String content = sendRecoveryRequest();
+        System.out.println(content);
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
     }
 
     private void updateResidentIDPProperty(IdentityProvider residentIdp, String propertyKey, String value) throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50-response.json
@@ -30,6 +30,28 @@
       ]
     },
     {
+      "id": "bXVsdGlhdHRyaWJ1dGUubG9naW4uaGFuZGxlcg",
+      "name": "multiattribute.login.handler",
+      "category": "Account Management",
+      "friendlyName": "Multi Attribute Login",
+      "order": 0,
+      "subCategory": "DEFAULT",
+      "properties": [
+        {
+          "name": "account.multiattributelogin.handler.enable",
+          "value": "false",
+          "displayName": "Enable Multi Attribute Login",
+          "description": "Enable using multiple attributes as login identifier"
+        },
+        {
+          "name": "account.multiattributelogin.handler.allowedattributes",
+          "value": "http://wso2.org/claims/username",
+          "displayName": "Allowed Attribute Claim List",
+          "description": "Allowed claim list separated by commas"
+        }
+      ]
+    },
+    {
       "id": "YWNjb3VudC5kaXNhYmxlLmhhbmRsZXI",
       "name": "account.disable.handler",
       "category": "Account Management",
@@ -60,15 +82,83 @@
       "subCategory": "DEFAULT",
       "properties": [
         {
-          "name": "Recovery.Notification.Password.Enable",
+          "name": "Recovery.Notification.Password.OTP.SendOTPInEmail",
           "value": "false",
-          "displayName": "Notification based password recovery",
-          "description": ""
+          "displayName": "Send OTP in e-mail",
+          "description": "Enable to send OTP in verification e-mail instead of confirmation code."
+          
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.UseUppercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include uppercase characters in OTP",
+          "description": "Enable to include uppercase characters in SMS and e-mail OTPs."
+          
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.UseLowercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include lowercase characters in OTP",
+          "description": "Enable to include lowercase characters in SMS and e-mail OTPs."
+          
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.UseNumbersInOTP",
+          "value": "true",
+          "displayName": "Include numbers in OTP",
+          "description": "Enable to include numbers in SMS and e-mail OTPs."
+          
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.OTPLength",
+          "value": "6",
+          "displayName": "OTP length",
+          "description": "Length of the OTP for SMS and e-mail verifications. OTP length must be 4-10."
         },
         {
           "name": "Recovery.ReCaptcha.Password.Enable",
           "value": "false",
           "displayName": "Enable reCaptcha for password recovery",
+          "description": ""
+          
+        },
+        {
+          "name": "Recovery.Question.Password.Enable",
+          "value": "false",
+          "displayName": "Security question based password recovery",
+          "description": ""
+          
+        },
+        {
+          "name": "Recovery.Question.Password.MinAnswers",
+          "value": "2",
+          "displayName": "Number of questions required for password recovery",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Question.Answer.Regex",
+          "value": ".*",
+          "displayName": "Security question answer regex",
+          "description": "Security question answer regex"
+        },
+        {
+          "name": "Recovery.Question.Answer.Uniqueness",
+          "value": "false",
+          "displayName": "Enforce security question answer uniqueness",
+          "description": "Enforce security question answer uniqueness"
+          
+        },
+        {
+          "name": "Recovery.Question.Password.ReCaptcha.Enable",
+          "value": "true",
+          "displayName": "Enable reCaptcha for security questions based password recovery",
+          "description": "Prompt reCaptcha for security question based password recovery"
+          
+        },
+        {
+          "name": "Recovery.Question.Password.ReCaptcha.MaxFailedAttempts",
+          "value": "2",
+          "displayName": "Max failed attempts for reCaptcha",
           "description": ""
         },
         {
@@ -76,24 +166,35 @@
           "value": "false",
           "displayName": "Username recovery",
           "description": ""
+          
         },
         {
           "name": "Recovery.ReCaptcha.Username.Enable",
           "value": "false",
           "displayName": "Enable reCaptcha for username recovery",
           "description": ""
+          
         },
         {
           "name": "Recovery.Notification.InternallyManage",
           "value": "true",
           "displayName": "Manage notifications sending internally",
           "description": "Disable if the client application handles notification sending"
+          
         },
         {
           "name": "Recovery.NotifySuccess",
           "value": "false",
           "displayName": "Notify when recovery success",
           "description": ""
+          
+        },
+        {
+          "name": "Recovery.Question.Password.NotifyStart",
+          "value": "false",
+          "displayName": "Notify when security questions based recovery starts",
+          "description": ""
+          
         },
         {
           "name": "Recovery.ExpiryTime",
@@ -108,10 +209,60 @@
           "description": "Expiration time of the SMS OTP code for password recovery"
         },
         {
+          "name": "Recovery.Notification.Password.smsOtp.Regex",
+          "value": "[a-zA-Z0-9]{6}",
+          "displayName": "SMS OTP regex",
+          "description": "Regex for SMS OTP in format [allowed characters]{length}. Supported character ranges are a-z, A-Z, 0-9. Minimum OTP length is 4"
+
+        },
+        {
+          "name": "Recovery.Question.Password.Forced.Enable",
+          "value": "false",
+          "displayName": "Enable forced security questions",
+          "description": "Force users to provide answers to security questions during sign in"
+        },
+        {
+          "name": "Recovery.Question.MinQuestionsToAnswer",
+          "value": "1",
+          "displayName": "Minimum number of forced security questions to be answered",
+          "description": "Force users to provide answers to security questions during sign in if user has answered lesser than this value"
+        },
+        {
           "name": "Recovery.CallbackRegex",
-          "value": ".*",
+          "value": "https:\/\/localhost:9443\/.*",
           "displayName": "Recovery callback URL regex",
           "description": "Recovery callback URL regex"
+        },
+        {
+          "name": "Recovery.AutoLogin.Enable",
+          "value": "false",
+          "displayName": "Enable Auto Login After Password Reset",
+          "description": "User will be logged in automatically after completing the Password Reset wizard"
+          
+        },
+        {
+          "name": "Recovery.Notification.Password.MaxFailedAttempts",
+          "value": "3",
+          "displayName": "Max failed attempts for password recovery",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Notification.Password.MaxResendAttempts",
+          "value": "5",
+          "displayName": "Max resend attempts for password recovery",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Notification.Password.emailLink.Enable",
+          "value": "false",
+          "displayName": "Notification based password recovery via an email",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Notification.Password.smsOtp.Enable",
+          "value": "false",
+          "displayName": "Notification based password recovery using SMS OTP",
+          "description": ""
         }
       ]
     },
@@ -140,6 +291,12 @@
           "value": "false",
           "displayName": "Enable password reset offline",
           "description": "An OTP generated and stored in users claims"
+        },
+        {
+          "name": "Recovery.AdminPasswordReset.ExpiryTime",
+          "value": "1440",
+          "displayName": "Admin forced password reset code expiry time",
+          "description": "Validity time of the admin forced password reset code in minutes"
         }
       ]
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -11,266 +11,266 @@
         <listener class-name="org.wso2.identity.integration.test.listeners.IdentityTestListener"/>
     </listeners>
 
-    <test name="is-tests-initialize" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.IdentityServerTestSuitInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.base.TomcatInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.base.LDAPServerInitializerTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-initialize" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.IdentityServerTestSuitInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.base.TomcatInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.base.LDAPServerInitializerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <!--Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.-->
-    <!--<test name="is-tests-default-configuration-sts" preserve-order="true" parallel="false" group-by-instances="true">-->
-        <!--&lt;!&ndash; Active sts test case needs to run before passive sts test case&ndash;&gt;-->
-        <!--<classes>-->
-            <!--<class name="org.wso2.identity.integration.test.sts.ActiveSTSTestCase"/>-->
-        <!--</classes>-->
-    <!--</test>-->
+<!--    &lt;!&ndash;Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--    &lt;!&ndash;<test name="is-tests-default-configuration-sts" preserve-order="true" parallel="false" group-by-instances="true">&ndash;&gt;-->
+<!--        &lt;!&ndash;&lt;!&ndash; Active sts test case needs to run before passive sts test case&ndash;&gt;&ndash;&gt;-->
+<!--        &lt;!&ndash;<classes>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.sts.ActiveSTSTestCase"/>&ndash;&gt;-->
+<!--        &lt;!&ndash;</classes>&ndash;&gt;-->
+<!--    &lt;!&ndash;</test>&ndash;&gt;-->
 
-    <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2PushedAuthRequestTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ResponseModeTestCase"/>
-            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
-            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OIDCMetadataTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2JWKSEndpointTestCase"/>
-            <!--<class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />
-            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />
-            <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>
-            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
-            <!--<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
-            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>-->
+<!--    <test name="is-tests-default-configuration" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2DeviceFlowTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2PushedAuthRequestTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ResponseModeTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCMetadataTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2JWKSEndpointTestCase"/>-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>&ndash;&gt;-->
 
-            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>
-            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.store.LegacyJDBCUserStoreAddingTestCase"/>
+<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.store.LegacyJDBCUserStoreAddingTestCase"/>-->
 
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.PermissionBasedScopeValidatorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSPWiseSkipLoginConsentTestCase"/>-->
 
-            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServicePasswordGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>
+<!--            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServiceAuthCodeGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.consented.token.OAuth2ServicePasswordGrantJWTAccessTokenWithConsentedTokenColumnTestCase"/>-->
 
-            <!--TODO Remove following open id tests since deprecated-->
-            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />
-            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />
-            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>
-            <!--TODO End of openid tests-->
+<!--            &lt;!&ndash;TODO Remove following open id tests since deprecated&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>-->
+<!--            &lt;!&ndash;TODO End of openid tests&ndash;&gt;-->
 
-            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>
-            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
-            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
-            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>
-            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />
-            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />
+<!--            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLMetadataTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathBasicAuthenticationSSOTest" />-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.ResidentIDPConfigsTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.PreferenceAPIIntegrationUITestCase" />-->
 
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>
-            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCRPInitiatedLogoutTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OIDCCustomScopesLoginTest"/>
-            <!-- <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase"/> -->
-            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />
-            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>
-            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSLOTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSSOTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLSSOConsentTestCase"/>
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.postAuthnHandler.ChallengeQuestionPostAuthnHandlerTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/>
-            <class name="org.wso2.identity.integration.test.functions.library.mgt.FunctionLibraryManagementTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithRevokedAccessToken" />
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationAfterAccountDisablingTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />
-            <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>
-<!--            Temporarily Coomenting out following test case cause, its not running on JDK 11-->
-<!--            Ref : https://github.com/wso2/product-is/issues/14041-->
-<!--            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>-->
-            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>
-            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>
-        </classes>
-    </test>
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCRPInitiatedLogoutTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OIDCCustomScopesLoginTest"/>-->
+<!--            &lt;!&ndash; <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase"/> &ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSLOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLIdPInitiatedSSOTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOConsentTestCase"/>-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.postAuthnHandler.ChallengeQuestionPostAuthnHandlerTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.functions.library.mgt.FunctionLibraryManagementTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithRevokedAccessToken" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationAfterAccountDisablingTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2BackChannelLogoutTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2OPIframeTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.CrossProtocolLogoutTestCase"/>-->
+<!--&lt;!&ndash;            Temporarily Coomenting out following test case cause, its not running on JDK 11&ndash;&gt;-->
+<!--&lt;!&ndash;            Ref : https://github.com/wso2/product-is/issues/14041&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="org.wso2.identity.integration.test.saml.SAMLARTRESOLVETestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.identityServlet.ExtendSessionEndpointAuthCodeGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithSessionTerminationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevocationWithMultipleSessionTerminationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-test-rest-api" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <!--Test cases for user REST APIs-->
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeSuccessTest"/>-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeNegativeTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeSuccessTestBase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeNegativeTestBase"/>
-            <!--Disabling since the workflow is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsNegativeTest"/>
-            <!--TODO: Temporary disabled MeAuthorizedAppsScopeTest. Enable after fixing https://github.com/wso2/product-is/issues/13230. -->
-            <!-- <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsScopeTest"/> -->
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionAdminSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationFailureTest"/>
-            <!--Test cases for server REST APIs-->
-            <!--Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.challenge.v1.ServerChallengeTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesPositiveTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesPositiveTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesNegativeTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationMetadataPositiveTest"/>
-            <!-- Disabling /user/{user-id}/* type of API tests as they will not be exposed in 5.9.0 -->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserSuccessTest"/>-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserNegativeTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.permission.management.v1.PermissionManagementTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>
-            <!--Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>-->
-            <!--Disabling the test until the application templates are restructured.-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderFailureTest"/>
-            <!-- Disabling the SecretManagement api tests as the api is removed from the access control -->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementSuccessTest"/>-->
-            <!--<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementFailureTest"/>-->
-            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>
-        </classes>
-    </test>
+<!--    <test name="is-test-rest-api" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            &lt;!&ndash;Test cases for user REST APIs&ndash;&gt;-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeSuccessTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserMeNegativeTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeSuccessTestBase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.association.v1.UserMeNegativeTestBase"/>-->
+<!--            &lt;!&ndash;Disabling since the workflow is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v1.MeAuthorizedAppsSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsNegativeTest"/>-->
+<!--            &lt;!&ndash;TODO: Temporary disabled MeAuthorizedAppsScopeTest. Enable after fixing https://github.com/wso2/product-is/issues/13230. &ndash;&gt;-->
+<!--            &lt;!&ndash; <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.MeAuthorizedAppsScopeTest"/> &ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.authorized.apps.v2.ApplicationAuthorizedAppsSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionAdminSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.application.v1.UserDiscoverableApplicationFailureTest"/>-->
+<!--            &lt;!&ndash;Test cases for server REST APIs&ndash;&gt;-->
+<!--            &lt;!&ndash;Disabling since the Challenge Question is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.challenge.v1.ServerChallengeTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesPositiveTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v1.EmailTemplatesNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesPositiveTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.email.template.v2.EmailTemplatesNegativeTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationMetadataPositiveTest"/>-->
+<!--            &lt;!&ndash; Disabling /user/{user-id}/* type of API tests as they will not be exposed in 5.9.0 &ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserSuccessTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.user.challenge.v1.UserNegativeTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.permission.management.v1.PermissionManagementTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.keystore.management.v1.KeystoreManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.idp.v1.IdPFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>-->
+<!--            &lt;!&ndash;Disabling since the WS-Trust functionality is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementWSTrustTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;Disabling the test until the application templates are restructured.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementSuccessTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibrarySuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.script.library.v1.ScriptLibraryFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.oidc.scope.management.v1.OIDCScopeManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConfigFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.cors.v1.CORSFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.tenant.management.v1.TenantFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.NotificationSenderFailureTest"/>-->
+<!--            &lt;!&ndash; Disabling the SecretManagement api tests as the api is removed from the access control &ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementSuccessTest"/>&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.rest.api.server.secret.management.v1.SecretManagementFailureTest"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.branding.preference.management.v1.BrandingPreferenceManagementFailureTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.selfRegister.SelfRegisterTenantedTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.admin.advisory.management.v1.AdminAdvisoryManagementSuccessTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.server.organization.management.v1.OrganizationManagementSuccessTest"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-scim2" preserve-order="true" parallel="false">
-        <classes>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2RoleTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2SchemasTest"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaMeTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-scim2" preserve-order="true" parallel="false">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2RoleTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.SCIM2MultiAttributeUserFilterTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIM2SchemasTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaMeTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>
-            <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>
-            <!-- This test has a restart-->
-            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />
-        </classes>
-    </test>
+<!--    <test name="is-test-adaptive-authentication" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.auth.AdaptiveScriptTemporaryClaimPersistenceTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.auth.SecondaryStoreUserLoginTestCase"/>-->
+<!--            &lt;!&ndash; This test has a restart&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-default-configuration-ldap" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.LDAPUserStoreInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-default-configuration-ldap" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.LDAPUserStoreInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-uuid-user-store" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <!-- This initializer test should run before running other tests. This will copy the relevant services that
-                 needs to run the new test cases.-->
-            <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-uuid-user-store" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            &lt;!&ndash; This initializer test should run before running other tests. This will copy the relevant services that-->
+<!--                 needs to run the new test cases.&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <!--
-    ====================================================================================================================
-        IMPORTANT : All the tests below this section, should be the ones that requires additional Identity Server
-        instance.
+<!--    &lt;!&ndash;-->
+<!--    ====================================================================================================================-->
+<!--        IMPORTANT : All the tests below this section, should be the ones that requires additional Identity Server-->
+<!--        instance.-->
 
-        To minimize the number of restarts, at each test, additional instance is started before all the tests in the
-        below tag and stopped at the end.
-    ====================================================================================================================
-    -->
+<!--        To minimize the number of restarts, at each test, additional instance is started before all the tests in the-->
+<!--        below tag and stopped at the end.-->
+<!--    ====================================================================================================================-->
+<!--    &ndash;&gt;-->
 
     <test name="is-tests-federation" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
@@ -280,100 +280,100 @@
             <!--TODO: Temporary disabled ConditionalAuthenticationTestCase. Enable after fixing the issues. -->
             <!--<class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" />-->
             <class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/>
-            <!--Disabling since the workflow is provided as a connector and it does not exist in the product by default.-->
-            <!--<class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.oidc.OIDCIdentityFederationTestCase"/>
-            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCFederatedIdpInitLogoutTest"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenExchangeGrantTypeTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingTestCase" />
-            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingIDPConfigDisabledTestCase" />
+<!--            &lt;!&ndash;Disabling since the workflow is provided as a connector and it does not exist in the product by default.&ndash;&gt;-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCIdentityFederationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCFederatedIdpInitLogoutTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenExchangeGrantTypeTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.FederatedTokenSharingIDPConfigDisabledTestCase" />-->
         </classes>
     </test>
 
-    <!--
-    ====================================================================================================================
-        IMPORTANT : All the tests below this section, should be the ones that requires configuration changes and
-        restarts.
+<!--    &lt;!&ndash;-->
+<!--    ====================================================================================================================-->
+<!--        IMPORTANT : All the tests below this section, should be the ones that requires configuration changes and-->
+<!--        restarts.-->
 
-        To minimize the number of restarts, at each test, do the configuration update and restart. Then do the test
-        and finally restore the configuration without restarting. The next test will perform the restart with the
-        configuration changes required for it.
+<!--        To minimize the number of restarts, at each test, do the configuration update and restart. Then do the test-->
+<!--        and finally restore the configuration without restarting. The next test will perform the restart with the-->
+<!--        configuration changes required for it.-->
 
-        If multiple tests can be run with one configuration change, group them into a test group and do the above at
-        @BeforeTest, and @AfterTest. See 'is-tests-jdbc-userstore' for example.
-    ====================================================================================================================
-    -->
+<!--        If multiple tests can be run with one configuration change, group them into a test group and do the above at-->
+<!--        @BeforeTest, and @AfterTest. See 'is-tests-jdbc-userstore' for example.-->
+<!--    ====================================================================================================================-->
+<!--    &ndash;&gt;-->
 
-    <test name="is-tests-federation-restart" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.JDBCUserStoreInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-read-only-userstore" preserve-order="true" parallel="false" group-by-instances="true" >
-        <classes>
-            <class name="org.wso2.identity.integration.test.base.ReadOnlyUserStoreInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateReadOnlyTest"/>
-            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-oauth-jwt-token-gen-enabled" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>
-            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
-            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>
-            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>
-            <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>
-            <!--<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>-->
-            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>
-            <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>
-            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>
-            <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.user.liteUserRegister.LiteUserRegisterTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenScopeValidatorTestCase" />
-            <class name="org.wso2.identity.integration.test.saml.SAMLSSOForAdminLoginTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuthAppsWithSameClientIdTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-federation-restart" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.JDBCUserStoreInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-read-only-userstore" preserve-order="true" parallel="false" group-by-instances="true" >-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.base.ReadOnlyUserStoreInitializerTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim2.rest.api.SCIMUserUpdateReadOnlyTest"/>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-oauth-jwt-token-gen-enabled" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-email-username" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>-->
+<!--            &lt;!&ndash;<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.rest.api.user.liteUserRegister.LiteUserRegisterTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenScopeValidatorTestCase" />-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLSSOForAdminLoginTestCase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.oauth2.OAuthAppsWithSameClientIdTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 
-    <test name="is-tests-saml-query-profile" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestBase"/>
-            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>
-        </classes>
-    </test>
-    <test name="is-tests-default-encryption" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.encryption.EventPublisherPasswordEncryptionTestCase"/>
-        </classes>
-    </test>
+<!--    <test name="is-tests-saml-query-profile" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestBase"/>-->
+<!--            <class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
+<!--    <test name="is-tests-default-encryption" preserve-order="true" parallel="false" group-by-instances="true">-->
+<!--        <classes>-->
+<!--            <class name="org.wso2.identity.integration.test.encryption.EventPublisherPasswordEncryptionTestCase"/>-->
+<!--        </classes>-->
+<!--    </test>-->
 </suite>

--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.10.13" useFeatures="true" includeLaunchers="true">
+version="4.10.14" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.10.13" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.10.13"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.10.14"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.1.51</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.2.10</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2273,22 +2273,22 @@
         <carbon.consent.mgt.version>2.6.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.9.11</identity.governance.version>
+        <identity.governance.version>1.9.12</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.9.4</identity.carbon.auth.saml2.version>
         <identity.carbon.auth.mutual.ssl.version>5.5.0</identity.carbon.auth.mutual.ssl.version>
         <identity.carbon.auth.iwa.version>5.5.0</identity.carbon.auth.iwa.version>
-        <identity.carbon.auth.rest.version>1.9.5</identity.carbon.auth.rest.version>
+        <identity.carbon.auth.rest.version>1.9.6</identity.carbon.auth.rest.version>
 
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.saml.version>5.11.41</identity.inbound.auth.saml.version>
-        <identity.inbound.auth.oauth.version>7.0.61</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.69</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.5</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.80</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.82</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.8</identity.user.account.association.version>
@@ -2303,8 +2303,8 @@
         <identity.data.publisher.audit.version>1.4.4</identity.data.publisher.audit.version>
 
         <!-- Identity Event Handler Versions -->
-        <identity.event.handler.account.lock.version>1.9.3</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.8.15</identity.event.handler.notification.version>
+        <identity.event.handler.account.lock.version>1.9.4</identity.event.handler.account.lock.version>
+        <identity.event.handler.notification.version>1.8.17</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->
@@ -2312,7 +2312,7 @@
         <!--<identity.agent-entitlement-filter.version>5.1.1</identity.agent-entitlement-filter.version>-->
 
         <!-- Authenticator Versions -->
-        <identity.outbound.auth.oidc.version>5.12.8</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.10</identity.outbound.auth.oidc.version>
         <identity.outbound.auth.oauth2.version>1.0.12</identity.outbound.auth.oauth2.version>
         <identity.outbound.auth.passive.sts.version>5.5.1</identity.outbound.auth.passive.sts.version>
         <identity.outbound.auth.samlsso.version>5.9.3</identity.outbound.auth.samlsso.version>
@@ -2320,7 +2320,7 @@
         <identity.outbound.auth.requestpath.oauth.version>5.5.6</identity.outbound.auth.requestpath.oauth.version>
 
         <!-- Social Authenticator Versions -->
-        <social.authenticator.facebook.version>5.2.12</social.authenticator.facebook.version>
+        <social.authenticator.facebook.version>5.2.14</social.authenticator.facebook.version>
         <social.authenticator.google.version>5.2.15</social.authenticator.google.version>
         <social.authenticator.windowslive.version>5.2.3</social.authenticator.windowslive.version>
         <social.authenticator.apple.version>1.0.5</social.authenticator.apple.version>
@@ -2333,8 +2333,8 @@
         <provisioning.connector.scim2.version>2.0.6</provisioning.connector.scim2.version>
 
         <!-- Local Authenticator Versions -->
-        <identity.local.auth.basicauth.version>6.8.4</identity.local.auth.basicauth.version>
-        <identity.local.auth.fido.version>5.4.12</identity.local.auth.fido.version>
+        <identity.local.auth.basicauth.version>6.8.5</identity.local.auth.basicauth.version>
+        <identity.local.auth.fido.version>5.4.13</identity.local.auth.fido.version>
         <identity.local.auth.iwa.version>5.4.4</identity.local.auth.iwa.version>
 
         <!-- Local Authentication API Connector Version -->
@@ -2349,21 +2349,21 @@
 
         <!-- Connector Versions -->
         <authenticator.totp.version>3.3.27</authenticator.totp.version>
-        <authenticator.backupcode.version>0.0.19</authenticator.backupcode.version>
+        <authenticator.backupcode.version>0.0.20</authenticator.backupcode.version>
         <authenticator.office365.version>2.1.3</authenticator.office365.version>
-        <authenticator.smsotp.version>3.3.23</authenticator.smsotp.version>
+        <authenticator.smsotp.version>3.3.24</authenticator.smsotp.version>
         <authenticator.magiclink.version>1.1.25</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.1.26</authenticator.emailotp.version>
-        <authenticator.local.auth.emailotp.version>1.0.21</authenticator.local.auth.emailotp.version>
+        <authenticator.local.auth.emailotp.version>1.0.23</authenticator.local.auth.emailotp.version>
         <authenticator.local.auth.smsotp.version>1.0.8</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.1.2</authenticator.twitter.version>
         <authenticator.x509.version>3.1.17</authenticator.x509.version>
         <identity.extension.utils>1.0.18</identity.extension.utils>
         <authenticator.auth.otp.commons.version>1.0.6</authenticator.auth.otp.commons.version>
 
-        <identity.org.mgt.version>1.4.17</identity.org.mgt.version>
-        <identity.org.mgt.core.version>1.1.6</identity.org.mgt.core.version>
-        <identity.organization.login.version>1.1.32</identity.organization.login.version>
+        <identity.org.mgt.version>1.4.26</identity.org.mgt.version>
+        <identity.org.mgt.core.version>1.1.7</identity.org.mgt.core.version>
+        <identity.organization.login.version>1.1.33</identity.organization.login.version>
         <identity.oauth2.grant.organizationswitch.version>1.1.22</identity.oauth2.grant.organizationswitch.version>
 
         <!-- Hash Provider Versions-->
@@ -2375,26 +2375,26 @@
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.37</identity.user.api.version>
-        <identity.server.api.version>1.2.187</identity.server.api.version>
+        <identity.server.api.version>1.2.189</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.8</identity.tool.samlsso.validator.version>
         <identity.app.authz.xacml.version>2.3.2</identity.app.authz.xacml.version>
         <identity.oauth.addons.version>2.5.8</identity.oauth.addons.version>
         <org.wso2.carbon.extension.identity.x509certificate.version>1.1.10</org.wso2.carbon.extension.identity.x509certificate.version>
-        <conditional.authentication.functions.version>1.2.46</conditional.authentication.functions.version>
+        <conditional.authentication.functions.version>1.2.47</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.16.4</identity.apps.console.version>
-        <identity.apps.myaccount.version>2.5.64</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.1.69</identity.apps.core.version>
+        <identity.apps.console.version>2.18.5</identity.apps.console.version>
+        <identity.apps.myaccount.version>2.5.91</identity.apps.myaccount.version>
+        <identity.apps.core.version>2.2.0</identity.apps.core.version>
         <identity.apps.tests.version>1.6.378</identity.apps.tests.version>
 
         <!-- Charon -->
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.10.13</carbon.kernel.version>
+        <carbon.kernel.version>4.10.14</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.0.7</identity.verification.version>
@@ -2403,7 +2403,7 @@
         <carbon.deployment.version>4.12.25</carbon.deployment.version>
         <carbon.commons.version>4.10.9</carbon.commons.version>
         <carbon.registry.version>4.8.24</carbon.registry.version>
-        <carbon.multitenancy.version>4.11.19</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.11.22</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.analytics-common.version>5.2.58</carbon.analytics-common.version>
         <carbon.dashboards.version>2.0.27</carbon.dashboards.version>


### PR DESCRIPTION
## Purpose 
The SMS OTP For Password Recovery Feature replaces the existing governance config `Recovery.Notification.Password.Enable config` with `Recovery.Notification.Password.emailLink.Enable` and `Recovery.Notification.Password.smsOtp.Enable`.  This change causes integration test failures since some of the integration tests depends on this former governance config. This PR removes this dependency and introduces the newly added configs. 

## Local Run (100%)
##### Note : The failed test case in the initial run is rerun and succeeds in the second run. 

https://github.com/wso2/product-is/assets/42939752/42d87317-24cf-4094-8175-5cd538faf20c

## Related Issue 
https://github.com/wso2-enterprise/iam-engineering/issues/534

## Related PRs 
https://github.com/wso2-extensions/identity-governance/pull/814
https://github.com/wso2/carbon-identity-framework/pull/5601