### PR TITLE
Add new intregation test for authenticator name validation.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorFailureTest.java
@@ -117,7 +117,7 @@ public class AuthenticatorFailureTest extends AuthenticatorTestBase {
                 .body("code", equalTo("AUT-60014"))
                 .body("message", equalTo("Authenticator name is invalid."))
                 .body("description", equalTo("The provided authenticator name invalid@name is not in the " +
-                        "expected format ^[a-zA-Z0-9][a-zA-Z0-9-_]*$."));
+                        "expected format ^custom_[a-zA-Z0-9-_]{3,}$."));
     }
 
     @Test(priority = 2)
@@ -147,7 +147,7 @@ public class AuthenticatorFailureTest extends AuthenticatorTestBase {
                 .assertThat()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body("code", equalTo("AUT-60015"))
-                .body("message", equalTo("Invalid empty or blank value."))
+                .body("message", equalTo("Authenticator display name is invalid."))
                 .body("description", equalTo("Value for displayName should not be empty or blank."));
     }
 
@@ -275,7 +275,7 @@ public class AuthenticatorFailureTest extends AuthenticatorTestBase {
                 .assertThat()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body("code", equalTo("AUT-60015"))
-                .body("message", equalTo("Invalid empty or blank value."))
+                .body("message", equalTo("Authenticator display name is invalid."))
                 .body("description", equalTo("Value for displayName should not be empty or blank."));
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorFailureTest.java
@@ -117,7 +117,7 @@ public class AuthenticatorFailureTest extends AuthenticatorTestBase {
                 .body("code", equalTo("AUT-60014"))
                 .body("message", equalTo("Authenticator name is invalid."))
                 .body("description", equalTo("The provided authenticator name invalid@name is not in the " +
-                        "expected format ^custom_[a-zA-Z0-9-_]{3,}$."));
+                        "expected format ^custom-[a-zA-Z0-9-_]{3,}$."));
     }
 
     @Test(priority = 2)
@@ -243,7 +243,7 @@ public class AuthenticatorFailureTest extends AuthenticatorTestBase {
                 .body("code", equalTo("AUT-60013"))
                 .body("message", equalTo("The authenticator already exists."))
                 .body("description", equalTo("The authenticator already exists for the given name:" +
-                        " custom_Authenticator."));
+                        " custom-Authenticator."));
     }
 
     @Test(priority = 10)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/AuthenticatorTestBase.java
@@ -47,7 +47,7 @@ public class AuthenticatorTestBase extends RESTAPIServerTestBase {
     protected static final String AUTHENTICATOR_CONFIG_API_BASE_PATH = "/api/server/v1/configs/authenticators/";
     protected static final String PATH_SEPARATOR = "/";
 
-    protected final String AUTHENTICATOR_NAME = "custom_Authenticator";
+    protected final String AUTHENTICATOR_NAME = "custom-Authenticator";
     protected final String AUTHENTICATOR_DISPLAY_NAME = "ABC custom authenticator";
     protected final String AUTHENTICATOR_ENDPOINT_URI = "https://test.com/authenticate";
     protected final String customIdPId = Base64.getUrlEncoder().withoutPadding().encodeToString(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPFailureTest.java
@@ -62,8 +62,8 @@ public class IdPFailureTest extends IdPTestBase {
     private static final String OIDC_SCOPES_PLACEHOLDER = "\"<OIDC_SCOPES>\"";
     private static final String AUTHENTICATOR_PROPERTIES_PLACEHOLDER = "\"<AUTHENTICATOR_PROPERTIES>\"";
     private static final String CUSTOM_IDP_NAME = "CustomAuthIDP";
-    private static final String USER_DEFINED_AUTHENTICATOR_ID_1 = "Y3VzdG9tX0F1dGhlbnRpY2F0b3Ix";
-    private static final String USER_DEFINED_AUTHENTICATOR_ID_2 = "Y3VzdG9tX0F1dGhlbnRpY2F0b3Iy";
+    private static final String USER_DEFINED_AUTHENTICATOR_ID_1 = "Y3VzdG9tLUF1dGhlbnRpY2F0b3Ix";
+    private static final String USER_DEFINED_AUTHENTICATOR_ID_2 = "Y3VzdG9tLUF1dGhlbnRpY2F0b3Iy";
     private static final String SYSTEM_DEFINED_AUTHENTICATOR_ID = "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I";
     private static final String ENDPOINT_URI = "https://abc.com/authenticate";
     private String idPId;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.authenticator.management.v1.util.UserDefinedLocalAuthenticatorPayload;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.AuthenticationType;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Endpoint;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest;
@@ -103,6 +104,7 @@ public class IdPSuccessTest extends IdPTestBase {
     public void init() throws IOException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
+        userDefinedAuthenticatorPayload = createUserDefinedAuthenticatorPayloadWithBasic(ENDPOINT_URI);
         userDefinedAuthenticatorPayload = createUserDefinedAuthenticatorPayloadWithBasic(ENDPOINT_URI);
         idpCreatePayload = readResource("add-idp-with-custom-fed-auth.json");
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
@@ -64,7 +64,7 @@ public class IdPSuccessTest extends IdPTestBase {
     private static final String METADATA_SAML_PLACEHOLDER = "<METADATA_SAML>";
     private static final String OIDC_SCOPES_PLACEHOLDER = "\"<OIDC_SCOPES>\"";
     private static final String AUTHENTICATOR_PROPERTIES_PLACEHOLDER = "\"<AUTHENTICATOR_PROPERTIES>\"";
-    private static final String FEDERATED_AUTHENTICATOR_ID = "Y3VzdG9tX0F1dGhlbnRpY2F0b3Ix";
+    private static final String FEDERATED_AUTHENTICATOR_ID = "Y3VzdG9tLUF1dGhlbnRpY2F0b3Ix";
     private static final String OIDC_AUTHENTICATOR_ID = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
     private static final String SAML_AUTHENTICATOR_ID = "U0FNTFNTT0F1dGhlbnRpY2F0b3I";
     private static final String CUSTOM_IDP_NAME = "Custom Auth IDP";

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.95</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.106</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22063

This PR to improve integration tests for following new validations added with the PR [1]
1. In addtion to above validate authenticator name uniqueness across both local and federared authenticator names.

[1]. https://github.com/wso2/carbon-identity-framework/pull/6288