### PR TITLE
Update framework, notification template versions and add default unicode support config

### DIFF
--- a/modules/distribution/src/repository/resources/conf/deployment.toml
+++ b/modules/distribution/src/repository/resources/conf/deployment.toml
@@ -39,6 +39,9 @@ hash= "66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"
 [identity.auth_framework.endpoint]
 app_password= "dashboard"
 
+[notification_templates]
+enable_unicode_support = true
+
 # The KeyStore which is used for encrypting/decrypting internal data. By default the primary keystore is used as the internal keystore.
 
 #[keystore.internal]

--- a/pom.xml
+++ b/pom.xml
@@ -2365,7 +2365,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.6.16</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.6.17</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2407,7 +2407,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.9.13</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.9.23</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.9.24</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
$subject. Onboarding the changes introduced with,
* https://github.com/wso2/carbon-identity-framework/pull/6142
* https://github.com/wso2-extensions/identity-event-handler-notification/pull/284
and enabling unicode support as the the default behavior.

Related to,
* https://github.com/wso2/product-is/issues/21235