### PR TITLE
Remove playground.appone and playground.apptwo apps

### DIFF
--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -459,19 +459,6 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>packaging-war-artifacts-oidc</id>
-                        <phase>process-test-resources</phase>
-                        <configuration>
-                            <tasks>
-                                <ant antfile="src/test/resources/artifacts/IS/oidc/oidc-sso-app-build.xml" target="playground.appone-app-build" />
-                                <ant antfile="src/test/resources/artifacts/IS/oidc/oidc-sso-app-build.xml" target="playground.apptwo-app-build" />
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>packaging-war-artifacts-passivests</id>
                         <phase>process-test-resources</phase>
                         <configuration>

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
@@ -39,7 +39,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.base.MockSMSProvider;
 import org.wso2.identity.integration.test.oidc.OIDCAbstractIntegrationTest;
 import org.wso2.identity.integration.test.oidc.OIDCUtilTest;
@@ -90,7 +90,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
     private String authorizationCode;
 
     private MockSMSProvider mockSMSProvider;
-    private MockClientCallback mockClientCallback;
+    private MockApplicationServer mockApplicationServer;
 
     private TestUserMode userMode;
 
@@ -116,8 +116,8 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         mockSMSProvider = new MockSMSProvider();
         mockSMSProvider.start();
 
-        mockClientCallback = new MockClientCallback();
-        mockClientCallback.start();
+        mockApplicationServer = new MockApplicationServer();
+        mockApplicationServer.start();
 
         super.init();
 
@@ -170,7 +170,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         scim2RestClient.closeHttpClient();
 
         mockSMSProvider.stop();
-        mockClientCallback.stop();
+        mockApplicationServer.stop();
     }
 
     @Test(groups = "wso2.is", description = "Test passwordless authentication with SMS OTP")
@@ -189,7 +189,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("client_id", oidcApplication.getClientId()));
-        urlParameters.add(new BasicNameValuePair("redirect_uri", MockClientCallback.CALLBACK_URL_APP1));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", oidcApplication.getCallBackURL()));
 
         urlParameters.add(new BasicNameValuePair("scope", "openid"));
 
@@ -212,7 +212,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         HttpResponse response = sendLoginPostForOtp(client, sessionDataKey, mockSMSProvider.getOTP());
         EntityUtils.consume(response.getEntity());
 
-        authorizationCode = mockClientCallback.getAuthorizationCode();
+        authorizationCode = mockApplicationServer.getAuthorizationCodeForApp(oidcApplication.getApplicationName());
         assertNotNull(authorizationCode);
     }
 
@@ -241,7 +241,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("code", authorizationCode));
         urlParameters.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
-        urlParameters.add(new BasicNameValuePair("redirect_uri", MockClientCallback.CALLBACK_URL_APP1));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", oidcApplication.getCallBackURL()));
         urlParameters.add(new BasicNameValuePair("client_id", oidcApplication.getClientSecret()));
 
         urlParameters.add(new BasicNameValuePair("scope", "openid"));
@@ -259,9 +259,9 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
 
     private OIDCApplication initOIDCApplication() {
 
-        OIDCApplication playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppOneAppName,
+        OIDCApplication playgroundApp = new OIDCApplication(MockApplicationServer.Constants.APP1.NAME,
                 OIDCUtilTest.playgroundAppOneAppContext,
-                MockClientCallback.CALLBACK_URL_APP1);
+                MockApplicationServer.Constants.APP1.CALLBACK_URL);
         return playgroundApp;
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
@@ -189,7 +189,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("client_id", oidcApplication.getClientId()));
-        urlParameters.add(new BasicNameValuePair("redirect_uri", MockClientCallback.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", MockClientCallback.CALLBACK_URL_APP1));
 
         urlParameters.add(new BasicNameValuePair("scope", "openid"));
 
@@ -241,7 +241,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("code", authorizationCode));
         urlParameters.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
-        urlParameters.add(new BasicNameValuePair("redirect_uri", MockClientCallback.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", MockClientCallback.CALLBACK_URL_APP1));
         urlParameters.add(new BasicNameValuePair("client_id", oidcApplication.getClientSecret()));
 
         urlParameters.add(new BasicNameValuePair("scope", "openid"));
@@ -261,7 +261,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
 
         OIDCApplication playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppOneAppName,
                 OIDCUtilTest.playgroundAppOneAppContext,
-                MockClientCallback.CALLBACK_URL);
+                MockClientCallback.CALLBACK_URL_APP1);
         return playgroundApp;
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
@@ -260,7 +260,6 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
     private OIDCApplication initOIDCApplication() {
 
         OIDCApplication playgroundApp = new OIDCApplication(MockApplicationServer.Constants.APP1.NAME,
-                OIDCUtilTest.playgroundAppOneAppContext,
                 MockApplicationServer.Constants.APP1.CALLBACK_URL);
         return playgroundApp;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/SecondaryStoreUserLoginTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/SecondaryStoreUserLoginTestCase.java
@@ -208,7 +208,7 @@ public class SecondaryStoreUserLoginTestCase extends OIDCAbstractIntegrationTest
 
     private void createAndRegisterPlaygroundApplication() throws Exception {
 
-        playgroundApp = new OIDCApplication(PLAYGROUND_APP_NAME, PLAYGROUND_APP_CONTEXT, PLAYGROUND_APP_CALLBACK_URI);
+        playgroundApp = new OIDCApplication(PLAYGROUND_APP_NAME, PLAYGROUND_APP_CALLBACK_URI);
         playgroundApp.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.lastNameClaimUri);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/MockApplicationServer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/MockApplicationServer.java
@@ -41,11 +41,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 /**
- * Mock client callback endpoint to test OIDC related flows.
+ * Mock application server to test OIDC related flows.
  */
 public class MockApplicationServer {
 
-    public class MockClient {
+    public static class MockClient {
         private final AtomicReference<String> authorizationCode = new AtomicReference<>();
         private final AtomicReference<String> errorCode = new AtomicReference<>();
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/TomcatInitializerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/TomcatInitializerTestCase.java
@@ -43,8 +43,6 @@ public class TomcatInitializerTestCase extends ISIntegrationTest {
             "travelocity.com-registrymount",
             "avis.com",
             "PassiveSTSSampleApp",
-            "playground.appone",
-            "playground.apptwo",
             "playground2"
     };
     private static final Log LOG = LogFactory.getLog(TomcatInitializerTestCase.class);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenExchangeGrantTypeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenExchangeGrantTypeTestCase.java
@@ -566,8 +566,7 @@ public class OAuth2TokenExchangeGrantTypeTestCase extends AbstractIdentityFedera
     private void updateServiceProviderWithOIDCConfigs(int portOffset, String applicationName,
                                                       ServiceProvider serviceProvider) throws Exception {
 
-        OIDCApplication application = new OIDCApplication(applicationName, "/" + applicationName,
-                OAuth2Constant.CALLBACK_URL);
+        OIDCApplication application = new OIDCApplication(applicationName, OAuth2Constant.CALLBACK_URL);
 
         OAuthConsumerAppDTO appDTO = getOAuthConsumerAppDTO(application);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAbstractIntegrationTest.java
@@ -20,13 +20,11 @@ package org.wso2.identity.integration.test.oidc;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
+import org.apache.http.message.BasicNameValuePair;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
@@ -52,6 +50,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
 
 /**
  * This class defines basic functionality needed to initiate an OIDC test.
@@ -188,28 +188,19 @@ public class OIDCAbstractIntegrationTest extends OAuth2ServiceAbstractIntegratio
                                               HttpClient client, CookieStore cookieStore)
             throws Exception {
 
-        List<NameValuePair> urlParameters = OIDCUtilTest.getNameValuePairs(application,
-                getTenantQualifiedURL(OAuth2Constant.APPROVAL_URL, tenantInfo.getDomain()));
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("client_id", application.getClientId()));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", application.getCallBackURL()));
 
-        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, String.format
-                (OIDCUtilTest.targetApplicationUrl, application.getApplicationContext() + OAuth2Constant.PlaygroundAppPaths
-                        .appUserAuthorizePath));
+        urlParameters.add(new BasicNameValuePair("scope", "openid"));
 
-        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
-        EntityUtils.consume(response.getEntity());
-
-        if (isFirstAuthenticationRequest) {
-            response = sendGetRequest(client, locationHeader.getValue());
-        } else {
-            HttpClient httpClientWithoutAutoRedirections = HttpClientBuilder.create().disableRedirectHandling()
-                    .setDefaultCookieStore(cookieStore).build();
-            response = sendGetRequest(httpClientWithoutAutoRedirections, locationHeader.getValue());
-        }
+        HttpResponse response = sendPostRequestWithParameters(client, urlParameters,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
 
         Map<String, Integer> keyPositionMap = new HashMap<>(1);
         if (isFirstAuthenticationRequest) {
             OIDCUtilTest.setSessionDataKey(response, keyPositionMap);
-
         } else {
             Assert.assertFalse(Utils.requestMissingClaims(response));
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAuthCodeGrantSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAuthCodeGrantSSOTestCase.java
@@ -41,7 +41,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
@@ -51,7 +51,6 @@ import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.ArrayList;
@@ -83,7 +82,7 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
     protected RequestConfig requestConfig;
     protected HttpClient client;
     protected List<NameValuePair> consentParameters = new ArrayList<>();
-    private MockClientCallback mockClientCallback;
+    private MockApplicationServer mockApplicationServer;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -108,8 +107,8 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
                 .setDefaultCookieStore(cookieStore)
                 .build();
 
-        mockClientCallback = new MockClientCallback();
-        mockClientCallback.start();
+        mockApplicationServer = new MockApplicationServer();
+        mockApplicationServer.start();
 
     }
 
@@ -119,7 +118,7 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
         deleteUser(user);
         deleteApplications();
         clear();
-        mockClientCallback.stop();
+        mockApplicationServer.stop();
     }
 
     @Test(groups = "wso2.is", description = "Test authz endpoint before creating a valid session")
@@ -136,7 +135,7 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
         HttpResponse httpResponse = sendGetRequest(client, uri.toString());
 
         EntityUtils.consume(httpResponse.getEntity());
-        Assert.assertTrue(mockClientCallback.getErrorCode().contains("login_required"));
+        Assert.assertTrue(mockApplicationServer.getErrorCode(application.getApplicationName()).contains("login_required"));
     }
 
     @Test(groups = "wso2.is", description = "Initiate authentication request from playground.appone",
@@ -314,7 +313,7 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
         Assert.assertNotNull(response, "Authorization code response is invalid for "
                 + application.getApplicationName());
 
-        authorizationCode = mockClientCallback.getAuthorizationCode();
+        authorizationCode = mockApplicationServer.getAuthorizationCodeForApp(application.getApplicationName());
         Assert.assertNotNull(authorizationCode, "Authorization code not received for " + application
                 .getApplicationName());
         EntityUtils.consume(response.getEntity());

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAuthCodeGrantSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCAuthCodeGrantSSOTestCase.java
@@ -381,14 +381,13 @@ public class OIDCAuthCodeGrantSSOTestCase extends OIDCAbstractIntegrationTest {
     protected void initApplications() throws Exception {
 
         OIDCApplication playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppOneAppName,
-                OIDCUtilTest.playgroundAppOneAppContext,
                 OIDCUtilTest.playgroundAppOneAppCallBackUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.lastNameClaimUri);
         applications.put(OIDCUtilTest.playgroundAppOneAppName, playgroundApp);
 
-        playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppTwoAppName, OIDCUtilTest.playgroundAppTwoAppContext,
+        playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppTwoAppName,
                 OIDCUtilTest.playgroundAppTwoAppCallBackUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCRPInitiatedLogoutTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCRPInitiatedLogoutTestCase.java
@@ -32,7 +32,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
@@ -65,7 +65,7 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
     protected List<NameValuePair> consentParameters = new ArrayList<>();
     OIDCApplication playgroundAppOne;
     OIDCApplication playgroundAppTwo;
-    private MockClientCallback mockClientCallback;
+    private MockApplicationServer mockApplicationServer;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -93,8 +93,8 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
                 .setDefaultRequestConfig(requestConfig)
                 .build();
 
-        mockClientCallback = new MockClientCallback();
-        mockClientCallback.start();
+        mockApplicationServer = new MockApplicationServer();
+        mockApplicationServer.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -104,7 +104,7 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
         deleteApplication(playgroundAppOne);
         deleteApplication(playgroundAppTwo);
         clear();
-        mockClientCallback.stop();
+        mockApplicationServer.stop();
     }
 
     @AfterMethod
@@ -206,7 +206,8 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
             sessionDataKeyConsent = keyValues.get(0).getValue();
             Assert.assertNotNull(sessionDataKeyConsent, "sessionDataKeyConsent is null.");
         } else {
-            authorizationCode = new AuthorizationCode(mockClientCallback.getAuthorizationCode());
+            authorizationCode = new AuthorizationCode(
+                    mockApplicationServer.getAuthorizationCodeForApp(application.getApplicationName()));
             Assert.assertNotNull(authorizationCode, "Authorization code not received for " + application
                     .getApplicationName());
         }
@@ -225,7 +226,8 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
         EntityUtils.consume(response.getEntity());
 
         response = sendPostRequest(client, locationHeader.getValue());
-        authorizationCode = new AuthorizationCode(mockClientCallback.getAuthorizationCode());
+        authorizationCode = new AuthorizationCode(
+                mockApplicationServer.getAuthorizationCodeForApp(application.getApplicationName()));
         Assert.assertNotNull(authorizationCode, "Authorization code not received for " + application
                 .getApplicationName());
         EntityUtils.consume(response.getEntity());
@@ -291,7 +293,7 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
                         + "post logout redirect url");
                 response = sendGetRequest(client, redirectUrl);
                 EntityUtils.consume(response.getEntity());
-                mockClientCallback.verifyForLogoutRedirectionForApp1();
+                mockApplicationServer.verifyLogoutRedirectionForApp(application.getApplicationName());
             } else {
                 Assert.assertTrue(redirectUrl.contains("oauth2_error.do"));
             }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCRPInitiatedLogoutTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCRPInitiatedLogoutTestCase.java
@@ -314,7 +314,6 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
     protected OIDCApplication initApplicationOne() {
 
         playgroundAppOne = new OIDCApplication(OIDCUtilTest.playgroundAppOneAppName,
-                OIDCUtilTest.playgroundAppOneAppContext,
                 OIDCUtilTest.playgroundAppOneAppCallBackUri);
         playgroundAppOne.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundAppOne.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);
@@ -324,7 +323,6 @@ public class OIDCRPInitiatedLogoutTestCase extends OIDCAbstractIntegrationTest {
     protected OIDCApplication initApplicationTwo() {
 
         playgroundAppTwo = new OIDCApplication(OIDCUtilTest.playgroundAppTwoAppName,
-                OIDCUtilTest.playgroundAppTwoAppContext,
                 OIDCUtilTest.playgroundAppTwoAppCallBackUri);
         playgroundAppOne.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundAppOne.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSPWiseSkipLoginConsentTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSPWiseSkipLoginConsentTestCase.java
@@ -30,7 +30,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
@@ -47,7 +47,7 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
     private CookieStore cookieStore = new BasicCookieStore();
     protected String sessionDataKey;
     protected String sessionDataKeyConsent;
-    private MockClientCallback mockClientCallback;
+    private MockApplicationServer mockApplicationServer;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -60,8 +60,8 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
         configureSPToSkipConsent();
         client = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
 
-        mockClientCallback = new MockClientCallback();
-        mockClientCallback.start();
+        mockApplicationServer = new MockApplicationServer();
+        mockApplicationServer.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -69,7 +69,7 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
 
         deleteObjects();
         clear();
-        mockClientCallback.stop();
+        mockApplicationServer.stop();
     }
 
     private void deleteObjects() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSPWiseSkipLoginConsentTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSPWiseSkipLoginConsentTestCase.java
@@ -30,6 +30,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.base.MockClientCallback;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
@@ -46,6 +47,7 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
     private CookieStore cookieStore = new BasicCookieStore();
     protected String sessionDataKey;
     protected String sessionDataKeyConsent;
+    private MockClientCallback mockClientCallback;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -57,6 +59,9 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
         createApplications();
         configureSPToSkipConsent();
         client = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+
+        mockClientCallback = new MockClientCallback();
+        mockClientCallback.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -64,6 +69,7 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
 
         deleteObjects();
         clear();
+        mockClientCallback.stop();
     }
 
     private void deleteObjects() throws Exception {
@@ -83,16 +89,16 @@ public class OIDCSPWiseSkipLoginConsentTestCase extends OIDCAbstractIntegrationT
     @Test(groups = "wso2.is", description = "Test authz endpoint before creating a valid session")
     public void testCreateUserSession() throws Exception {
 
-        testSendAuthenticationRequest(OIDCUtilTest.applications.get(OIDCUtilTest.playgroundAppOneAppName), true, client,
-                cookieStore);
+        testSendAuthenticationRequest(OIDCUtilTest.applications.get(OIDCUtilTest.playgroundAppOneAppName), true,
+                client, cookieStore);
         testAuthentication();
     }
 
     @Test(groups = "wso2.is", description = "Initiate authentication request from playground.apptwo")
-    public void testIntiateLoginRequestForAlreadyLoggedUser() throws Exception {
+    public void testInitiateLoginRequestForAlreadyLoggedUser() throws Exception {
 
-        testSendAuthenticationRequest(OIDCUtilTest.applications.get(OIDCUtilTest.playgroundAppTwoAppName), false, client
-                , cookieStore);
+        testSendAuthenticationRequest(OIDCUtilTest.applications.get(OIDCUtilTest.playgroundAppTwoAppName), false,
+                client, cookieStore);
     }
 
     private void testAuthentication() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSSOConsentTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSSOConsentTestCase.java
@@ -31,9 +31,11 @@ import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
+import org.json.simple.JSONValue;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -41,6 +43,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.automation.engine.context.beans.User;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.identity.integration.test.base.MockClientCallback;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim;
@@ -55,8 +58,11 @@ import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -81,6 +87,7 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
     protected List<NameValuePair> consentParameters = new ArrayList<>();
     OIDCApplication playgroundApp;
     private String claimsToGetConsent;
+    private MockClientCallback mockClientCallback;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -105,6 +112,9 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
                 .setDefaultCookieSpecRegistry(cookieSpecRegistry)
                 .setDefaultRequestConfig(requestConfig)
                 .build();
+
+        mockClientCallback = new MockClientCallback();
+        mockClientCallback.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -113,6 +123,7 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
         deleteUser(user);
         deleteApplication(playgroundApp);
         clear();
+        mockClientCallback.stop();
     }
 
     @Test(groups = "wso2.is", description = "Test consent management after updating " +
@@ -140,17 +151,16 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
     public void testSendAuthenticationRequest(OIDCApplication application, HttpClient client)
             throws Exception {
 
-        List<NameValuePair> urlParameters = OIDCUtilTest.getNameValuePairs(application);
-        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, String.format
-                (OIDCUtilTest.targetApplicationUrl, application.getApplicationContext() +
-                        OAuth2Constant.PlaygroundAppPaths.appUserAuthorizePath));
-        Assert.assertNotNull(response, "Authorization request failed for " + application.getApplicationName() +
-                ". Authorized response is null.");
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("client_id", application.getClientId()));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", application.getCallBackURL()));
 
+        urlParameters.add(new BasicNameValuePair("scope", "openid email profile"));
+
+        HttpResponse response = sendPostRequestWithParameters(client, urlParameters,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
         Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
-
-        Assert.assertNotNull(locationHeader, "Authorization request failed for " +
-                application.getApplicationName() + ". Authorized response header is null.");
         EntityUtils.consume(response.getEntity());
 
         response = sendGetRequest(client, locationHeader.getValue());
@@ -222,53 +232,41 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
         EntityUtils.consume(response.getEntity());
 
         response = sendPostRequest(client, locationHeader.getValue());
-        Assert.assertNotNull(response, "Authorization code response is invalid for " +
-                application.getApplicationName());
+        EntityUtils.consume(response.getEntity());
 
-        Map<String, Integer> keyPositionMap = new HashMap<>(1);
-        keyPositionMap.put("Authorization Code", 1);
-        List<DataExtractUtil.KeyValue> keyValues = DataExtractUtil.extractTableRowDataFromResponse(response,
-                keyPositionMap);
-        Assert.assertNotNull(keyValues, "Authorization code not received for " +
-                application.getApplicationName());
-
-        authorizationCode = keyValues.get(0).getValue();
+        authorizationCode = mockClientCallback.getAuthorizationCode();
         Assert.assertNotNull(authorizationCode, "Authorization code not received for " + application
                 .getApplicationName());
-        EntityUtils.consume(response.getEntity());
     }
 
     private void testGetAccessToken(OIDCApplication application) throws Exception {
 
-        HttpResponse response = sendGetAccessTokenPost(client, application);
-        Assert.assertNotNull(response, "Access token response is invalid for " +
-                application.getApplicationName());
-        EntityUtils.consume(response.getEntity());
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("code", authorizationCode));
+        urlParameters.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", application.getCallBackURL()));
+        urlParameters.add(new BasicNameValuePair("client_id", application.getClientSecret()));
 
-        response = sendPostRequest(client, String.format(OIDCUtilTest.targetApplicationUrl,
-                application.getApplicationContext() + OAuth2Constant.PlaygroundAppPaths.appAuthorizePath));
+        urlParameters.add(new BasicNameValuePair("scope", "openid"));
 
-        Map<String, Integer> keyPositionMap = new HashMap<>(1);
-        keyPositionMap.put("name=\"accessToken\"", 1);
-        List<DataExtractUtil.KeyValue> keyValues = DataExtractUtil.extractInputValueFromResponse(response,
-                keyPositionMap);
-        Assert.assertNotNull(keyValues, "Access token not received for " + application.getApplicationName());
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER,
+                OAuth2Constant.BASIC_HEADER + " " + getBase64EncodedString(application.getClientId(),
+                        application.getClientSecret())));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
 
-        accessToken = keyValues.get(0).getValue();
-        Assert.assertNotNull(accessToken, "Access token not received for " + application.getApplicationName());
-        EntityUtils.consume(response.getEntity());
+        HttpResponse response = sendPostRequest(client, headers, urlParameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+        String responseString = EntityUtils.toString(response.getEntity());
+        Map<String, Object> responseMap = (Map<String, Object>) JSONValue.parse(responseString);
+        accessToken = (String) responseMap.get("access_token");
 
-        response = sendPostRequest(client, String.format(OIDCUtilTest.targetApplicationUrl,
-                application.getApplicationContext() + OAuth2Constant.PlaygroundAppPaths.appAuthorizePath));
-
-        keyPositionMap = new HashMap<>(1);
-        keyPositionMap.put("id=\"loggedUser\"", 1);
-        keyValues = DataExtractUtil.extractLabelValueFromResponse(response, keyPositionMap);
-        Assert.assertNotNull(keyValues, "No user logged in for " + application.getApplicationName());
-
-        String loggedUser = keyValues.get(0).getValue();
-        Assert.assertNotNull(loggedUser, "Logged user is null for " + application.getApplicationName());
-        EntityUtils.consume(response.getEntity());
+        String idToken = (String) responseMap.get("id_token");
+        String[] tokenParts = idToken.split("\\.");
+        String payload = new String(java.util.Base64.getUrlDecoder().decode(tokenParts[1]));
+        Map<String, Object> parsedIdToken = (Map<String, Object>) JSONValue.parse(payload);
+        Assert.assertNotNull(parsedIdToken.get("sub"), "No user logged in for " + application.getApplicationName());
     }
 
     protected void initUser() throws Exception {
@@ -304,19 +302,6 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
         claimConfig.addRequestedClaimsItem(requestedClaim);
 
         updateApplication(playgroundApp.getApplicationId(), new ApplicationPatchModel().claimConfiguration(claimConfig));
-    }
-
-    protected HttpResponse sendGetAccessTokenPost(HttpClient client, OIDCApplication application) throws IOException {
-
-        List<NameValuePair> urlParameters = new ArrayList<>();
-        urlParameters.add(new BasicNameValuePair("callbackurl", application.getCallBackURL()));
-        urlParameters.add(new BasicNameValuePair("accessEndpoint", OAuth2Constant.ACCESS_TOKEN_ENDPOINT));
-        urlParameters.add(new BasicNameValuePair("consumerSecret", application.getClientSecret()));
-        HttpResponse response = sendPostRequestWithParameters(client, urlParameters, String.format
-                (OIDCUtilTest.targetApplicationUrl, application.getApplicationContext() +
-                        OAuth2Constant.PlaygroundAppPaths.accessTokenRequestPath));
-
-        return response;
     }
 
     private void performOIDCLogout() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSSOConsentTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSSOConsentTestCase.java
@@ -43,7 +43,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.automation.engine.context.beans.User;
 import org.apache.commons.lang.StringUtils;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim;
@@ -87,7 +87,7 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
     protected List<NameValuePair> consentParameters = new ArrayList<>();
     OIDCApplication playgroundApp;
     private String claimsToGetConsent;
-    private MockClientCallback mockClientCallback;
+    private MockApplicationServer mockApplicationServer;
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
@@ -113,8 +113,8 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
                 .setDefaultRequestConfig(requestConfig)
                 .build();
 
-        mockClientCallback = new MockClientCallback();
-        mockClientCallback.start();
+        mockApplicationServer = new MockApplicationServer();
+        mockApplicationServer.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -123,7 +123,7 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
         deleteUser(user);
         deleteApplication(playgroundApp);
         clear();
-        mockClientCallback.stop();
+        mockApplicationServer.stop();
     }
 
     @Test(groups = "wso2.is", description = "Test consent management after updating " +
@@ -234,7 +234,7 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
         response = sendPostRequest(client, locationHeader.getValue());
         EntityUtils.consume(response.getEntity());
 
-        authorizationCode = mockClientCallback.getAuthorizationCode();
+        authorizationCode = mockApplicationServer.getAuthorizationCodeForApp(application.getApplicationName());
         Assert.assertNotNull(authorizationCode, "Authorization code not received for " + application
                 .getApplicationName());
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSSOConsentTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCSSOConsentTestCase.java
@@ -281,7 +281,6 @@ public class OIDCSSOConsentTestCase extends OIDCAbstractIntegrationTest {
     protected OIDCApplication initApplication() {
 
         playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppOneAppName,
-                OIDCUtilTest.playgroundAppOneAppContext,
                 OIDCUtilTest.playgroundAppOneAppCallBackUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
@@ -57,13 +57,9 @@ public class OIDCUtilTest {
 
     public static final String playgroundAppOneAppName = MockApplicationServer.Constants.APP1.NAME;
     public static final String playgroundAppOneAppCallBackUri = MockApplicationServer.Constants.APP1.CALLBACK_URL;
-    public static final String playgroundAppOneAppContext = "/playground.appone";
 
     public static final String playgroundAppTwoAppName = MockApplicationServer.Constants.APP2.NAME;
     public static final String playgroundAppTwoAppCallBackUri = MockApplicationServer.Constants.APP2.CALLBACK_URL;
-    public static final String playgroundAppTwoAppContext = "/playground.apptwo";
-
-    public static final String targetApplicationUrl = "http://localhost:" + TOMCAT_PORT + "%s";
 
     public static final String emailClaimUri = "http://wso2.org/claims/emailaddress";
     public static final String firstNameClaimUri = "http://wso2.org/claims/givenname";
@@ -86,14 +82,14 @@ public class OIDCUtilTest {
      */
     public static void initApplications() {
 
-        OIDCApplication playgroundApp = new OIDCApplication(playgroundAppOneAppName, playgroundAppOneAppContext,
+        OIDCApplication playgroundApp = new OIDCApplication(playgroundAppOneAppName,
                 playgroundAppOneAppCallBackUri);
         playgroundApp.addRequiredClaim(emailClaimUri);
         playgroundApp.addRequiredClaim(firstNameClaimUri);
         playgroundApp.addRequiredClaim(lastNameClaimUri);
         applications.put(playgroundAppOneAppName, playgroundApp);
 
-        playgroundApp = new OIDCApplication(playgroundAppTwoAppName, playgroundAppTwoAppContext,
+        playgroundApp = new OIDCApplication(playgroundAppTwoAppName,
                 playgroundAppTwoAppCallBackUri);
         playgroundApp.addRequiredClaim(emailClaimUri);
         playgroundApp.addRequiredClaim(firstNameClaimUri);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
@@ -22,6 +22,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.wso2.identity.integration.test.base.MockClientCallback;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
@@ -55,13 +56,14 @@ public class OIDCUtilTest {
     protected static String sessionDataKey;
 
     public static final String playgroundAppOneAppName = "playground.appone";
-    public static final String playgroundAppOneAppCallBackUri = "http://localhost:" + TOMCAT_PORT + "/playground" + "" +
-            ".appone/oauth2client";
+    public static final String playgroundAppOneAppCallBackUri = MockClientCallback.CALLBACK_URL_APP1;
+
+    // TODO find the usages to identify the test cases that initiate the login from the app, instead of sending the
+    //  login request directly to IS.
     public static final String playgroundAppOneAppContext = "/playground.appone";
 
     public static final String playgroundAppTwoAppName = "playground.apptwo";
-    public static final String playgroundAppTwoAppCallBackUri = "http://localhost:" + TOMCAT_PORT + "/playground" + "" +
-            ".apptwo/oauth2client";
+    public static final String playgroundAppTwoAppCallBackUri = MockClientCallback.CALLBACK_URL_APP2;
     public static final String playgroundAppTwoAppContext = "/playground.apptwo";
 
     public static final String targetApplicationUrl = "http://localhost:" + TOMCAT_PORT + "%s";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/OIDCUtilTest.java
@@ -22,7 +22,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.message.BasicNameValuePair;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
@@ -55,15 +55,12 @@ public class OIDCUtilTest {
     public static final String profile = "default";
     protected static String sessionDataKey;
 
-    public static final String playgroundAppOneAppName = "playground.appone";
-    public static final String playgroundAppOneAppCallBackUri = MockClientCallback.CALLBACK_URL_APP1;
-
-    // TODO find the usages to identify the test cases that initiate the login from the app, instead of sending the
-    //  login request directly to IS.
+    public static final String playgroundAppOneAppName = MockApplicationServer.Constants.APP1.NAME;
+    public static final String playgroundAppOneAppCallBackUri = MockApplicationServer.Constants.APP1.CALLBACK_URL;
     public static final String playgroundAppOneAppContext = "/playground.appone";
 
-    public static final String playgroundAppTwoAppName = "playground.apptwo";
-    public static final String playgroundAppTwoAppCallBackUri = MockClientCallback.CALLBACK_URL_APP2;
+    public static final String playgroundAppTwoAppName = MockApplicationServer.Constants.APP2.NAME;
+    public static final String playgroundAppTwoAppCallBackUri = MockApplicationServer.Constants.APP2.CALLBACK_URL;
     public static final String playgroundAppTwoAppContext = "/playground.apptwo";
 
     public static final String targetApplicationUrl = "http://localhost:" + TOMCAT_PORT + "%s";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/bean/OIDCApplication.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oidc/bean/OIDCApplication.java
@@ -27,7 +27,6 @@ public class OIDCApplication {
     private String applicationName;
     private String clientId;
     private String clientSecret;
-    private String applicationContext;
     private String callBackURL;
     private String subjectClaimURI;
     private List<String> requiredClaims = null;
@@ -36,9 +35,8 @@ public class OIDCApplication {
 
     }
 
-    public OIDCApplication(String applicationName, String applicationContext, String callBackURL) {
+    public OIDCApplication(String applicationName, String callBackURL) {
         this.applicationName = applicationName;
-        this.applicationContext = applicationContext;
         this.callBackURL = callBackURL;
     }
 
@@ -72,14 +70,6 @@ public class OIDCApplication {
 
     public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
-    }
-
-    public String getApplicationContext() {
-        return applicationContext;
-    }
-
-    public void setApplicationContext(String applicationContext) {
-        this.applicationContext = applicationContext;
     }
 
     public String getCallBackURL() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/PasswordRecoveryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/PasswordRecoveryTestCase.java
@@ -43,7 +43,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.identity.integration.test.base.MockClientCallback;
+import org.wso2.identity.integration.test.base.MockApplicationServer;
 import org.wso2.identity.integration.test.oidc.OIDCAbstractIntegrationTest;
 import org.wso2.identity.integration.test.oidc.OIDCUtilTest;
 import org.wso2.identity.integration.test.oidc.bean.OIDCApplication;
@@ -75,7 +75,7 @@ public class PasswordRecoveryTestCase extends OIDCAbstractIntegrationTest {
     private CloseableHttpClient client;
     private OIDCApplication oidcApplication;
     private UserObject userObject;
-    private MockClientCallback mockClientCallback;
+    private MockApplicationServer mockApplicationServer;
 
     public static final String USERNAME = "recoverytestuser";
     public static final String PASSWORD = "Oidcsessiontestuser@123";
@@ -108,8 +108,8 @@ public class PasswordRecoveryTestCase extends OIDCAbstractIntegrationTest {
         userObject = initUser();
         createUser(userObject);
 
-        mockClientCallback = new MockClientCallback();
-        mockClientCallback.start();
+        mockApplicationServer = new MockApplicationServer();
+        mockApplicationServer.start();
     }
 
     @AfterClass(alwaysRun = true)
@@ -121,7 +121,7 @@ public class PasswordRecoveryTestCase extends OIDCAbstractIntegrationTest {
         identityGovernanceRestClient.closeHttpClient();
         client.close();
         Utils.getMailServer().purgeEmailFromAllMailboxes();
-        mockClientCallback.stop();
+        mockApplicationServer.stop();
     }
 
     @Test

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/PasswordRecoveryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/PasswordRecoveryTestCase.java
@@ -201,7 +201,6 @@ public class PasswordRecoveryTestCase extends OIDCAbstractIntegrationTest {
     private OIDCApplication initApplication() {
 
         OIDCApplication playgroundApp = new OIDCApplication(OIDCUtilTest.playgroundAppOneAppName,
-                OIDCUtilTest.playgroundAppOneAppContext,
                 OIDCUtilTest.playgroundAppOneAppCallBackUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.emailClaimUri);
         playgroundApp.addRequiredClaim(OIDCUtilTest.firstNameClaimUri);


### PR DESCRIPTION
Removing the 2 samples apps named playground.appone and playground.apptwo deployed testing OIDC related flows.