### PR TITLE
Bump carbon.identity.framework.version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2344,7 +2344,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.15</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.16</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Bump framework verion to 7.7.16

Related PR:
- https://github.com/wso2/carbon-identity-framework/pull/6105