### PR TITLE
Add integration tests for /authenticator/meta/tags endpoint.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorSuccessTest.java
@@ -234,7 +234,7 @@ public class AuthenticatorSuccessTest extends AuthenticatorTestBase {
                         AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant)));
     }
 
-    @Test(dependsOnMethods = {"testUpdateUserDefinedLocalAuthenticator"})
+    @Test(dependsOnMethods = {"testValidateCustomTagInGetMetaTags", "testUpdateUserDefinedLocalAuthenticator"})
     public void testDeleteUserDefinedLocalAuthenticator() throws JsonProcessingException {
 
         Response response = getResponseOfDelete(AUTHENTICATOR_CUSTOM_API_BASE_PATH + PATH_SEPARATOR
@@ -245,7 +245,7 @@ public class AuthenticatorSuccessTest extends AuthenticatorTestBase {
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 
-    @Test(dependsOnMethods = {"testUpdateUserDefinedLocalAuthenticator"})
+    @Test(dependsOnMethods = {"testDeleteUserDefinedLocalAuthenticator"})
     public void testDeleteNonExistingUserDefinedLocalAuthenticator() throws JsonProcessingException {
 
         Response response = getResponseOfDelete(AUTHENTICATOR_CUSTOM_API_BASE_PATH + PATH_SEPARATOR

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
@@ -42,6 +42,7 @@ public class AuthenticatorTestBase extends RESTAPIServerTestBase {
     protected static final String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.authenticators.v1";
 
     protected static final String AUTHENTICATOR_API_BASE_PATH = "/authenticators";
+    protected static final String AUTHENTICATOR_META_TAGS_PATH = "/authenticators/meta/tags";
     protected static final String AUTHENTICATOR_CUSTOM_API_BASE_PATH = "/authenticators/custom";
     protected static final String AUTHENTICATOR_CONFIG_API_BASE_PATH = "/api/server/v1/configs/authenticators/";
     protected static final String PATH_SEPARATOR = "/";

--- a/pom.xml
+++ b/pom.xml
@@ -2356,7 +2356,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.45</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.46</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2468,7 +2468,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.12</identity.server.api.version>
+        <identity.server.api.version>1.3.13</identity.server.api.version>
         <identity.user.api.version>1.3.46</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22058

With this PR following integration tests are added.
1. Check /authenticators/meta/tags returning when there is an custom authenticators.
2. Added assertion for the user defined local authenticator payload to check whether tags are returning.