### PR TITLE
Improve user update integration test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
@@ -87,7 +87,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI =
             MANAGER_CLAIM_ATTRIBUTE_URI + "." + MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME;
     private static final String MANAGER_LOCAL_CLAIM_URI = "http://wso2.org/claims/manager";
-    private static final String MANAGER_EMAIL_LOCAL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
+    private static final String MANAGER_EMAIL_LOCAL_CLAIM_URI = "http://wso2.org/claims/emails.work";
     private static final String MANAGER_EMAIL_LOCAL_CLAIM_VALUE = "piraveena@gmail.com";
     private static final String MANAGER_EMAIL_LOCAL_CLAIM_VALUE_AFTER_REPLACE = "piraveenaReplace@gmail.com";
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
@@ -88,7 +88,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI =
             MANAGER_CLAIM_ATTRIBUTE_URI + "." + MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME;
     private static final String MANAGER_LOCAL_CLAIM_URI = "http://wso2.org/claims/manager";
-    private static final String MANAGER_EMAIL_LOCAL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
+    private static final String MANAGER_EMAIL_LOCAL_CLAIM_URI = "http://wso2.org/claims/emails.work";
     private static final String MANAGER_EMAIL_LOCAL_CLAIM_VALUE = "piraveena@gmail.com";
     private static final String MANAGER_EMAIL_LOCAL_CLAIM_VALUE_AFTER_REPLACE = "piraveenaReplace@gmail.com";
     private static final String MANAGER_EMAIL_LOCAL_CLAIM_VALUE_AFTER_ADD = "piraveenaAdd@gmail.com";


### PR DESCRIPTION
### Purpose

Ideally, SCIM attributes in all SCIM dialects should be mapped to distinct local claims. This constraint is not enforced in the backend but validated in the front end. The existing validation in the backend is to prevent two attributes in the same dialect being mapped to a single local claim.

When two SCIM attributes in two dialects are mapped to the same local claim, several problems arise. Among them, one problem is when one user attribute is set and the user is retrieved, both the SCIM attributes are seen to be set to the same value. Also, when the user is updated with distinct values for the two SCIM attributes, finally, only one value is stored against the local claim. This causes one SCIM attribute to appear as not updated correctly.

This PR changes the claim mapping such that no two SCIM claims are mapped to the same local claim, in the context of the affected tests.

