### PR TITLE
Integration test update for organization multi meta-attribute filtering

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementSuccessTest.java
@@ -261,8 +261,8 @@ public class OrganizationManagementSuccessTest extends OrganizationManagementBas
         return new Object[][] {
                 {"name co G", false, false},
                 {"attributes.Country co S", true, false},
-                {"attributes.Country eq Sri Lanka", true, false},
                 {"attributes.Country eq Sri Lanka and name co Greater", true, false},
+                {"attributes.Country eq Sri Lanka and attributes.Language eq Sinhala", true, false},
                 {"attributes.Country eq USA", false, true}
         };
     }


### PR DESCRIPTION
### Purpose
$Subject

**Approach**
Updated the **OrganizationManagementSuccessTest** test class's **testFilterOrganizations** method data provider by adding an additional test case to cover scenarios where organizations are filtered by two meta attributes.

### Related Issues
- https://github.com/wso2/product-is/issues/20688