### PR TITLE
Bump Carbon Kernel Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2443,7 +2443,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.10.18</carbon.kernel.version>
+        <carbon.kernel.version>4.10.19</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.0.7</identity.verification.version>


### PR DESCRIPTION
- This PR bumps the `carbon-kernel` version from `4.10.18` to `4.10.19`