### PR TITLE
Modify integration tests for trusted app configurations

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationPatchTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationPatchTest.java
@@ -18,6 +18,7 @@ package org.wso2.identity.integration.test.rest.api.server.application.managemen
 import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -25,6 +26,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.assertNotBlank;
 import static org.wso2.identity.integration.test.rest.api.server.application.management.v1.Utils.extractApplicationIdFromLocationHeader;
 
@@ -118,7 +120,8 @@ public class ApplicationPatchTest extends ApplicationManagementBaseTest {
                 .body("advancedConfigurations.find{ it.key == 'skipLoginConsent' }.value", equalTo(false))
                 .body("advancedConfigurations.find{ it.key == 'skipLogoutConsent' }.value", equalTo(false))
                 .body("advancedConfigurations.find{ it.key == 'returnAuthenticatedIdpList' }.value", equalTo(false))
-                .body("advancedConfigurations.find{ it.key == 'enableAuthorization' }.value", equalTo(false));
+                .body("advancedConfigurations.find{ it.key == 'enableAuthorization' }.value", equalTo(false))
+                .body("advancedConfigurations.trustedAppConfiguration", nullValue());
 
         // Do the PATCH update request.
         String patchRequest = readResource("patch-application-advanced-configuration.json");
@@ -134,7 +137,17 @@ public class ApplicationPatchTest extends ApplicationManagementBaseTest {
                 .body("advancedConfigurations.find{ it.key == 'skipLoginConsent' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'skipLogoutConsent' }.value", equalTo(true))
                 .body("advancedConfigurations.find{ it.key == 'returnAuthenticatedIdpList' }.value", equalTo(true))
-                .body("advancedConfigurations.find{ it.key == 'enableAuthorization' }.value", equalTo(true));
+                .body("advancedConfigurations.find{ it.key == 'enableAuthorization' }.value", equalTo(true))
+                .body("advancedConfigurations.trustedAppConfiguration.find{ it.key == 'isFIDOTrustedApp' }.value",
+                        equalTo(true))
+                .body("advancedConfigurations.trustedAppConfiguration.find{ it.key == 'isConsentGranted' }.value",
+                        equalTo(true))
+                .body("advancedConfigurations.trustedAppConfiguration.find{ it.key == 'androidPackageName' }.value",
+                        equalTo("sample.package.name"))
+                .body("advancedConfigurations.trustedAppConfiguration.find{ it.key == 'androidThumbprints' }.value",
+                        Matchers.hasItem("sampleThumbprint"))
+                .body("advancedConfigurations.trustedAppConfiguration.find{ it.key == 'appleAppId' }.value",
+                        equalTo("sample.app.id"));
     }
 
     @Test(description = "Test updating the claim configuration of an application",

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/AdvancedApplicationConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/AdvancedApplicationConfiguration.java
@@ -41,6 +41,7 @@ public class AdvancedApplicationConfiguration  {
     private List<AdditionalSpProperties> additionalSpProperties;
     private Boolean enableAPIBasedAuthentication;
     private AdvancedApplicationConfigurationAttestationMetaData attestationMetaData;
+    private TrustedAppConfiguration trustedAppConfiguration;
 
     private Boolean useExternalConsentPage;
 
@@ -228,6 +229,24 @@ public class AdvancedApplicationConfiguration  {
     }
 
     /**
+    **/
+    public AdvancedApplicationConfiguration trustedAppConfiguration(TrustedAppConfiguration trustedAppConfiguration) {
+
+        this.trustedAppConfiguration = trustedAppConfiguration;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("trustedAppConfiguration")
+    @Valid
+    public TrustedAppConfiguration getTrustedAppConfiguration() {
+        return trustedAppConfiguration;
+    }
+    public void setTrustedAppConfiguration(TrustedAppConfiguration trustedAppConfiguration) {
+        this.trustedAppConfiguration = trustedAppConfiguration;
+    }
+
+    /**
      **/
     public AdvancedApplicationConfiguration additionalSpProperties(List<AdditionalSpProperties> additionalSpProperties) {
 
@@ -285,12 +304,13 @@ public class AdvancedApplicationConfiguration  {
                 Objects.equals(this.additionalSpProperties, advancedApplicationConfiguration.additionalSpProperties) &&
                 Objects.equals(this.enableAPIBasedAuthentication, advancedApplicationConfiguration.enableAPIBasedAuthentication) &&
                 Objects.equals(this.attestationMetaData, advancedApplicationConfiguration.attestationMetaData) &&
+                Objects.equals(this.trustedAppConfiguration, advancedApplicationConfiguration.trustedAppConfiguration) &&
                 Objects.equals(this.useExternalConsentPage, advancedApplicationConfiguration.useExternalConsentPage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization, fragment, enableAPIBasedAuthentication, attestationMetaData, additionalSpProperties, useExternalConsentPage);
+        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization, fragment, enableAPIBasedAuthentication, attestationMetaData, trustedAppConfiguration, additionalSpProperties, useExternalConsentPage);
     }
 
     @Override
@@ -309,6 +329,7 @@ public class AdvancedApplicationConfiguration  {
         sb.append("    fragment: ").append(toIndentedString(fragment)).append("\n");
         sb.append("    enableAPIBasedAuthentication: ").append(toIndentedString(enableAPIBasedAuthentication)).append("\n");
         sb.append("    attestationMetaData: ").append(toIndentedString(attestationMetaData)).append("\n");
+        sb.append("    trustedAppConfiguration: ").append(toIndentedString(trustedAppConfiguration)).append("\n");
         sb.append("    additionalSpProperties: ").append(toIndentedString(additionalSpProperties)).append("\n");
         sb.append("    useExternalConsentPage: ").append(toIndentedString(useExternalConsentPage)).append("\n");
         sb.append("}");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/TrustedAppConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/TrustedAppConfiguration.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@ApiModel(description = "Decides the trusted app configurations for the application.")
+public class TrustedAppConfiguration {
+  
+    private Boolean isFIDOTrustedApp;
+    private Boolean isConsentGranted;
+    private String androidPackageName;
+    private List<String> androidThumbprints = null;
+
+    private String appleAppId;
+
+    /**
+    * Decides whether the application is a FIDO trusted app.
+    **/
+    public TrustedAppConfiguration isFIDOTrustedApp(Boolean isFIDOTrustedApp) {
+
+        this.isFIDOTrustedApp = isFIDOTrustedApp;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "Decides whether the application is a FIDO trusted app.")
+    @JsonProperty("isFIDOTrustedApp")
+    @Valid
+    public Boolean getIsFIDOTrustedApp() {
+        return isFIDOTrustedApp;
+    }
+    public void setIsFIDOTrustedApp(Boolean isFIDOTrustedApp) {
+        this.isFIDOTrustedApp = isFIDOTrustedApp;
+    }
+
+    /**
+    * Decides whether consent is granted for the trusted app.
+    **/
+    public TrustedAppConfiguration isConsentGranted(Boolean isConsentGranted) {
+
+        this.isConsentGranted = isConsentGranted;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "Decides whether consent is granted for the trusted app.")
+    @JsonProperty("isConsentGranted")
+    @Valid
+    public Boolean getIsConsentGranted() {
+        return isConsentGranted;
+    }
+    public void setIsConsentGranted(Boolean isConsentGranted) {
+        this.isConsentGranted = isConsentGranted;
+    }
+
+    /**
+    * Decides the android package name for the application.
+    **/
+    public TrustedAppConfiguration androidPackageName(String androidPackageName) {
+
+        this.androidPackageName = androidPackageName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "com.wso2.mobile.sample", value = "Decides the android package name for the application.")
+    @JsonProperty("androidPackageName")
+    @Valid
+    public String getAndroidPackageName() {
+        return androidPackageName;
+    }
+    public void setAndroidPackageName(String androidPackageName) {
+        this.androidPackageName = androidPackageName;
+    }
+
+    /**
+    * Decides the android thumbprints for the application.
+    **/
+    public TrustedAppConfiguration androidThumbprints(List<String> androidThumbprints) {
+
+        this.androidThumbprints = androidThumbprints;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Decides the android thumbprints for the application.")
+    @JsonProperty("androidThumbprints")
+    @Valid
+    public List<String> getAndroidThumbprints() {
+        return androidThumbprints;
+    }
+    public void setAndroidThumbprints(List<String> androidThumbprints) {
+        this.androidThumbprints = androidThumbprints;
+    }
+
+    public TrustedAppConfiguration addAndroidThumbprintsItem(String androidThumbprintsItem) {
+        if (this.androidThumbprints == null) {
+            this.androidThumbprints = new ArrayList<>();
+        }
+        this.androidThumbprints.add(androidThumbprintsItem);
+        return this;
+    }
+
+        /**
+    * Decides the apple app id for the application.
+    **/
+    public TrustedAppConfiguration appleAppId(String appleAppId) {
+
+        this.appleAppId = appleAppId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "APPLETEAMID.com.org.mobile.sample", value = "Decides the apple app id for the application.")
+    @JsonProperty("appleAppId")
+    @Valid
+    public String getAppleAppId() {
+        return appleAppId;
+    }
+    public void setAppleAppId(String appleAppId) {
+        this.appleAppId = appleAppId;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrustedAppConfiguration trustedAppConfiguration = (TrustedAppConfiguration) o;
+        return Objects.equals(this.isFIDOTrustedApp, trustedAppConfiguration.isFIDOTrustedApp) &&
+            Objects.equals(this.isConsentGranted, trustedAppConfiguration.isConsentGranted) &&
+            Objects.equals(this.androidPackageName, trustedAppConfiguration.androidPackageName) &&
+            Objects.equals(this.androidThumbprints, trustedAppConfiguration.androidThumbprints) &&
+            Objects.equals(this.appleAppId, trustedAppConfiguration.appleAppId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isFIDOTrustedApp, isConsentGranted, androidPackageName, androidThumbprints, appleAppId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TrustedAppConfiguration {\n");
+        
+        sb.append("    isFIDOTrustedApp: ").append(toIndentedString(isFIDOTrustedApp)).append("\n");
+        sb.append("    isConsentGranted: ").append(toIndentedString(isConsentGranted)).append("\n");
+        sb.append("    androidPackageName: ").append(toIndentedString(androidPackageName)).append("\n");
+        sb.append("    androidThumbprints: ").append(toIndentedString(androidThumbprints)).append("\n");
+        sb.append("    appleAppId: ").append(toIndentedString(appleAppId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-application-advanced-configuration.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/patch-application-advanced-configuration.json
@@ -5,6 +5,12 @@
     "skipLoginConsent": true,
     "skipLogoutConsent": true,
     "returnAuthenticatedIdpList": true,
-    "enableAuthorization": true
+    "enableAuthorization": true,
+    "trustedAppConfiguration": {
+      "isFIDOTrustedApp": true,
+      "androidPackageName": "sample.package.name",
+      "androidThumbprints": ["sampleThumbprint"],
+      "appleAppId": "sample.app.id"
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2262,7 +2262,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.3.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.26</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2375,7 +2375,7 @@
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.38</identity.user.api.version>
-        <identity.server.api.version>1.2.202</identity.server.api.version>
+        <identity.server.api.version>1.2.204</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.8</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
With the PRs https://github.com/wso2/carbon-identity-framework/pull/5753 and https://github.com/wso2/identity-api-server/pull/623, the trusted app configuration object is added to application advanced configuration section. 

This PR modifies the integration test: ApplicationPatchTest and adds the needed model to support the new addition.

Related issue: https://github.com/wso2/product-is/issues/20487