### PR TITLE
Update OpenIDConnectAuthenticator name in integration tests.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
@@ -47,7 +47,7 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
     private String testIdpName = "TestIDPProvider";
     private String testIdpNameSearch = "SearchTestIDPProviderTest";
     private String updatedTestIdpName = "UpdatedTestIDPProvider";
-    private String testFedAuthName = "OpenIDAuthenticator";
+    private String testFedAuthName = "OpenIDConnectAuthenticator";
 
     //Resident idp default values
     private boolean residentIdpEnable;
@@ -159,7 +159,7 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
     public void testAddIdp() throws Exception {
         String testIdpDescription = "This is test identity provider";
         String testIdpRealmId = "localhost";
-        String testFedAuthDispName = "openid";
+        String testFedAuthDispName = "openidConnect";
 
         String testFedAuthPropName = "OpenIdUrl";
         String testFedAuthPropValue = "https://testDomain:9853/openid";


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/21111

The IS does not have federated authenticator by `OpenIDAuthenticator` name, instead it has `OpenIDConnectAuthenticator`. With this PR, its name and display will be updated.