### PR TITLE
Bump PII Masked Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2273,7 +2273,7 @@
         <carbon.consent.mgt.version>2.6.2</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.9.15</identity.governance.version>
+        <identity.governance.version>1.9.16</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.9.4</identity.carbon.auth.saml2.version>
@@ -2303,7 +2303,7 @@
         <identity.data.publisher.audit.version>1.4.4</identity.data.publisher.audit.version>
 
         <!-- Identity Event Handler Versions -->
-        <identity.event.handler.account.lock.version>1.9.6</identity.event.handler.account.lock.version>
+        <identity.event.handler.account.lock.version>1.9.7</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.8.18</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
@@ -2359,7 +2359,7 @@
         <authenticator.twitter.version>1.1.2</authenticator.twitter.version>
         <authenticator.x509.version>3.1.17</authenticator.x509.version>
         <identity.extension.utils>1.0.18</identity.extension.utils>
-        <authenticator.auth.otp.commons.version>1.0.6</authenticator.auth.otp.commons.version>
+        <authenticator.auth.otp.commons.version>1.0.7</authenticator.auth.otp.commons.version>
 
         <identity.org.mgt.version>1.4.34</identity.org.mgt.version>
         <identity.org.mgt.core.version>1.1.8</identity.org.mgt.core.version>


### PR DESCRIPTION
### Purpose
- Bump versions of following components.
    - `org.wso2.carbon.identity.auth.otp.core`
    - `org.wso2.carbon.identity.recovery`
    - `org.wso2.carbon.identity.handler.event.account.lock`

### Related PRs
- https://github.com/wso2-extensions/identity-auth-otp-commons/pull/10
- https://github.com/wso2-extensions/identity-governance/pull/821
- https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/137 