### PR TITLE
Move TenantContextRewriteValve after the custom valves

### DIFF
--- a/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -131,7 +131,6 @@
                 <Valve className="org.wso2.carbon.identity.cors.valve.CORSValve"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.SameSiteCookieValve"/>
                 <Valve className="org.wso2.carbon.identity.context.rewrite.valve.OrganizationContextRewriteValve"/>
-                <Valve className="org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve"/>
                 <!--Error pages -->
                 <Valve className="org.apache.catalina.valves.ErrorReportValve" showServerInfo="false" showReport="false"/>
                 {% for valve in catalina.valves %}
@@ -141,6 +140,7 @@
                     {% endfor %}
                  />
                 {% endfor %}
+                <Valve className="org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve"/>
             </Host>
         </Engine>
     </Service>


### PR DESCRIPTION
## Purpose

Addresses https://github.com/wso2/product-is/issues/20589.

The TenantContextRewriteValve does not call the next valves in most flows, which prevents custom valves from being called. By moving the TenantContextRewriteValve to the end of the chain, the custom valves can be executed as well.