### PR TITLE
Remove Recovery.Notification.Password.Enable config and use sms otp a…

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/ChallengeQuestionsUITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/ChallengeQuestionsUITestCase.java
@@ -50,8 +50,10 @@ public class ChallengeQuestionsUITestCase extends OAuth2ServiceAbstractIntegrati
     private static final String RECOVERY_ENDPOINT_QS_CONTENT = "name=\"recoveryOption\" value=\"SECURITY_QUESTIONS\"";
     private static final String RECOVERY_ENDPOINT_NOTIFICATION_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
     private static final String ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY = "Recovery.Question.Password.Enable";
-    private static final String ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY =
-            "Recovery.Notification.Password.Enable";
+    private static final String ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.emailLink.Enable";
+    private static final String ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.smsOtp.Enable";
     private static final String OIDC_APP_NAME = "playground2";
     private IdentityProvider superTenantResidentIDP;
     private ServerConfigurationManager serverConfigurationManager;
@@ -112,7 +114,8 @@ public class ChallengeQuestionsUITestCase extends OAuth2ServiceAbstractIntegrati
     @Test(groups = "wso2.is", description = "Check Password recovery option recovery Page")
     public void testRecovery() throws Exception {
 
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "true");
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
         Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/PreferenceAPIIntegrationUITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/PreferenceAPIIntegrationUITestCase.java
@@ -53,13 +53,16 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
     private static final String ENABLE_SELF_REGISTRATION_PROP_KEY = "SelfRegistration.Enable";
     private static final String ENABLE_USERNAME_RECOVERY_PROP_KEY = "Recovery.Notification.Username.Enable";
     private static final String ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY = "Recovery.Question.Password.Enable";
-    private static final String ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY =
-            "Recovery.Notification.Password.Enable";
+    private static final String ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.emailLink.Enable";
+    private static final String ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.smsOtp.Enable";
     private static final String CALLBACK_URL = "https://localhost/callback";
     private static final String RECOVERY_USERNAME_CONTENT = "id=\"usernameRecoverLink\"";
     private static final String RECOVERY_PASSWORD_CONTENT = "id=\"passwordRecoverLink\"";
     private static final String RECOVERY_ENDPOINT_QS_CONTENT = "name=\"recoveryOption\" value=\"SECURITY_QUESTIONS\"";
-    private static final String RECOVERY_ENDPOINT_NOTIFICATION_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
+    private static final String RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
+    private static final String RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT = "name=\"recoveryOption\" value=\"SMSOTP\"";
     private static final String CREATE_ACCOUNT_CONTENT = "id=\"registerLink\"";
     private static final String RECOVERY_ENDPOINT_URL = "/accountrecoveryendpoint/recoveraccountrouter.do";
 
@@ -123,8 +126,8 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_SELF_REGISTRATION_PROP_KEY, "false");
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_USERNAME_RECOVERY_PROP_KEY, "false");
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "false");
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "false");
-
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "false");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "false");
     }
 
     @Test(groups = "wso2.is", description = "Check Initial Login Page")
@@ -161,9 +164,17 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
     }
 
     @Test(groups = "wso2.is", description = "Check Notification Password recovery Login Page")
-    public void testNotificationPasswordRecovery() throws Exception {
+    public void testNotificationPasswordEmailLinkRecovery() throws Exception {
 
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "true");
+        String content = sendAuthorizeRequest();
+        Assert.assertTrue(content.contains(RECOVERY_PASSWORD_CONTENT));
+    }
+
+    @Test(groups = "wso2.is", description = "Check Notification Password recovery Login Page")
+    public void testNotificationPasswordSMSOTPRecovery() throws Exception {
+
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "true");
         String content = sendAuthorizeRequest();
         Assert.assertTrue(content.contains(RECOVERY_PASSWORD_CONTENT));
     }
@@ -174,16 +185,30 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
         Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
-        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
     }
 
     @Test(groups = "wso2.is", description = "Check Notification recovery option recovery Page")
-    public void testRecoveryNotificationOnly() throws Exception {
+    public void testRecoveryNotificationEmailLinkOnly() throws Exception {
 
-        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true");
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
+        System.out.println(content);
         Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
-        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
+        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+    }
+
+    @Test(groups = "wso2.is", description = "Check Notification recovery option recovery Page")
+    public void testRecoveryNotificationSMSOTPOnly() throws Exception {
+
+        updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "true");
+        String content = sendRecoveryRequest();
+        System.out.println(content);
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
     }
 
     private void updateResidentIDPProperty(IdentityProvider residentIdp, String propertyKey, String value) throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50-response.json
@@ -30,6 +30,28 @@
       ]
     },
     {
+      "id": "bXVsdGlhdHRyaWJ1dGUubG9naW4uaGFuZGxlcg",
+      "name": "multiattribute.login.handler",
+      "category": "Account Management",
+      "friendlyName": "Multi Attribute Login",
+      "order": 0,
+      "subCategory": "DEFAULT",
+      "properties": [
+        {
+          "name": "account.multiattributelogin.handler.enable",
+          "value": "false",
+          "displayName": "Enable Multi Attribute Login",
+          "description": "Enable using multiple attributes as login identifier"
+        },
+        {
+          "name": "account.multiattributelogin.handler.allowedattributes",
+          "value": "http://wso2.org/claims/username",
+          "displayName": "Allowed Attribute Claim List",
+          "description": "Allowed claim list separated by commas"
+        }
+      ]
+    },
+    {
       "id": "YWNjb3VudC5kaXNhYmxlLmhhbmRsZXI",
       "name": "account.disable.handler",
       "category": "Account Management",
@@ -60,15 +82,83 @@
       "subCategory": "DEFAULT",
       "properties": [
         {
-          "name": "Recovery.Notification.Password.Enable",
+          "name": "Recovery.Notification.Password.OTP.SendOTPInEmail",
           "value": "false",
-          "displayName": "Notification based password recovery",
-          "description": ""
+          "displayName": "Send OTP in e-mail",
+          "description": "Enable to send OTP in verification e-mail instead of confirmation code."
+
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.UseUppercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include uppercase characters in OTP",
+          "description": "Enable to include uppercase characters in SMS and e-mail OTPs."
+
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.UseLowercaseCharactersInOTP",
+          "value": "true",
+          "displayName": "Include lowercase characters in OTP",
+          "description": "Enable to include lowercase characters in SMS and e-mail OTPs."
+
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.UseNumbersInOTP",
+          "value": "true",
+          "displayName": "Include numbers in OTP",
+          "description": "Enable to include numbers in SMS and e-mail OTPs."
+
+        },
+        {
+          "name": "Recovery.Notification.Password.OTP.OTPLength",
+          "value": "6",
+          "displayName": "OTP length",
+          "description": "Length of the OTP for SMS and e-mail verifications. OTP length must be 4-10."
         },
         {
           "name": "Recovery.ReCaptcha.Password.Enable",
           "value": "false",
           "displayName": "Enable reCaptcha for password recovery",
+          "description": ""
+
+        },
+        {
+          "name": "Recovery.Question.Password.Enable",
+          "value": "false",
+          "displayName": "Security question based password recovery",
+          "description": ""
+
+        },
+        {
+          "name": "Recovery.Question.Password.MinAnswers",
+          "value": "2",
+          "displayName": "Number of questions required for password recovery",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Question.Answer.Regex",
+          "value": ".*",
+          "displayName": "Security question answer regex",
+          "description": "Security question answer regex"
+        },
+        {
+          "name": "Recovery.Question.Answer.Uniqueness",
+          "value": "false",
+          "displayName": "Enforce security question answer uniqueness",
+          "description": "Enforce security question answer uniqueness"
+
+        },
+        {
+          "name": "Recovery.Question.Password.ReCaptcha.Enable",
+          "value": "true",
+          "displayName": "Enable reCaptcha for security questions based password recovery",
+          "description": "Prompt reCaptcha for security question based password recovery"
+
+        },
+        {
+          "name": "Recovery.Question.Password.ReCaptcha.MaxFailedAttempts",
+          "value": "2",
+          "displayName": "Max failed attempts for reCaptcha",
           "description": ""
         },
         {
@@ -76,24 +166,35 @@
           "value": "false",
           "displayName": "Username recovery",
           "description": ""
+
         },
         {
           "name": "Recovery.ReCaptcha.Username.Enable",
           "value": "false",
           "displayName": "Enable reCaptcha for username recovery",
           "description": ""
+
         },
         {
           "name": "Recovery.Notification.InternallyManage",
           "value": "true",
           "displayName": "Manage notifications sending internally",
           "description": "Disable if the client application handles notification sending"
+
         },
         {
           "name": "Recovery.NotifySuccess",
           "value": "false",
           "displayName": "Notify when recovery success",
           "description": ""
+
+        },
+        {
+          "name": "Recovery.Question.Password.NotifyStart",
+          "value": "false",
+          "displayName": "Notify when security questions based recovery starts",
+          "description": ""
+
         },
         {
           "name": "Recovery.ExpiryTime",
@@ -108,10 +209,60 @@
           "description": "Expiration time of the SMS OTP code for password recovery"
         },
         {
+          "name": "Recovery.Notification.Password.smsOtp.Regex",
+          "value": "[a-zA-Z0-9]{6}",
+          "displayName": "SMS OTP regex",
+          "description": "Regex for SMS OTP in format [allowed characters]{length}. Supported character ranges are a-z, A-Z, 0-9. Minimum OTP length is 4"
+
+        },
+        {
+          "name": "Recovery.Question.Password.Forced.Enable",
+          "value": "false",
+          "displayName": "Enable forced security questions",
+          "description": "Force users to provide answers to security questions during sign in"
+        },
+        {
+          "name": "Recovery.Question.MinQuestionsToAnswer",
+          "value": "1",
+          "displayName": "Minimum number of forced security questions to be answered",
+          "description": "Force users to provide answers to security questions during sign in if user has answered lesser than this value"
+        },
+        {
           "name": "Recovery.CallbackRegex",
-          "value": ".*",
+          "value": "https:\/\/localhost:9443\/.*",
           "displayName": "Recovery callback URL regex",
           "description": "Recovery callback URL regex"
+        },
+        {
+          "name": "Recovery.AutoLogin.Enable",
+          "value": "false",
+          "displayName": "Enable Auto Login After Password Reset",
+          "description": "User will be logged in automatically after completing the Password Reset wizard"
+
+        },
+        {
+          "name": "Recovery.Notification.Password.MaxFailedAttempts",
+          "value": "3",
+          "displayName": "Max failed attempts for password recovery",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Notification.Password.MaxResendAttempts",
+          "value": "5",
+          "displayName": "Max resend attempts for password recovery",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Notification.Password.emailLink.Enable",
+          "value": "false",
+          "displayName": "Notification based password recovery via an email",
+          "description": ""
+        },
+        {
+          "name": "Recovery.Notification.Password.smsOtp.Enable",
+          "value": "false",
+          "displayName": "Notification based password recovery using SMS OTP",
+          "description": ""
         }
       ]
     },
@@ -140,6 +291,12 @@
           "value": "false",
           "displayName": "Enable password reset offline",
           "description": "An OTP generated and stored in users claims"
+        },
+        {
+          "name": "Recovery.AdminPasswordReset.ExpiryTime",
+          "value": "1440",
+          "displayName": "Admin forced password reset code expiry time",
+          "description": "Validity time of the admin forced password reset code in minutes"
         }
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.2.9</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.2.10</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2273,7 +2273,7 @@
         <carbon.consent.mgt.version>2.6.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.9.11</identity.governance.version>
+        <identity.governance.version>1.9.12</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.9.4</identity.carbon.auth.saml2.version>
@@ -2375,7 +2375,7 @@
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.37</identity.user.api.version>
-        <identity.server.api.version>1.2.188</identity.server.api.version>
+        <identity.server.api.version>1.2.189</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.8</identity.tool.samlsso.validator.version>
@@ -2385,9 +2385,9 @@
         <conditional.authentication.functions.version>1.2.47</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.18.4</identity.apps.console.version>
+        <identity.apps.console.version>2.18.5</identity.apps.console.version>
         <identity.apps.myaccount.version>2.5.91</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.1.77</identity.apps.core.version>
+        <identity.apps.core.version>2.2.0</identity.apps.core.version>
         <identity.apps.tests.version>1.6.378</identity.apps.tests.version>
 
         <!-- Charon -->


### PR DESCRIPTION
## Purpose 
The SMS OTP For Password Recovery Feature replaces the existing governance config `Recovery.Notification.Password.Enable config` with `Recovery.Notification.Password.emailLink.Enable` and `Recovery.Notification.Password.smsOtp.Enable`.  This change causes integration test failures since some of the integration tests depends on this former governance config. This PR removes this dependency and introduces the newly added configs. 

## Local Run (100%)
##### Note : The failed test case in the initial run is rerun and succeeds in the second run. 

https://github.com/wso2/product-is/assets/42939752/42d87317-24cf-4094-8175-5cd538faf20c

## Related Issue 
https://github.com/wso2-enterprise/iam-engineering/issues/534

## Related PRs 
https://github.com/wso2-extensions/identity-governance/pull/814
https://github.com/wso2/carbon-identity-framework/pull/5601