### PR TITLE
Update `SelfSignUpConsentTest` with Tenanted Callback Endpoint and Assertion Adjustments

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/SelfSignUpConsentTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/consent/SelfSignUpConsentTest.java
@@ -65,7 +65,8 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
 
     public static final String CONSNT_ENDPOINT_SUFFIX = "/api/identity/consent-mgt/v1.0/consents";
     public static final String USER_RECOVERY_ME_ENDPOINT = "/api/identity/user/v1.0/me";
-    private static final String CALLBACK_ENDPOINT = "https://localhost:9443/carbon/callback";
+    private static final String CALLBACK_ENDPOINT = "https://localhost:9853/carbon/callback";
+    private static final String TENANTED_CALLBACK_ENDPOINT = "https://localhost:9853/t/wso2.com/carbon/callback";
     private static final String COUNTRY_WSO2_CLAIM = "http://wso2.org/claims/country";
     private static final String CALLBACK_QUERY_PARAM = "callback";
     private static final String USERNAME_QUERY_PARAM = "username";
@@ -147,7 +148,7 @@ public class SelfSignUpConsentTest extends ISIntegrationTest {
         Assert.assertNotNull(content);
         Assert.assertTrue(content.contains("Enter your username"), "Page for entering username is not prompted while" +
                 " self registering");
-        Assert.assertTrue(content.contains(CALLBACK_ENDPOINT), "Callback endpoint is not available in self " +
+        Assert.assertTrue(content.contains(TENANTED_CALLBACK_ENDPOINT), "Callback endpoint is not available in self " +
                 "registration username input page.");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2480,7 +2480,7 @@
         <!-- Identity Portal Versions -->
         <identity.apps.console.version>2.36.0</identity.apps.console.version>
         <identity.apps.myaccount.version>2.13.41</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.8.8</identity.apps.core.version>
+        <identity.apps.core.version>2.8.11</identity.apps.core.version>
         <identity.apps.tests.version>1.6.378</identity.apps.tests.version>
 
         <!-- Charon -->


### PR DESCRIPTION
## Purpose
This pull request includes changes to the `SelfSignUpConsentTest` class in the `org.wso2.identity.integration.test.consent` package to update the callback endpoints and adjust the corresponding test assertions.

### Changes to callback endpoints:

* Updated the `CALLBACK_ENDPOINT` to use the correct port (`https://localhost:9853/carbon/callback`).
* Added a new constant `TENANTED_CALLBACK_ENDPOINT` for tenant specific callback URL (`https://localhost:9853/t/wso2.com/carbon/callback`).

### Adjustments to test assertions:

* Modified the `testInitialSelfSignUpPage` method to assert the presence of the `TENANTED_CALLBACK_ENDPOINT` instead of `CALLBACK_ENDPOINT`.

## Related PRs
- https://github.com/wso2/identity-apps/pull/7250