### PR TITLE
Refactor the actionRestClient invoke implementation

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/ActionsBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/ActionsBaseTestCase.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  */
 public class ActionsBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    protected ActionsRestClient restClient;
+    protected ActionsRestClient actionsRestClient;
 
     /**
      * Initialize the test case.
@@ -44,7 +44,7 @@ public class ActionsBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
         super.init(userMode);
 
-        restClient = new ActionsRestClient(serverURL, tenantInfo);
+        actionsRestClient = new ActionsRestClient(serverURL, tenantInfo);
 
         setSystemproperties();
     }
@@ -59,7 +59,7 @@ public class ActionsBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
      */
     public String createAction(String actionType, ActionModel actionModel) throws IOException {
 
-        return restClient.createActionType(actionModel, actionType);
+        return actionsRestClient.createActionType(actionModel, actionType);
     }
 
     /**
@@ -72,6 +72,6 @@ public class ActionsBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
      */
     public int deleteAction(String actionType, String actionId) throws IOException {
 
-        return restClient.deleteActionType(actionType, actionId);
+        return actionsRestClient.deleteActionType(actionType, actionId);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenClientCredentialsGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenClientCredentialsGrantTestCase.java
@@ -58,7 +58,6 @@ import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
 import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
-import org.wso2.identity.integration.test.restclients.ActionsRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.utils.CarbonUtils;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenClientCredentialsGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenClientCredentialsGrantTestCase.java
@@ -199,8 +199,11 @@ public class PreIssueAccessTokenClientCredentialsGrantTestCase extends ActionsBa
         deleteApp(applicationId);
         deleteDomainAPI(domainAPIId);
         scim2RestClient.deleteUser(userId);
-        scim2RestClient = null;
         MockServer.shutDownMockServer();
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        client.close();
         accessToken = null;
         jwtClaims = null;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenClientCredentialsGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenClientCredentialsGrantTestCase.java
@@ -171,8 +171,6 @@ public class PreIssueAccessTokenClientCredentialsGrantTestCase extends ActionsBa
                 }).build();
 
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
-        restClient = new ActionsRestClient(serverURL, tenantInfo);
-        // TODO: Review if ActionsRestClient should be instantiated, or if the superclass initialization is sufficient
 
         customScopes = Arrays.asList(CUSTOM_SCOPE_1, CUSTOM_SCOPE_2, CUSTOM_SCOPE_3);
 
@@ -198,7 +196,6 @@ public class PreIssueAccessTokenClientCredentialsGrantTestCase extends ActionsBa
     public void atEnd() throws Exception {
 
         deleteAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionId);
-        restClient = null;
         deleteRole(roleId);
         deleteApp(applicationId);
         deleteDomainAPI(domainAPIId);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenPasswordGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenPasswordGrantTestCase.java
@@ -127,8 +127,6 @@ public class PreIssueAccessTokenPasswordGrantTestCase extends ActionsBaseTestCas
         super.init(TestUserMode.TENANT_USER);
 
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
-        restClient = new ActionsRestClient(serverURL, tenantInfo);
-        // TODO: Review if ActionsRestClient should be instantiated, or if the superclass initialization is sufficient
 
         List<String> customScopes = Arrays.asList(CUSTOM_SCOPE_1, CUSTOM_SCOPE_2, CUSTOM_SCOPE_3);
 
@@ -154,7 +152,6 @@ public class PreIssueAccessTokenPasswordGrantTestCase extends ActionsBaseTestCas
     public void atEnd() throws Exception {
 
         deleteAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionId);
-        restClient = null;
         deleteRole(roleId);
         deleteApp(applicationId);
         deleteDomainAPI(domainAPIId);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenPasswordGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenPasswordGrantTestCase.java
@@ -155,8 +155,10 @@ public class PreIssueAccessTokenPasswordGrantTestCase extends ActionsBaseTestCas
         deleteApp(applicationId);
         deleteDomainAPI(domainAPIId);
         scim2RestClient.deleteUser(userId);
-        scim2RestClient = null;
         MockServer.shutDownMockServer();
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
         accessToken = null;
         jwtClaims = null;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenPasswordGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/PreIssueAccessTokenPasswordGrantTestCase.java
@@ -42,7 +42,6 @@ import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
 import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
-import org.wso2.identity.integration.test.restclients.ActionsRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.utils.CarbonUtils;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ActionsRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ActionsRestClient.java
@@ -143,4 +143,14 @@ public class ActionsRestClient extends RestBaseClient {
 
         return headerList;
     }
+
+    /**
+     * Close the HTTP client.
+     *
+     * @throws IOException If an error occurred while closing the Http Client.
+     */
+    public void closeHttpClient() throws IOException {
+
+        client.close();
+    }
 }


### PR DESCRIPTION
### Description
This refines the invocation method of the actionsRestClient in both the `preIssueAccessTokenPasswordGrantTestCase` and `preIssueAccessTokenClientCredentialsGrantTestCase`.

### Related Issues
- https://github.com/wso2/product-is/issues/20842

### Related PRs
- https://github.com/wso2/product-is/pull/20903
- https://github.com/wso2/product-is/pull/21033