### PR TITLE
Modify Action Management Rest Api tests for not implemented action types

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsFailureTest.java
@@ -159,6 +159,21 @@ public class ActionsFailureTest extends ActionsTestBase {
     }
 
     @Test(dependsOnMethods = {"testCreateActionAfterReachingMaxActionCount"})
+    public void testCreateActionWithNotImplementedActionTypes() {
+
+        for (String actionTypePath : NOT_IMPLEMENTED_ACTION_TYPE_PATHS) {
+            String body = toJSONString(action1);
+            Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                    actionTypePath, body);
+            responseOfPost.then()
+                    .log().ifValidationFails()
+                    .assertThat().statusCode(HttpStatus.SC_NOT_IMPLEMENTED)
+                    .body("description", equalTo("The requested action type is not currently " +
+                            "supported by the server."));
+        }
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithNotImplementedActionTypes"})
     public void testUpdateActionWithInvalidID() {
 
         // Update Action basic information with an invalid action id.
@@ -173,14 +188,6 @@ public class ActionsFailureTest extends ActionsTestBase {
                 .assertThat().statusCode(HttpStatus.SC_NOT_FOUND)
                 .body("description", equalTo("No Action is configured on the given Action Type and Id."));
 
-        // Update Action basic information with correct Id and different action type.
-        getResponseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
-                PRE_UPDATE_PASSWORD_PATH + "/" + testActionId2, body);
-        getResponseOfPatch.then()
-                .log().ifValidationFails()
-                .assertThat().statusCode(HttpStatus.SC_NOT_FOUND)
-                .body("description", equalTo("No Action is configured on the given Action Type and Id."));
-
         // Update Action Endpoint Authentication Properties with an invalid action id.
         AuthenticationTypeProperties authenticationType = new AuthenticationTypeProperties()
                 .properties(new HashMap<String, Object>() {{
@@ -190,14 +197,6 @@ public class ActionsFailureTest extends ActionsTestBase {
         body = toJSONString(authenticationType);
         Response responseOfPut = getResponseOfPut(ACTION_MANAGEMENT_API_BASE_PATH +
                 PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + TEST_ACTION_INVALID_ID + ACTION_BEARER_AUTH_PATH, body);
-        responseOfPut.then()
-                .log().ifValidationFails()
-                .assertThat().statusCode(HttpStatus.SC_NOT_FOUND)
-                .body("description", equalTo("No Action is configured on the given Action Type and Id."));
-
-        // Update Action Endpoint Authentication Properties with correct Id and different action type.
-        responseOfPut = getResponseOfPut(ACTION_MANAGEMENT_API_BASE_PATH +
-                PRE_UPDATE_PASSWORD_PATH + "/" + testActionId2 + ACTION_BEARER_AUTH_PATH, body);
         responseOfPut.then()
                 .log().ifValidationFails()
                 .assertThat().statusCode(HttpStatus.SC_NOT_FOUND)
@@ -251,15 +250,6 @@ public class ActionsFailureTest extends ActionsTestBase {
                 .assertThat()
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body("description", equalTo("No Action is configured on the given Action Type and Id."));
-
-        // With correct Id and different action type.
-        getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH + PRE_UPDATE_PASSWORD_PATH +
-                "/" + testActionId2 + ACTION_ACTIVATE_PATH, "")
-                .then()
-                .log().ifValidationFails()
-                .assertThat()
-                .statusCode(HttpStatus.SC_NOT_FOUND)
-                .body("description", equalTo("No Action is configured on the given Action Type and Id."));
     }
 
     @Test(dependsOnMethods = {"testActivateActionWithInvalidID"})
@@ -272,15 +262,6 @@ public class ActionsFailureTest extends ActionsTestBase {
                 .assertThat()
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body("description", equalTo("No Action is configured on the given Action Type and Id."));
-
-        // With correct Id and different action type.
-        getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH + PRE_UPDATE_PASSWORD_PATH +
-                "/" + testActionId2 + ACTION_DEACTIVATE_PATH, "")
-                .then()
-                .log().ifValidationFails()
-                .assertThat()
-                .statusCode(HttpStatus.SC_NOT_FOUND)
-                .body("description", equalTo("No Action is configured on the given Action Type and Id."));
     }
 
     @Test(dependsOnMethods = {"testDeactivateActionWithInvalidID"})
@@ -288,14 +269,6 @@ public class ActionsFailureTest extends ActionsTestBase {
 
         getResponseOfDelete(ACTION_MANAGEMENT_API_BASE_PATH + PRE_ISSUE_ACCESS_TOKEN_PATH +
                 "/" + TEST_ACTION_INVALID_ID)
-                .then()
-                .log().ifValidationFails()
-                .assertThat()
-                .statusCode(HttpStatus.SC_NOT_FOUND)
-                .body("description", equalTo("No Action is configured on the given Action Type and Id."));
-
-        getResponseOfDelete(ACTION_MANAGEMENT_API_BASE_PATH + PRE_UPDATE_PASSWORD_PATH +
-                "/" + testActionId2)
                 .then()
                 .log().ifValidationFails()
                 .assertThat()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsSuccessTest.java
@@ -145,14 +145,7 @@ public class ActionsSuccessTest extends ActionsTestBase {
                         notNullValue())
                 .body( "find { it.type == '" + PRE_ISSUE_ACCESS_TOKEN_ACTION_TYPE + "' }.count",
                         equalTo(1))
-                .body( "find { it.type == '" + PRE_ISSUE_ACCESS_TOKEN_ACTION_TYPE + "' }.self", notNullValue())
-                .body( "find { it.type == '" + PRE_UPDATE_PASSWORD_ACTION_TYPE + "' }.displayName",
-                        notNullValue())
-                .body( "find { it.type == '" + PRE_UPDATE_PASSWORD_ACTION_TYPE + "' }.description",
-                        notNullValue())
-                .body( "find { it.type == '" + PRE_UPDATE_PASSWORD_ACTION_TYPE + "' }.count",
-                        equalTo(0))
-                .body( "find { it.type == '" + PRE_UPDATE_PASSWORD_ACTION_TYPE + "' }.self", notNullValue());
+                .body( "find { it.type == '" + PRE_ISSUE_ACCESS_TOKEN_ACTION_TYPE + "' }.self", notNullValue());
     }
 
     @Test(dependsOnMethods = {"testGetActions"})

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsTestBase.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ActionsTestBase extends RESTAPIServerTestBase {
 
@@ -40,14 +42,12 @@ public class ActionsTestBase extends RESTAPIServerTestBase {
     protected static final String ACTION_MANAGEMENT_API_BASE_PATH = "/actions";
     protected static final String TYPES_API_PATH = "/types";
     protected static final String PRE_ISSUE_ACCESS_TOKEN_PATH = "/preIssueAccessToken";
-    protected static final String PRE_UPDATE_PASSWORD_PATH = "/preUpdatePassword";
     protected static final String ACTION_DEACTIVATE_PATH = "/deactivate";
     protected static final String ACTION_ACTIVATE_PATH = "/activate";
     protected static final String ACTION_BEARER_AUTH_PATH = "/bearer";
     protected static final String ACTION_BASIC_AUTH_PATH = "/basic";
 
     protected static final String PRE_ISSUE_ACCESS_TOKEN_ACTION_TYPE = "PRE_ISSUE_ACCESS_TOKEN";
-    protected static final String PRE_UPDATE_PASSWORD_ACTION_TYPE = "PRE_UPDATE_PASSWORD";
 
     protected static final String TEST_ACTION_NAME = "Access Token Pre Issue";
     protected static final String TEST_ACTION_DESCRIPTION = "This is the configuration of pre-action for issuing access token.";
@@ -72,9 +72,16 @@ public class ActionsTestBase extends RESTAPIServerTestBase {
     protected static final String TEST_APIKEY_VALUE_AUTH_PROPERTY = "value";
     protected static final String TEST_APIKEY_VALUE_AUTH_PROPERTY_VALUE = "secret";
 
+    protected static final Set<String> NOT_IMPLEMENTED_ACTION_TYPE_PATHS = new HashSet<>();
+
     protected static String swaggerDefinition;
 
     static {
+        NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/preUpdatePassword");
+        NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/preUpdateProfile");
+        NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/preRegistration");
+        NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/authentication");
+
         String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.action.management.v1";
         try {
             swaggerDefinition = getAPISwaggerDefinition(API_PACKAGE_NAME, API_DEFINITION_NAME);

--- a/pom.xml
+++ b/pom.xml
@@ -2436,7 +2436,7 @@
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
         <identity.user.api.version>1.3.39</identity.user.api.version>
-        <identity.server.api.version>1.2.225</identity.server.api.version>
+        <identity.server.api.version>1.2.226</identity.server.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.9</identity.tool.samlsso.validator.version>


### PR DESCRIPTION
### Purpose
> Since the following action types executions are not implemented in the system, this PR will improve the integration tests to validate that.
- preUpdatePassword
- preUpdateProfile
- preRegistration
- authentication

### Related PR
- https://github.com/wso2/identity-api-server/pull/663

### Related Issue
- https://github.com/wso2/product-is/issues/20748