### PR TITLE
Add integration-tests for excludeSystemPortals parameter

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationManagementSuccessTest.java
@@ -91,6 +91,28 @@ public class ApplicationManagementSuccessTest extends ApplicationManagementBaseT
     }
 
     @Test
+    public void testGetAllApplicationsExcludingSystemApps() throws IOException {
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("excludeSystemPortals", true);
+        Response response = getResponseOfGet(APPLICATION_MANAGEMENT_API_BASE_PATH, params);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+        ObjectMapper jsonWriter = new ObjectMapper(new JsonFactory());
+        ApplicationListResponse listResponse = jsonWriter.readValue(response.asString(), ApplicationListResponse.class);
+        Assert.assertFalse(listResponse.getApplications()
+                        .stream()
+                        .anyMatch(appBasicInfo -> appBasicInfo.getName().equals(ApplicationConstants.CONSOLE_APPLICATION_NAME)),
+                "Default resident service provider '" + ApplicationConstants.CONSOLE_APPLICATION_NAME + "' is listed by the API");
+        Assert.assertFalse(listResponse.getApplications()
+                        .stream()
+                        .anyMatch(appBasicInfo -> appBasicInfo.getName().equals(ApplicationConstants.MY_ACCOUNT_APPLICATION_NAME)),
+                "Default resident service provider '" + ApplicationConstants.MY_ACCOUNT_APPLICATION_NAME + "' is listed by the API");
+    }
+
+    @Test
     public void testGetResidentApplication() throws IOException {
 
         Response response = getResponseOfGet(RESIDENT_APP_API_BASE_PATH);


### PR DESCRIPTION
In this pr, we are adding a new integration-test for excludeSystemPortals parameter in applications get call which will exclude the system apps mentioned through the config[1] when the parameter is true.

[1] https://github.com/wso2/carbon-identity-framework/blob/da79dc6ebb25359ab3177140df501dc899b41172/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2#L4031