### PR TITLE
Fix Fapi failure due to Docker Compose Not found

### DIFF
--- a/.github/workflows/fapi-oidc-conformance-test.yml
+++ b/.github/workflows/fapi-oidc-conformance-test.yml
@@ -183,6 +183,12 @@ jobs:
         java-version: 17
         distribution: temurin
 
+    - name: Install Docker Compose
+      run: |
+        sudo curl -L "https://github.com/docker/compose/releases/download/$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r .tag_name)/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+        docker-compose --version
+
     - name: Start Conformance Suite server
       run: |
         DOCKER_COMPOSE_FILE=./docker-compose.yml


### PR DESCRIPTION
FAPI Suite is failing due to docker-compose not found
https://github.com/wso2/product-is/actions/runs/10376812875/job/28729582734

With this fix we are installing docker to fix the issue
FIxed verified in forked branch: https://github.com/Thumimku/product-is/actions/runs/10401218266