### PR TITLE
Fix SCIM custom claim dialect related test issue

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
@@ -144,7 +144,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
         RestAssured.basePath = basePath;
     }
 
-    @Test(description = "Creates custom schema dialect, simple attribute and complex attributes.")
+    @Test(description = "Creates simple attribute and complex attributes in urn:scim:wso2:schema.")
     private void createClaims() throws Exception {
 
         AutomationContext context = new AutomationContext("IDENTITY", mode);
@@ -152,24 +152,10 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
         loginLogoutClient = new LoginLogoutClient(context);
         cookie = loginLogoutClient.login();
         claimMetadataManagementServiceClient = new ClaimMetadataManagementServiceClient(backendURL, cookie);
-        ClaimDialectDTO[] claimDialects = claimMetadataManagementServiceClient.getClaimDialects();
 
-        boolean isCustomSchemaDialectExist = Arrays.stream(claimDialects)
-                .anyMatch(claimDialect -> StringUtils.equals(claimDialect.getClaimDialectURI(), CUSTOM_SCHEMA_URI));
-
-        if (!isCustomSchemaDialectExist) {
-            // Set custom schema dialect.
-            ClaimDialectDTO claimDialectDTO = new ClaimDialectDTO();
-            claimDialectDTO.setClaimDialectURI(CUSTOM_SCHEMA_URI);
-            claimMetadataManagementServiceClient.addClaimDialect(claimDialectDTO);
-        }
-
-        //Set claims
+        //Set claims.
         setSimpleAttribute();
         setComplexAttribute();
-        ClaimDialectDTO[] updatedClaimDialects = claimMetadataManagementServiceClient.getClaimDialects();
-        Assert.assertTrue(Arrays.stream(updatedClaimDialects)
-                .anyMatch(dialect -> StringUtils.equals(dialect.getClaimDialectURI(), CUSTOM_SCHEMA_URI)));
 
         ExternalClaimDTO[] externalClaimDTOs =
                 claimMetadataManagementServiceClient.getExternalClaims(CUSTOM_SCHEMA_URI);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
@@ -124,7 +124,10 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
     public void testFinish() {
 
         try {
-            claimMetadataManagementServiceClient.removeClaimDialect(CUSTOM_SCHEMA_URI);
+            claimMetadataManagementServiceClient.removeExternalClaim(CUSTOM_SCHEMA_URI, COUNTRY_CLAIM_ATTRIBUTE_URI);
+            claimMetadataManagementServiceClient.removeExternalClaim(CUSTOM_SCHEMA_URI,
+                    MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI);
+            claimMetadataManagementServiceClient.removeExternalClaim(CUSTOM_SCHEMA_URI, MANAGER_CLAIM_ATTRIBUTE_URI);
             claimMetadataManagementServiceClient.removeLocalClaim(MANAGER_LOCAL_CLAIM_URI);
         } catch (RemoteException | ClaimMetadataManagementServiceClaimMetadataException e) {
             log.error(e);
@@ -165,6 +168,15 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
         ClaimDialectDTO[] updatedClaimDialects = claimMetadataManagementServiceClient.getClaimDialects();
         Assert.assertTrue(Arrays.stream(updatedClaimDialects)
                 .anyMatch(dialect -> StringUtils.equals(dialect.getClaimDialectURI(), CUSTOM_SCHEMA_URI)));
+
+        ExternalClaimDTO[] externalClaimDTOs =
+                claimMetadataManagementServiceClient.getExternalClaims(CUSTOM_SCHEMA_URI);
+        Assert.assertTrue(Arrays.stream(externalClaimDTOs)
+                .anyMatch(claim -> StringUtils.equals(claim.getExternalClaimURI(), COUNTRY_CLAIM_ATTRIBUTE_URI)));
+        Assert.assertTrue(Arrays.stream(externalClaimDTOs)
+                .anyMatch(claim -> StringUtils.equals(claim.getExternalClaimURI(), MANAGER_CLAIM_ATTRIBUTE_URI)));
+        Assert.assertTrue(Arrays.stream(externalClaimDTOs)
+                .anyMatch(claim -> StringUtils.equals(claim.getExternalClaimURI(), MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI)));
     }
 
     @Test(dependsOnMethods = "createClaims", description = "Create user with custom schema dialect.")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
@@ -141,7 +141,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
         RestAssured.basePath = basePath;
     }
 
-    @Test(description = "Creates custom schema dialect, simple attribute and complex attributes.")
+    @Test(description = "Creates simple attribute and complex attributes in urn:scim:wso2:schema.")
     private void createClaims() throws Exception {
 
         AutomationContext context = new AutomationContext("IDENTITY", mode);
@@ -149,25 +149,10 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
         loginLogoutClient = new LoginLogoutClient(context);
         cookie = loginLogoutClient.login();
         claimMetadataManagementServiceClient = new ClaimMetadataManagementServiceClient(backendURL, cookie);
-        ClaimDialectDTO[] claimDialects = claimMetadataManagementServiceClient.getClaimDialects();
-
-        boolean isCustomSchemaDialectExist = Arrays.stream(claimDialects)
-                .anyMatch(claimDialect -> StringUtils.equals(claimDialect.getClaimDialectURI(), CUSTOM_SCHEMA_URI));
-
-        if (!isCustomSchemaDialectExist) {
-            // Set custom schema dialect.
-            ClaimDialectDTO claimDialectDTO = new ClaimDialectDTO();
-            claimDialectDTO.setClaimDialectURI(CUSTOM_SCHEMA_URI);
-            claimMetadataManagementServiceClient.addClaimDialect(claimDialectDTO);
-        }
 
         //Set claims.
         setSimpleAttribute();
         setComplexAttribute();
-
-        ClaimDialectDTO[] updatedClaimDialects = claimMetadataManagementServiceClient.getClaimDialects();
-        Assert.assertTrue(Arrays.stream(updatedClaimDialects)
-                .anyMatch(dialect -> StringUtils.equals(dialect.getClaimDialectURI(), CUSTOM_SCHEMA_URI)));
 
         ExternalClaimDTO[] externalClaimDTOs =
                 claimMetadataManagementServiceClient.getExternalClaims(CUSTOM_SCHEMA_URI);

--- a/pom.xml
+++ b/pom.xml
@@ -2360,7 +2360,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.5.48</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.57</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Fix:
The SCIM2CustomSchemaUserTestCase.createClaims() test is failing with a NoSuchMethodError:
```
[ERROR] org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase.createClaims(org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase)
[ERROR] Run 1: SCIM2CustomSchemaUserTestCase.createClaims:153 » NoSuchMethod org.wso2.carbon....
[ERROR] Run 2: SCIM2CustomSchemaUserTestCase.createClaims:153 » NoSuchMethod org.wso2.carbon....
```

### Root Cause
This error is occurring due to changes introduced in PR #5661 (https://github.com/wso2/carbon-identity-framework/pull/5661). That PR added claims to the "urn:scim:wso2:schema" dialect by default. However, the SCIM2CustomSchemaUserTestCase assumes this custom dialect URI is not set and attempts to create the claim dialect within the test.

### Solution
Updated test to, check if custom schema dialect exists and create dialect only if it doesn't exist.

is-tests-scim2 tests passed locally with this change.
<img width="793" alt="image" src="https://github.com/user-attachments/assets/e41ca1fa-f982-4c68-950f-3450048bbd99">
