### PR TITLE
Upgrade dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2484,9 +2484,9 @@
         <carbon.deployment.version>4.12.30</carbon.deployment.version>
         <carbon.commons.version>4.10.13</carbon.commons.version>
         <carbon.registry.version>4.8.39</carbon.registry.version>
-        <carbon.multitenancy.version>4.11.29</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.11.31</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
-        <carbon.analytics-common.version>5.2.60</carbon.analytics-common.version>
+        <carbon.analytics-common.version>5.2.61</carbon.analytics-common.version>
         <carbon.dashboards.version>2.0.27</carbon.dashboards.version>
         <carbon.database.utils.version>2.2.2</carbon.database.utils.version>
         <carbon.healthcheck.version>1.3.0</carbon.healthcheck.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2440,7 +2440,7 @@
         <authenticator.local.auth.smsotp.version>1.0.11</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.1.2</authenticator.twitter.version>
         <authenticator.x509.version>3.1.24</authenticator.x509.version>
-        <identity.extension.utils>1.0.19</identity.extension.utils>
+        <identity.extension.utils>1.0.21</identity.extension.utils>
         <authenticator.auth.otp.commons.version>1.0.8</authenticator.auth.otp.commons.version>
 
         <identity.org.mgt.version>1.4.59</identity.org.mgt.version>


### PR DESCRIPTION
Upgrading the following dependency versions:

- identity.extension.utils version from `1.0.19` to `1.0.21`.
- carbon.multitenancy.version from `4.11.29` to `4.11.31`.
- carbon.analytics-common.version `5.2.60` to `5.2.61`.

Related issue
-  https://github.com/wso2/product-is/issues/21200