### PR TITLE
Bump kernel version & scim2 version

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.10.17" useFeatures="true" includeLaunchers="true">
+version="4.10.18" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.10.17" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.10.17"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.10.18"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2298,7 +2298,7 @@
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.7</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.90</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.91</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.8</identity.user.account.association.version>
@@ -2404,7 +2404,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.10.17</carbon.kernel.version>
+        <carbon.kernel.version>4.10.18</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.0.7</identity.verification.version>


### PR DESCRIPTION
### Purpose
- Bump kernel version to 4.10.18
- Bump identity.inbound.provisioning.scim2.version to 3.4.91