### PR TITLE
Change sample app name

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
@@ -74,7 +74,7 @@ public class RegistryMountTestCase extends ISIntegrationTest {
 
     // SAML Application attributes
     private static final String USER_AGENT = "Apache-HttpClient/4.2.5 (java 1.5)";
-    private static final String APPLICATION_NAME = "SAML-SSO-TestApplication";
+    private static final String APPLICATION_NAME = "SAML-Registry-Mount-Application";
     private static final String ATTRIBUTE_CS_INDEX_VALUE = "1239245949";
 
     private static final String ACS_URL = "http://localhost:8490/%s/home.jsp";


### PR DESCRIPTION
Sample app name used in RegistryMountTestCase is duplicated and hence it can be failing due to the test execution order and other external factor to this test case.

Hence the test case name is changed.