### PR TITLE
Swap policy removal steps from pdp and pap

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2XACMLScopeValidatorTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2XACMLScopeValidatorTestCase.java
@@ -143,9 +143,9 @@ public class OAuth2XACMLScopeValidatorTestCase extends OAuth2ServiceAbstractInte
         serverConfigurationManager.restoreToLastConfiguration(false);
         consumerKey = null;
         consumerSecret = null;
-        entitlementPolicyClient.removePolicy(VALIDATE_SCOPE_BASED_POLICY_ID);
         entitlementPolicyClient.publishPolicies(new String[]{VALIDATE_SCOPE_BASED_POLICY_ID}, new String[]{"PDP " +
                 "Subscriber"}, "DELETE", true, null, 1);
+        entitlementPolicyClient.removePolicy(VALIDATE_SCOPE_BASED_POLICY_ID);
     }
 
     @Test(groups = "wso2.is", description = "Check Oauth2 application registration.")


### PR DESCRIPTION
With the changes to be introduced for the xacml registry removal effort, we will no longer be allowing a policy already published in the PDP to be deleted from the PAP. To cater to this, we will have to swap the policy removal order in the test case `OAuth2XACMLScopeValidatorTestCase`.

### Related issues
- https://github.com/wso2/product-is/issues/20000

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5686