### PR TITLE
Update user defined authenticator name in integration tests.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorFailureTest.java
@@ -243,7 +243,7 @@ public class AuthenticatorFailureTest extends AuthenticatorTestBase {
                 .body("code", equalTo("AUT-60013"))
                 .body("message", equalTo("The authenticator already exists."))
                 .body("description", equalTo("The authenticator already exists for the given name:" +
-                        " customAuthenticator."));
+                        " custom_Authenticator."));
     }
 
     @Test(priority = 10)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
@@ -47,7 +47,7 @@ public class AuthenticatorTestBase extends RESTAPIServerTestBase {
     protected static final String AUTHENTICATOR_CONFIG_API_BASE_PATH = "/api/server/v1/configs/authenticators/";
     protected static final String PATH_SEPARATOR = "/";
 
-    protected final String AUTHENTICATOR_NAME = "customAuthenticator";
+    protected final String AUTHENTICATOR_NAME = "custom_Authenticator";
     protected final String AUTHENTICATOR_DISPLAY_NAME = "ABC custom authenticator";
     protected final String AUTHENTICATOR_ENDPOINT_URI = "https://test.com/authenticate";
     protected final String customIdPId = Base64.getUrlEncoder().withoutPadding().encodeToString(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPFailureTest.java
@@ -62,8 +62,8 @@ public class IdPFailureTest extends IdPTestBase {
     private static final String OIDC_SCOPES_PLACEHOLDER = "\"<OIDC_SCOPES>\"";
     private static final String AUTHENTICATOR_PROPERTIES_PLACEHOLDER = "\"<AUTHENTICATOR_PROPERTIES>\"";
     private static final String CUSTOM_IDP_NAME = "CustomAuthIDP";
-    private static final String USER_DEFINED_AUTHENTICATOR_ID_1 = "Y3VzdG9tQXV0aGVudGljYXRvcjE=";
-    private static final String USER_DEFINED_AUTHENTICATOR_ID_2 = "Y3VzdG9tQXV0aGVudGljYXRvcg==";
+    private static final String USER_DEFINED_AUTHENTICATOR_ID_1 = "Y3VzdG9tX0F1dGhlbnRpY2F0b3Ix";
+    private static final String USER_DEFINED_AUTHENTICATOR_ID_2 = "Y3VzdG9tX0F1dGhlbnRpY2F0b3Iy";
     private static final String SYSTEM_DEFINED_AUTHENTICATOR_ID = "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I";
     private static final String ENDPOINT_URI = "https://abc.com/authenticate";
     private String idPId;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
@@ -63,7 +63,7 @@ public class IdPSuccessTest extends IdPTestBase {
     private static final String METADATA_SAML_PLACEHOLDER = "<METADATA_SAML>";
     private static final String OIDC_SCOPES_PLACEHOLDER = "\"<OIDC_SCOPES>\"";
     private static final String AUTHENTICATOR_PROPERTIES_PLACEHOLDER = "\"<AUTHENTICATOR_PROPERTIES>\"";
-    private static final String FEDERATED_AUTHENTICATOR_ID = "Y3VzdG9tQXV0aGVudGljYXRvcg";
+    private static final String FEDERATED_AUTHENTICATOR_ID = "Y3VzdG9tX0F1dGhlbnRpY2F0b3Ix";
     private static final String OIDC_AUTHENTICATOR_ID = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
     private static final String SAML_AUTHENTICATOR_ID = "U0FNTFNTT0F1dGhlbnRpY2F0b3I";
     private static final String CUSTOM_IDP_NAME = "Custom Auth IDP";


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22063

With the PR [1], following changes are added. This PR to improve integration tests for new validations.
1. There improve authenticator name regex validation to check whether authenticator name start with `custom-` prefix with atleast three charactors.
2. In addtion to above validate authenticator name uniqueness across both local and federared authenticator names.
3. Improve display name validation to check whether it has atleast three charactors.

[1]. https://github.com/wso2/carbon-identity-framework/pull/6288