### PR TITLE
Update shade plugin configs

### DIFF
--- a/modules/integration/tests-common/jacoco-report-generator/pom.xml
+++ b/modules/integration/tests-common/jacoco-report-generator/pom.xml
@@ -83,6 +83,7 @@
                                     <mainClass>org.wso2.carbon.identity.jacoco.ReportGenerator</mainClass>
                                 </transformer>
                             </transformers>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Avoid the shade plugin from creating the dependency-reduced-pom.xml, since there is no requirement for us to use this file.