### PR TITLE
 Add integration tests for managing user defined federated authenticator

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
@@ -29,6 +29,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.AuthenticationType;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Endpoint;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.util.UserDefinedAuthenticatorPayload;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -45,7 +49,19 @@ import static org.testng.Assert.assertNotNull;
 public class IdPSuccessTest extends IdPTestBase {
 
     private String idPId;
+    private String customIdPId;
     private String idPTemplateId;
+    private UserDefinedAuthenticatorPayload userDefinedAuthenticatorPayload;
+    private String idpCreatePayload;
+
+    private static final String FEDERATED_AUTHENTICATOR_ID_PLACEHOLDER = "<FEDERATED_AUTHENTICATOR_ID>";
+    private static final String FEDERATED_AUTHENTICATOR_PLACEHOLDER = "\"<FEDERATED_AUTHENTICATOR>\"";
+    private static final String FEDERATED_AUTHENTICATOR_ID = "Y3VzdG9tQXV0aGVudGljYXRvcg==";
+    private static final String ENDPOINT_URI = "https://abc.com/authenticate";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String USERNAME_VALUE = "testUser";
+    private static final String PASSWORD_VALUE = "testPassword";
 
     @Factory(dataProvider = "restAPIUserConfigProvider")
     public IdPSuccessTest(TestUserMode userMode) throws Exception {
@@ -61,6 +77,30 @@ public class IdPSuccessTest extends IdPTestBase {
     public void init() throws IOException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
+        userDefinedAuthenticatorPayload = createUserDefinedAuthenticatorPayload();
+        idpCreatePayload = readResource("add-idp-with-custom-fed-auth.json");
+
+    }
+
+    private UserDefinedAuthenticatorPayload createUserDefinedAuthenticatorPayload() {
+
+        UserDefinedAuthenticatorPayload userDefinedAuthenticatorPayload = new UserDefinedAuthenticatorPayload();
+        userDefinedAuthenticatorPayload.setIsEnabled(true);
+        userDefinedAuthenticatorPayload.setAuthenticatorId(FEDERATED_AUTHENTICATOR_ID);
+        userDefinedAuthenticatorPayload.setDefinedBy(FederatedAuthenticatorRequest.DefinedByEnum.USER.toString());
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setUri(ENDPOINT_URI);
+        AuthenticationType authenticationType = new AuthenticationType();
+        authenticationType.setType(AuthenticationType.TypeEnum.BASIC);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(USERNAME, USERNAME_VALUE);
+        properties.put(PASSWORD, PASSWORD_VALUE);
+        authenticationType.setProperties(properties);
+        endpoint.authentication(authenticationType);
+        userDefinedAuthenticatorPayload.setEndpoint(endpoint);
+
+        return userDefinedAuthenticatorPayload;
     }
 
     @AfterClass(alwaysRun = true)
@@ -254,6 +294,26 @@ public class IdPSuccessTest extends IdPTestBase {
                 .body("displayName", equalTo("scim"))
                 .body("blockingEnabled", equalTo(false))
                 .body("rulesEnabled", equalTo(false));
+    }
+
+    @Test
+    public void testAddIdPWithUserDefinedAuthenticator() throws IOException {
+
+        String body = idpCreatePayload.replace(FEDERATED_AUTHENTICATOR_ID_PLACEHOLDER,
+                userDefinedAuthenticatorPayload.getAuthenticatorId());
+        body = body.replace(FEDERATED_AUTHENTICATOR_PLACEHOLDER,
+                userDefinedAuthenticatorPayload.convertToJasonPayload());
+        Response response = getResponseOfPost(IDP_API_BASE_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+        customIdPId = location.substring(location.lastIndexOf("/") + 1);
+        assertNotNull(customIdPId);
     }
 
     @Test(dependsOnMethods = {"testGetMetaOutboundConnector"})

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/AuthenticationType.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/AuthenticationType.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class AuthenticationType  {
+
+
+    @XmlType(name="TypeEnum")
+    @XmlEnum(String.class)
+    public enum TypeEnum {
+
+        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+
+
+        private String value;
+
+        TypeEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static TypeEnum fromValue(String value) {
+            for (TypeEnum b : TypeEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private TypeEnum type;
+    private Map<String, Object> properties = new HashMap<>();
+
+
+    /**
+     **/
+    public AuthenticationType type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+
+    @ApiModelProperty(example = "BASIC", required = true, value = "")
+    @JsonProperty("type")
+    @Valid
+    @NotNull(message = "Property type cannot be null.")
+
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+     **/
+    public AuthenticationType properties(Map<String, Object> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+
+    @ApiModelProperty(example = "{\"username\":\"auth_username\",\"password\":\"auth_password\"}", required = true, value = "")
+    @JsonProperty("properties")
+    @Valid
+    @NotNull(message = "Property properties cannot be null.")
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+
+    public AuthenticationType putPropertiesItem(String key, Object propertiesItem) {
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AuthenticationType authenticationType = (AuthenticationType) o;
+        return Objects.equals(this.type, authenticationType.type) &&
+                Objects.equals(this.properties, authenticationType.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AuthenticationType {\n");
+
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Endpoint.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/Endpoint.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+import java.util.Objects;
+
+public class Endpoint  {
+
+    private String uri;
+    private AuthenticationType authentication;
+
+    /**
+     **/
+    public Endpoint uri(String uri) {
+
+        this.uri = uri;
+        return this;
+    }
+
+    @ApiModelProperty(example = "https://abc.com/token", value = "")
+    @JsonProperty("uri")
+    @Valid
+    @Pattern(regexp="^https?://.+")
+    public String getUri() {
+        return uri;
+    }
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+     **/
+    public Endpoint authentication(AuthenticationType authentication) {
+
+        this.authentication = authentication;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("authentication")
+    @Valid
+    public AuthenticationType getAuthentication() {
+        return authentication;
+    }
+    public void setAuthentication(AuthenticationType authentication) {
+        this.authentication = authentication;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Endpoint endpoint = (Endpoint) o;
+        return Objects.equals(this.uri, endpoint.uri) &&
+                Objects.equals(this.authentication, endpoint.authentication);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, authentication);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Endpoint {\n");
+
+        sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
+        sb.append("    authentication: ").append(toIndentedString(authentication)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/FederatedAuthenticatorRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/FederatedAuthenticatorRequest.java
@@ -23,6 +23,9 @@ import io.swagger.annotations.ApiModelProperty;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 
 import javax.validation.Valid;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -107,6 +110,38 @@ public class FederatedAuthenticatorRequest {
                 "}";
     }
 
+    @XmlType(name="DefinedByEnum")
+    @XmlEnum(String.class)
+    public enum DefinedByEnum {
+
+        @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+        private String value;
+
+        DefinedByEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static DefinedByEnum fromValue(String value) {
+            for (DefinedByEnum b : DefinedByEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
     /**
      * Convert the given object to string with each line indented by 4 spaces
      * (except the first line).
@@ -125,6 +160,8 @@ public class FederatedAuthenticatorRequest {
         private Boolean isEnabled = false;
         private Boolean isDefault = false;
         private List<Property> properties = null;
+        private DefinedByEnum definedBy;
+        private Endpoint endpoint;
 
         /**
          *
@@ -234,16 +271,63 @@ public class FederatedAuthenticatorRequest {
             return this;
         }
 
+        /**
+         *
+         **/
+        public FederatedAuthenticator definedBy(DefinedByEnum definedBy) {
+
+            this.definedBy = definedBy;
+            return this;
+        }
+
+        @ApiModelProperty(value = "")
+        @JsonProperty("definedBy")
+        @Valid
+        public DefinedByEnum getDefinedBy() {
+            return definedBy;
+        }
+        public void setDefinedBy(DefinedByEnum definedBy) {
+            this.definedBy = definedBy;
+        }
+
+        /**
+         **/
+        public FederatedAuthenticator endpoint(Endpoint endpoint) {
+
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        @ApiModelProperty(value = "")
+        @JsonProperty("endpoint")
+        @Valid
+        public Endpoint getEndpoint() {
+            return endpoint;
+        }
+        public void setEndpoint(Endpoint endpoint) {
+            this.endpoint = endpoint;
+        }
+
         @Override
         public String toString() {
 
-            return "class FederatedAuthenticator {\n" +
+            String classToString = "class FederatedAuthenticator {\n" +
                     "    authenticatorId: " + toIndentedString(authenticatorId) + "\n" +
                     "    name: " + toIndentedString(name) + "\n" +
                     "    isEnabled: " + toIndentedString(isEnabled) + "\n" +
-                    "    isDefault: " + toIndentedString(isDefault) + "\n" +
-                    "    properties: " + toIndentedString(properties) + "\n" +
-                    "}";
+
+                    "    isDefault: " + toIndentedString(isDefault) + "\n";
+            if (properties != null) {
+                classToString += "    properties: " + toIndentedString(properties) + "\n";
+            }
+            if (definedBy != null) {
+                classToString += "    definedBy: " + toIndentedString(definedBy) + "\n";
+            }
+            if (endpoint != null) {
+                classToString += "    endpoint: " + toIndentedString(endpoint) + "\n";
+            }
+
+            return classToString + "}";
         }
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/util/UserDefinedAuthenticatorPayload.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/util/UserDefinedAuthenticatorPayload.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.idp.v1.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Endpoint;
+
+public class UserDefinedAuthenticatorPayload {
+
+    @JsonProperty("isEnabled")
+    private Boolean isEnabled;
+
+    @JsonProperty("authenticatorId")
+    private String authenticatorId;
+
+    @JsonProperty("definedBy")
+    private String definedBy;
+
+    @JsonProperty("endpoint")
+    private Endpoint endpoint;
+
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    public String getAuthenticatorId() {
+        return authenticatorId;
+    }
+
+    public void setAuthenticatorId(String authenticatorId) {
+        this.authenticatorId = authenticatorId;
+    }
+
+    public String getDefinedBy() {
+        return definedBy;
+    }
+
+    public void setDefinedBy(String definedBy) {
+        this.definedBy = definedBy;
+    }
+
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String convertToJasonPayload() throws JsonProcessingException {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(this);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/idp/v1/add-idp-with-custom-fed-auth.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/idp/v1/add-idp-with-custom-fed-auth.json
@@ -1,0 +1,38 @@
+{
+  "name": "Custom Auth IDP",
+  "description": "IdP with user defined federated authenticator",
+  "image": "https://example.com/image",
+  "isPrimary": false,
+  "isFederationHub": false,
+  "homeRealmIdentifier": "localhost",
+  "alias": "https://localhost:9444/oauth2/token",
+  "claims": {
+    "userIdClaim": {
+      "uri": "http://wso2.org/claims/username"
+    },
+    "roleClaim": {
+      "uri": "http://wso2.org/claims/role"
+    },
+    "provisioningClaims": [
+      {
+        "claim": {
+          "uri": "http://wso2.org/claims/username"
+        },
+        "defaultValue": "sathya"
+      }
+    ]
+  },
+  "federatedAuthenticators": {
+    "defaultAuthenticatorId": "<FEDERATED_AUTHENTICATOR_ID>",
+    "authenticators": [
+      "<FEDERATED_AUTHENTICATOR>"
+    ]
+  },
+  "provisioning": {
+    "jit": {
+      "isEnabled": true,
+      "scheme": "PROVISION_SILENTLY",
+      "userstore": "PRIMARY"
+    }
+  }
+}


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/21216

Add integration tests for managing user defined federated authenticators.

Related PRs:
- https://github.com/wso2/identity-api-server/pull/734
- https://github.com/wso2/carbon-identity-framework/pull/6105