### PR TITLE
Change_Port_Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ By default mode, it would ask you to enter the master password
 
 > ciphertool -Dchange  (in UNIX)
 
+4. Change the Port by modifying the conf/axis2.xml file
+
+Locate the `<offset>` tag in the conf/axis2.xml file.
+Change the value from 0 to 2 (or the desired offset).
+> For example: `<offset>2</offset>`
+> With this change, if the default port is 9443, it will now run on port 9443 + 2 = 9445.
+
 For more details see
 https://is.docs.wso2.com/en/7.0.0/deploy/security/encrypt-passwords-with-cipher-tool/
 

--- a/README.txt
+++ b/README.txt
@@ -171,6 +171,14 @@ By default mode, it would ask you to enter the master password
 
 > ciphertool -Dchange  (in UNIX)
 
+4. Change the Port by modifying the conf/axis2.xml file
+
+Locate the <offset> tag in the conf/axis2.xml file.
+Change the value from 0 to 2 (or the desired offset).
+For example: <offset>2</offset>
+With this change, if the default port is 9443, it will now run on port 9443 + 2 = 9445.
+
+
 For more details see
 https://is.docs.wso2.com/en/6.0.0/deploy/security/encrypt-passwords-with-cipher-tool/
 


### PR DESCRIPTION
When integrating WSO2 with another project, you might encounter a common issue if both the WSO2 server and the other project are configured to use the same port. To resolve this, you need to change the default port used by WSO2. Here’s a clear guide on how to do this.