### PR TITLE
Fix curl cmd in Fapi and OIDC suites

### DIFF
--- a/.github/workflows/fapi-oidc-conformance-test.yml
+++ b/.github/workflows/fapi-oidc-conformance-test.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Get Jacoco Agent
       id: download_jacoco
       run: |
-        curl -vLJO -H 'Accept: application/octet-stream' https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.12/jacoco-0.8.12.zip
+        curl -vLJ -H 'Accept: application/octet-stream' -o jacoco-0.8.12.zip "https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.12/jacoco-0.8.12.zip"
         unzip jacoco-0.8.12.zip -d jacoco-0.8.12
 
     - name: Get IS zip

--- a/.github/workflows/oidc-conformance-test.yml
+++ b/.github/workflows/oidc-conformance-test.yml
@@ -131,7 +131,8 @@ jobs:
     - name: Download Jacoco Agent
       id: download_jacoco
       run: |
-        curl -vLJO -H 'Accept: application/octet-stream' https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.12/jacoco-0.8.12.zip
+        curl -vLJ -H 'Accept: application/octet-stream' -o jacoco-0.8.12.zip "https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.12/jacoco-0.8.12.zip"
+        unzip jacoco-0.8.12.zip -d jacoco-0.8.12
 
     - name: Run IS
       run: |


### PR DESCRIPTION
Wrapping the URL in double quotes (") prevents zsh from interpreting special characters like ? and &.
-o jacoco-0.8.12.zip: Explicitly sets the output file name as jacoco-0.8.12.zip.
