### PR TITLE
Bump identity-api-server version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2478,7 +2478,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.21</identity.server.api.version>
+        <identity.server.api.version>1.3.22</identity.server.api.version>
         <identity.user.api.version>1.3.48</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
### Purpose
$subject

The integration tests are not triggered for this pr since the tests were succesful for the below pr and it is the only change between these versions. 
- https://github.com/wso2/identity-api-server/pull/771