### PR TITLE
Ignore authentication action type in api tests.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsSuccessTest.java
@@ -132,7 +132,7 @@ public class ActionsSuccessTest extends ActionsTestBase {
     }
 
     @Test(dependsOnMethods = {"testGetActionByActionType"})
-    public void testGetActions() {
+    public void testGetActionTypes() {
 
         Response responseOfGet = getResponseOfGet(ACTION_MANAGEMENT_API_BASE_PATH + TYPES_API_PATH);
         responseOfGet.then()
@@ -148,7 +148,7 @@ public class ActionsSuccessTest extends ActionsTestBase {
                 .body( "find { it.type == '" + PRE_ISSUE_ACCESS_TOKEN_ACTION_TYPE + "' }.self", notNullValue());
     }
 
-    @Test(dependsOnMethods = {"testGetActions"})
+    @Test(dependsOnMethods = {"testGetActionTypes"})
     public void testUpdateAction() {
 
         // Update all the attributes of the action.

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/ActionsTestBase.java
@@ -80,7 +80,6 @@ public class ActionsTestBase extends RESTAPIServerTestBase {
         NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/preUpdatePassword");
         NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/preUpdateProfile");
         NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/preRegistration");
-        NOT_IMPLEMENTED_ACTION_TYPE_PATHS.add("/authentication");
 
         String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.action.management.v1";
         try {


### PR DESCRIPTION
Updates actions api tests to accommodate https://github.com/wso2/product-is/issues/21384

As the API contract is updated the restassured api client doesn't allow to initiate requests with invalid action types. So, the api tests doesn't cover that scenario.