### PR TITLE
Exclude multiple emails and mobiles related claims from ReadWriteLDAPUserStoreManagerTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/ReadWriteLDAPUserStoreManagerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/mgt/ReadWriteLDAPUserStoreManagerTestCase.java
@@ -21,11 +21,19 @@ package org.wso2.identity.integration.test.user.mgt;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 
-import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
 
 public class ReadWriteLDAPUserStoreManagerTestCase extends UserManagementServiceAbstractTest {
+
+    // These attributes are not supported by the default LDAP schema.
+    private static final Set<String> UNSUPPORTED_CLAIMS = new HashSet<>(Arrays.asList(
+            "http://wso2.org/claims/emailAddresses",
+            "http://wso2.org/claims/verifiedEmailAddresses",
+            "http://wso2.org/claims/mobileNumbers",
+            "http://wso2.org/claims/verifiedMobileNumbers"));
 
     @BeforeClass(alwaysRun = true)
     public void configureServer() throws Exception {
@@ -51,6 +59,12 @@ public class ReadWriteLDAPUserStoreManagerTestCase extends UserManagementService
     @Override
     protected void setUserRole() {
        newUserRole = "ReadWriteLDAPUserRole";
+    }
+
+    @Override
+    protected Set<String> getExcludedClaims() {
+
+        return UNSUPPORTED_CLAIMS;
     }
 }
 


### PR DESCRIPTION
With multiple emails and mobile number support per user feature, we introduced following new attributes.
- http://wso2.org/claims/emailAddresses
- http://wso2.org/claims/verifiedEmailAddresses
- http://wso2.org/claims/mobileNumbers
- http://wso2.org/claims/verifiedMobileNumbers

These attributes are not supported in the default LDAP schema. Therefore, they need to be excluded from the ReadWriteLDAPUserStoreManagerTestCase to prevent test failures.

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6157