### PR TITLE
Add unicode support config to email_otp_config.toml

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/email/email_otp_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/email/email_otp_config.toml
@@ -37,3 +37,6 @@ federatedEmailAttributeKey = "email"
 EmailOTPEnableByUserClaim = true
 CaptureAndUpdateEmailAddress = true
 showEmailAddressInUI = true
+
+[notification_templates]
+enable_unicode_support = true


### PR DESCRIPTION
$subject to avoid EmailOTPTestCase failing when using outdated config which got outdated from https://github.com/wso2/product-is/pull/21784. 

https://github.com/wso2/product-is/pull/21784#issuecomment-2491683475