### PR TITLE
Implement integration templates packaging process

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- ~ Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~ Copyright (c) 2005-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  ~
  ~ WSO2 Inc. licenses this file to you under the Apache License,
  ~ Version 2.0 (the "License"); you may not use this file except
@@ -505,6 +505,15 @@
             <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
             <includes>
                 <include>x509certificateauthenticationendpoint/</include>
+            </includes>
+        </fileSet>
+
+        <!--Copy integration UI templates.-->
+        <fileSet>
+            <directory>../integration-ui-templates/target/templates</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/resources/identity/extensions</outputDirectory>
+            <includes>
+                <include>**/*</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/modules/integration-ui-templates/pom.xml
+++ b/modules/integration-ui-templates/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.is</groupId>
+        <artifactId>identity-server-parent</artifactId>
+        <version>7.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2is-identity-integration-ui-templates</artifactId>
+    <packaging>pom</packaging>
+    <name>Identity Server : identity-integration-ui-templates</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+            <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.custom-application</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+            <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.custom-protocol-application</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+            <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.m2m-application</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+            <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.mobile-application</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+            <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.single-page-application</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+            <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.traditional-web-application</artifactId>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- Download integration templates from nexus and copy to the target/unpacked-resources folder-->
+                    <execution>
+                        <id>download-integration-ui-templates</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <type>zip</type>
+                            <outputDirectory>${project.build.directory}/unpacked-resources</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-templates-structure</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/templates"/>
+                                <copy todir="${project.build.directory}/templates" overwrite="true">
+                                    <fileset dir="${project.build.directory}/unpacked-resources">
+                                        <include name="**/*"/>
+                                    </fileset>
+                                    <cutdirsmapper dirs="1"/>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -2311,7 +2311,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.3.63</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.64</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <module>modules/provisioning-connectors</module>
         <module>modules/local-authenticators</module>
         <module>modules/oauth2-grant-types</module>
+        <module>modules/integration-ui-templates</module>
         <module>modules/distribution</module>
         <module>modules/styles</module>
         <module>modules/tests-utils</module>
@@ -2212,6 +2213,44 @@
                 <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
                 <version>${identity.extension.utils}</version>
             </dependency>
+
+            <!-- Integration UI Templates -->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+                <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.custom-application</artifactId>
+                <version>${identity.integration.ui.templates.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+                <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.custom-protocol-application</artifactId>
+                <version>${identity.integration.ui.templates.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+                <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.m2m-application</artifactId>
+                <version>${identity.integration.ui.templates.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+                <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.mobile-application</artifactId>
+                <version>${identity.integration.ui.templates.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+                <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.single-page-application</artifactId>
+                <version>${identity.integration.ui.templates.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.integration.ui.templates</groupId>
+                <artifactId>org.wso2.carbon.identity.integration.ui.templates.applications.traditional-web-application</artifactId>
+                <version>${identity.integration.ui.templates.version}</version>
+                <type>zip</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -2537,6 +2576,9 @@
         <org.apache.log4j.wso2.version>1.2.17.wso2v1</org.apache.log4j.wso2.version>
 
         <project.scm.id>my-scm-server</project.scm.id>
+
+        <!-- Integration UI Templates Version -->
+        <identity.integration.ui.templates.version>1.0.6</identity.integration.ui.templates.version>
 
     </properties>
 


### PR DESCRIPTION
## Purpose
Previously, application templates were part of the extension management feature itself. With the SSO template onboarding feature, we have moved the application templates to a separate repository (https://github.com/wso2-extensions/identity-integration-ui-templates). In this new setup, each template is released separately (with single version), and published to the public nexus through Jenkins job.

This PR introduces logic to download the specified release in `pom.xml` and include those templates into the `/repository/resources/identity/extensions` directory.

## Related Issues

- https://github.com/wso2/product-is/issues/20107