### PR TITLE
Add integration test to get user defined local authenticators

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorSuccessTest.java
@@ -142,8 +142,7 @@ public class AuthenticatorSuccessTest extends AuthenticatorTestBase {
                 .body("type", equalTo("LOCAL"))
                 .body("definedBy", equalTo("USER"))
                 .body("isEnabled", equalTo(true))
-                .body("self", equalTo(getTenantedRelativePath(
-                        AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant)));
+                .body("self", equalTo(getTenantedRelativePath(BASE_PATH + AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant)));
     }
 
     @Test(dependsOnMethods = {"testCreateUserDefinedLocalAuthenticator"})
@@ -166,14 +165,33 @@ public class AuthenticatorSuccessTest extends AuthenticatorTestBase {
                 Assert.assertEquals(authenticator.getString("displayName"), AUTHENTICATOR_DISPLAY_NAME);
                 Assert.assertEquals(authenticator.getString("type"), "LOCAL");
                 Assert.assertTrue(authenticator.getBoolean("isEnabled"));
-                Assert.assertEquals(authenticator.getString("self"),
-                        getTenantedRelativePath(AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant));
+                Assert.assertEquals(authenticator.getString("self"), getTenantedRelativePath(
+                        BASE_PATH + AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant));
             }
         }
         Assert.assertTrue(isUserDefinedAuthenticatorFound);
     }
 
     @Test(dependsOnMethods = {"testCreateUserDefinedLocalAuthenticator"})
+    public void testGetUserDefinedLocalAuthenticator() {
+
+        Response response = getResponseOfGet(AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .header(HttpHeaders.LOCATION, notNullValue())
+                .body("id", equalTo(customIdPId))
+                .body("name", equalTo(AUTHENTICATOR_NAME))
+                .body("displayName", equalTo(AUTHENTICATOR_DISPLAY_NAME))
+                .body("type", equalTo("LOCAL"))
+                .body("definedBy", equalTo("USER"))
+                .body("isEnabled", equalTo(true))
+                .body("endpoint.uri", equalTo(AUTHENTICATOR_ENDPOINT_URI))
+                .body("endpoint.authentication", equalTo("Basic"));
+    }
+
+    @Test(dependsOnMethods = {"testGetUserDefinedLocalAuthenticator"})
     public void testUpdateUserDefinedLocalAuthenticator() throws JsonProcessingException {
 
         updatePayload.displayName(AUTHENTICATOR_DISPLAY_NAME + UPDATE_VALUE_POSTFIX);
@@ -193,7 +211,7 @@ public class AuthenticatorSuccessTest extends AuthenticatorTestBase {
                 .body("definedBy", equalTo("USER"))
                 .body("isEnabled", equalTo(false))
                 .body("self", equalTo(getTenantedRelativePath(
-                        AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant)));
+                        BASE_PATH + AUTHENTICATOR_CONFIG_API_BASE_PATH + customIdPId, tenant)));
     }
 
     @Test(dependsOnMethods = {"testUpdateUserDefinedLocalAuthenticator"})

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
@@ -41,9 +41,10 @@ public class AuthenticatorTestBase extends RESTAPIServerTestBase {
     protected static final String API_VERSION = "v1";
     protected static final String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.authenticators.v1";
 
+    protected static final String BASE_PATH = "/api/server/v1";
     protected static final String AUTHENTICATOR_API_BASE_PATH = "/authenticators";
     protected static final String AUTHENTICATOR_CUSTOM_API_BASE_PATH = "/authenticators/custom";
-    protected static final String AUTHENTICATOR_CONFIG_API_BASE_PATH = "/api/server/v1/configs/authenticators/";
+    protected static final String AUTHENTICATOR_CONFIG_API_BASE_PATH = "/configs/authenticators/";
     protected static final String PATH_SEPARATOR = "/";
 
     protected final String AUTHENTICATOR_NAME = "customAuthenticator";


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/21216

PR:
- https://github.com/wso2/identity-api-server/pull/734

With this PR, we all integration tests to retrieve created user defined local authenticators.