### PR TITLE
Fix maven build warnings

### DIFF
--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -558,11 +558,6 @@
                 <version>${carbon.consent.mgt.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.consent.mgt</groupId>
-                <artifactId>org.wso2.carbon.api.server.consent.mgt</artifactId>
-                <version>${carbon.consent.mgt.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.identity.local.auth.api</groupId>
                 <artifactId>org.wso2.carbon.api.server.local.auth.api</artifactId>
                 <version>${identity.local.auth.api.version}</version>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -582,23 +582,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-project-info-reports-plugin</artifactId>
-                            <version>2.4</version>
-                            <reportSets>
-                                <reportSet>
-                                    <reports>
-                                        <report>index</report>
-                                    </reports>
-                                </reportSet>
-                            </reportSets>
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
+                <version>3.21.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -638,13 +622,6 @@
                             </namespaceContexts>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.google.code.maven-config-processor-plugin</groupId>
-                <artifactId>config-processor-maven-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
                     <execution>
                         <id>add-missing-axis2-configs</id>
                         <phase>prepare-package</phase>
@@ -783,11 +760,12 @@
             </plugin>
         </plugins>
     </build>
-    <!--reporting>
+    <reporting>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.8.0</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -797,5 +775,5 @@
                 </reportSets>
             </plugin>
         </plugins>
-    </reporting-->
+    </reporting>
 </project>


### PR DESCRIPTION
Below warning logs are fixed

```
[WARNING] Some problems were encountered while building the effective model for org.wso2.is:api-resources-full:war:7.1.0-m5-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.wso2.carbon.consent.mgt:org.wso2.carbon.api.server.consent.mgt:jar -> duplicate declaration of version ${carbon.consent.mgt.version} @ org.wso2.is:api-resources:7.1.0-m5-SNAPSHOT, /Users/maduranga/Documents/wso2/git/product-is/modules/api-resources/pom.xml, line 560, column 25
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.wso2.is:api-resources:pom:7.1.0-m5-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.wso2.carbon.consent.mgt:org.wso2.carbon.api.server.consent.mgt:jar -> duplicate declaration of version ${carbon.consent.mgt.version} @ line 560, column 25
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.wso2.is:wso2is:jar:7.1.0-m5-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.google.code.maven-config-processor-plugin:config-processor-maven-plugin @ line 643, column 21
[WARNING] Reporting configuration should be done in <reporting> section, not in maven-site-plugin <configuration> as reportPlugins parameter. @ line 586, column 32
```