### PR TITLE
Bump `carbon-identity-framework` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2323,7 +2323,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.5.5</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.7</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
- This PR bumps the `carbon-identity-framework` from `7.5.5` to `7.5.7`
- Related to https://github.com/wso2/carbon-identity-framework/pull/5794
---
- Problem Statement: wso2-enterprise/iam-product-management#67
- Public Git Issue: wso2/product-is#20564