### PR TITLE
Add unicode support config to enable_email_username_deployment.toml

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/user/enable_email_username_deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/user/enable_email_username_deployment.toml
@@ -47,3 +47,6 @@ enable_email_domain = true
 
 [identity_mgt.events.schemes.liteUserRegistration.properties]
 enable = true
+
+[notification_templates]
+enable_unicode_support = true


### PR DESCRIPTION
$subject to avoid LiteUserRegisterTestCase failing when using outdated config which got outdated from https://github.com/wso2/product-is/pull/21784. 

https://github.com/wso2/product-is/pull/21784#issuecomment-2491683475