### PR TITLE
Fix integration tests for system and custom schema

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/mgt/AccountLockEnabledTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2016-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -64,7 +64,7 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
     private static final String CONNECTOR_ACCOUNT_LOCK_HANDLER = "YWNjb3VudC5sb2NrLmhhbmRsZXI";
     private static final String LOCALE_ATTRIBUTE = "locale";
     private static final String USERS_PATH = "users";
-    private static final String USER_SCHEMA = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    private static final String SCIM_SYSTEM_USER_SCHEMA = "urn:scim:wso2:schema";
 
 
     private SCIM2RestClient scim2RestClient;
@@ -106,7 +106,8 @@ public class AccountLockEnabledTestCase extends ISIntegrationTest {
             }
 
 
-            JSONObject userParameters = (JSONObject) scim2RestClient.getUser(testLockUserId, null).get(USER_SCHEMA);
+            JSONObject userParameters = (JSONObject) scim2RestClient.getUser(testLockUserId, null)
+                    .get(SCIM_SYSTEM_USER_SCHEMA);
             Assert.assertTrue((Boolean) userParameters.get(ACCOUNT_LOCK_ATTRIBUTE),
                     "Test Failure : User Account Didn't Locked Properly");
         } catch (Exception e) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceJWTGrantTestCase.java
@@ -70,7 +70,7 @@ import org.wso2.identity.integration.test.rest.api.user.common.model.ListObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
 import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
-import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionEnterprise;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionSystem;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.ClaimManagementRestClient;
 import org.wso2.identity.integration.test.restclients.IdpMgtRestClient;
@@ -571,7 +571,7 @@ public class OAuth2ServiceJWTGrantTestCase extends OAuth2ServiceAbstractIntegrat
         userInfo.setPassword(JWT_USER_PASSWORD);
         userInfo.setName(new Name().givenName(JWT_USER));
         userInfo.addEmail(new Email().value(EMAIL_CLAIM_VALUE));
-        userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().country(COUNTRY_CLAIM_VALUE));
+        userInfo.setScimSchemaExtensionSystem(new ScimSchemaExtensionSystem().country(COUNTRY_CLAIM_VALUE));
 
         userId = scim2RestClient.createUser(userInfo);
         String roleId = scim2RestClient.getRoleIdByName("admin");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
@@ -40,7 +40,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
-import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionEnterprise;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionSystem;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
@@ -369,7 +369,7 @@ public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractInt
 			UserObject userInfo = new UserObject();
 			userInfo.setUserName(lockedUser);
 			userInfo.setPassword(lockedUserPassword);
-			userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().accountLocked(true));
+			userInfo.setScimSchemaExtensionSystem(new ScimSchemaExtensionSystem().accountLocked(true));
 			userId = scim2RestClient.createUser(userInfo);
 		} catch (Exception e) {
 			Assert.fail("Error while creating the user", e);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationAfterAccountDisablingTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2TokenRevocationAfterAccountDisablingTestCase.java
@@ -105,7 +105,7 @@ public class OAuth2TokenRevocationAfterAccountDisablingTestCase extends OAuth2Se
     private static final String CONNECTOR_ACCOUNT_DISABLE_HANDLER = "YWNjb3VudC5kaXNhYmxlLmhhbmRsZXI";
     private static final String CATEGORY_ACCOUNT_MANAGEMENT = "QWNjb3VudCBNYW5hZ2VtZW50";
 
-    private static final String USER_SCHEMA_ATTRIBUTE ="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    private static final String USER_SYSTEM_SCHEMA_ATTRIBUTE ="urn:scim:wso2:schema";
     private static final String ACCOUNT_DISABLED_ATTRIBUTE ="accountDisabled";
     private static final String APP_CALLBACK_URL = "http://localhost:8490/playground2/oauth2client";
 
@@ -233,12 +233,12 @@ public class OAuth2TokenRevocationAfterAccountDisablingTestCase extends OAuth2Se
     private void testDisableUserAccount() throws Exception {
 
         UserItemAddGroupobj disableUserPatchOp = new UserItemAddGroupobj().op(OpEnum.REPLACE);
-        disableUserPatchOp.setPath(USER_SCHEMA_ATTRIBUTE + ":" + ACCOUNT_DISABLED_ATTRIBUTE);
+        disableUserPatchOp.setPath(USER_SYSTEM_SCHEMA_ATTRIBUTE + ":" + ACCOUNT_DISABLED_ATTRIBUTE);
         disableUserPatchOp.setValue(true);
         scim2RestClient.updateUser(new PatchOperationRequestObject().addOperations(disableUserPatchOp), userId);
 
-        Boolean accountActiveValue = (Boolean) ((JSONObject) scim2RestClient.getUser(userId, null).get(USER_SCHEMA_ATTRIBUTE))
-                .get(ACCOUNT_DISABLED_ATTRIBUTE);
+        Boolean accountActiveValue = (Boolean) ((JSONObject) scim2RestClient.getUser(userId, null)
+                .get(USER_SYSTEM_SCHEMA_ATTRIBUTE)).get(ACCOUNT_DISABLED_ATTRIBUTE);
         Assert.assertTrue(accountActiveValue, "User account didn't disabled");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2ImpersonationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2ImpersonationTestCase.java
@@ -61,7 +61,7 @@ import org.wso2.identity.integration.test.rest.api.user.common.model.ListObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
 import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
-import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionEnterprise;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionSystem;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.utils.CarbonUtils;
@@ -214,7 +214,7 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         userInfo.setPassword(IMPERSONATOR_PASSWORD);
         userInfo.setName(new Name().givenName(IMPERSONATOR_USERNAME));
         userInfo.addEmail(new Email().value(IMPERSONATOR_EMAIL));
-        userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().country(COUNTRY_CLAIM_VALUE));
+        userInfo.setScimSchemaExtensionSystem(new ScimSchemaExtensionSystem().country(COUNTRY_CLAIM_VALUE));
 
         impersonatorId = scim2RestClient.createUser(userInfo);
         String roleId = scim2RestClient.getRoleIdByName("everyone");
@@ -234,7 +234,7 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         userInfo.setPassword(END_USER_PASSWORD);
         userInfo.setName(new Name().givenName(END_USER_USERNAME));
         userInfo.addEmail(new Email().value(END_USER_EMAIL));
-        userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().country(COUNTRY_CLAIM_VALUE));
+        userInfo.setScimSchemaExtensionSystem(new ScimSchemaExtensionSystem().country(COUNTRY_CLAIM_VALUE));
 
         endUserId = scim2RestClient.createUser(userInfo);
         String roleId = scim2RestClient.getRoleIdByName("everyone");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/consented/token/OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/consented/token/OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest.java
@@ -61,7 +61,7 @@ import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.ListObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.RoleItemAddGroupobj;
-import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionEnterprise;
+import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionSystem;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
@@ -121,7 +121,7 @@ public class OAuth2ServiceWithConsentedTokenColumnAbstractIntegrationTest extend
         userInfo.setUserName(USERNAME);
         userInfo.setPassword(PASSWORD);
         userInfo.addEmail(new Email().value(USER_EMAIL));
-        userInfo.setScimSchemaExtensionEnterprise(new ScimSchemaExtensionEnterprise().country(COUNTRY));
+        userInfo.setScimSchemaExtensionSystem(new ScimSchemaExtensionSystem().country(COUNTRY));
 
         userId = scim2RestClient.createUser(userInfo);
         String roleId = scim2RestClient.getRoleIdByName("admin");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/ScimSchemaExtensionSystem.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/ScimSchemaExtensionSystem.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.user.common.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.Objects;
+
+public class ScimSchemaExtensionSystem {
+
+    private Boolean accountLocked;
+    private String country;
+    private String stateorprovince;
+
+    /**
+     *
+     **/
+    public ScimSchemaExtensionSystem accountLocked(Boolean accountLocked) {
+
+        this.accountLocked = accountLocked;
+        return this;
+    }
+
+    @ApiModelProperty(example = "false")
+    @JsonProperty("accountLocked")
+    @Valid
+    public Boolean accountLocked() {
+        return accountLocked;
+    }
+
+    public void setAccountLocked(Boolean accountLocked) {
+        this.accountLocked = accountLocked;
+    }
+
+    /**
+     *
+     **/
+    public ScimSchemaExtensionSystem country(String country) {
+
+        this.country = country;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Sri Lanka")
+    @JsonProperty("country")
+    @Valid
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    @ApiModelProperty(example = "Western")
+    @JsonProperty("stateorprovince")
+    @Valid
+    public String getStateorprovince() {
+        return stateorprovince;
+    }
+
+    public void setStateorprovince(String stateorprovince) {
+        this.stateorprovince = stateorprovince;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScimSchemaExtensionSystem scimSchemaExtensionSystem = (ScimSchemaExtensionSystem) o;
+        return Objects.equals(this.accountLocked, scimSchemaExtensionSystem.accountLocked) &&
+                Objects.equals(this.country, scimSchemaExtensionSystem.country) &&
+                Objects.equals(this.stateorprovince, scimSchemaExtensionSystem.stateorprovince);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountLocked, country, stateorprovince);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ScimSchemaExtensionSystem {\n" +
+                "    accountLocked: " + toIndentedString(accountLocked) + "\n" +
+                "    country: " + toIndentedString(country) + "\n" +
+                "    stateorprovince: " + toIndentedString(stateorprovince) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/UserObject.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/UserObject.java
@@ -36,6 +36,7 @@ public class UserObject {
     private List<PhoneNumbers> phoneNumbers = null;
     private String locale;
     private ScimSchemaExtensionEnterprise scimSchemaExtensionEnterprise;
+    private ScimSchemaExtensionSystem scimSchemaExtensionSystem;
 
     /**
      *
@@ -210,6 +211,26 @@ public class UserObject {
         this.scimSchemaExtensionEnterprise = scimSchemaExtensionEnterprise;
     }
 
+    /**
+     *
+     **/
+    public UserObject scimSchemaExtensionSystem(ScimSchemaExtensionSystem scimSchemaExtensionSystem) {
+
+        this.scimSchemaExtensionSystem = scimSchemaExtensionSystem;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("urn:scim:wso2:schema")
+    @Valid
+    public ScimSchemaExtensionSystem getScimSchemaExtensionSystem() {
+        return scimSchemaExtensionSystem;
+    }
+
+    public void setScimSchemaExtensionSystem(ScimSchemaExtensionSystem scimSchemaExtensionSystem) {
+        this.scimSchemaExtensionSystem = scimSchemaExtensionSystem;
+    }
+
 
     @Override
     public boolean equals(Object o) {
@@ -227,13 +248,15 @@ public class UserObject {
                 Objects.equals(this.password, user.password) &&
                 Objects.equals(this.emails, user.emails) &&
                 Objects.equals(this.locale, user.locale) &&
-                Objects.equals(this.scimSchemaExtensionEnterprise, user.scimSchemaExtensionEnterprise);
+                Objects.equals(this.scimSchemaExtensionEnterprise, user.scimSchemaExtensionEnterprise) &&
+                Objects.equals(this.scimSchemaExtensionSystem, user.scimSchemaExtensionSystem);
 
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schemas, name, userName, password, emails, locale, scimSchemaExtensionEnterprise);
+        return Objects.hash(schemas, name, userName, password, emails, locale, scimSchemaExtensionEnterprise,
+                scimSchemaExtensionSystem);
     }
 
     @Override
@@ -247,6 +270,7 @@ public class UserObject {
                 "    emails: " + toIndentedString(emails) + "\n" +
                 "    locale: " + toIndentedString(locale) + "\n" +
                 "    urn:ietf:params:scim:schemas:extension:enterprise:2.0:User: " + toIndentedString(scimSchemaExtensionEnterprise) + "\n" +
+                "    urn:scim:wso2:schema: " + toIndentedString(scimSchemaExtensionSystem) + "\n" +
                 "}";
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -48,7 +48,9 @@ public class SCIM2RestClient extends RestBaseClient {
     private static final String SCIM_JSON_CONTENT_TYPE = "application/scim+json";
     private static final String ROLE_SEARCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:SearchRequest";
     private static final String USER_ENTERPRISE_SCHEMA = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    private static final String USER_SYSTEM_SCHEMA = "urn:scim:wso2:schema";
     private static final String SCIM_SCHEMA_EXTENSION_ENTERPRISE = "scimSchemaExtensionEnterprise";
+    private static final String SCIM_SCHEMA_EXTENSION_SYSTEM = "scimSchemaExtensionSystem";
     private static final String DISPLAY_NAME_ATTRIBUTE = "displayName";
     private static final String ATTRIBUTES_PART = "?attributes=";
     private static final String EQ_OP = "eq";
@@ -78,6 +80,9 @@ public class SCIM2RestClient extends RestBaseClient {
         if (userInfo.getScimSchemaExtensionEnterprise() != null) {
             jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_ENTERPRISE, USER_ENTERPRISE_SCHEMA);
         }
+        if (userInfo.getScimSchemaExtensionSystem() != null) {
+            jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_SYSTEM, USER_SYSTEM_SCHEMA);
+        }
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(getUsersPath(), jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
@@ -100,6 +105,9 @@ public class SCIM2RestClient extends RestBaseClient {
         String jsonRequest = toJSONString(userInfo);
         if (userInfo.getScimSchemaExtensionEnterprise() != null) {
             jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_ENTERPRISE, USER_ENTERPRISE_SCHEMA);
+        }
+        if (userInfo.getScimSchemaExtensionSystem() != null) {
+            jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_SYSTEM, USER_SYSTEM_SCHEMA);
         }
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(getSubOrgUsersPath(), jsonRequest,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2SchemasTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2SchemasTest.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.SCHEMAS_ENDPOINT;
@@ -137,7 +136,7 @@ public class SCIM2SchemasTest extends SCIM2BaseTest {
     @Test(dependsOnMethods = "getSchemas")
     public void validateUserExtensionSchemaElement() {
 
-        String baseIdentifier = "find{ it.name == 'EnterpriseUser' }.attributes.find {it.name == 'country'}.";
+        String baseIdentifier = "find{ it.name == 'SystemUser' }.attributes.find {it.name == 'country'}.";
         this.response.then()
                 .log().ifValidationFails()
                 .assertThat()
@@ -150,7 +149,7 @@ public class SCIM2SchemasTest extends SCIM2BaseTest {
     @Test(dependsOnMethods = "getSchemas")
     public void validateUserExtensionSchemaBooleanElement() {
 
-        String baseIdentifier = "find{ it.name == 'EnterpriseUser' }.attributes.find {it.name == 'emailVerified'}.";
+        String baseIdentifier = "find{ it.name == 'SystemUser' }.attributes.find {it.name == 'emailVerified'}.";
         this.response.then()
                 .log().ifValidationFails()
                 .assertThat()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIMUtils.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIMUtils.java
@@ -40,7 +40,8 @@ import java.util.LinkedHashMap;
 public class SCIMUtils {
 
     private static final String SCIM_USER_SCHEMAS = "[urn:ietf:params:scim:schemas:core:2.0:User, " +
-            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User, urn:scim:wso2:schema]";
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User, urn:scim:wso2:schema, " +
+            "urn:scim:schemas:extension:custom:User]";
     private static final UserStoreConfigUtils userStoreConfigUtils = new UserStoreConfigUtils();
 
     /**
@@ -53,7 +54,7 @@ public class SCIMUtils {
 
         Assert.assertTrue(schemasAttribute instanceof ArrayList, "'schemas' attribute is not a list of " +
                 "strings");
-        Assert.assertEquals(((ArrayList) schemasAttribute).size(), 3);
+        Assert.assertEquals(((ArrayList) schemasAttribute).size(), 4);
         Assert.assertTrue(StringUtils.equals(SCIM_USER_SCHEMAS, schemasAttribute.toString()));
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaMeTestCase.java
@@ -71,8 +71,8 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
     private ClaimMetadataManagementServiceClient claimMetadataManagementServiceClient = null;
 
     // Custom schema related constants.
-    private static final String CUSTOM_SCHEMA_URI = "urn:scim:wso2:schema";
-    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:wso2:schema\"";
+    private static final String CUSTOM_SCHEMA_URI = "urn:scim:schemas:extension:custom:User";
+    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:schemas:extension:custom:User\"";
     // Country claim related constants.
     private static final String COUNTRY_CLAIM_ATTRIBUTE_NAME = "country";
     private static final String COUNTRY_CLAIM_ATTRIBUTE_URI = CUSTOM_SCHEMA_URI + ":" + COUNTRY_CLAIM_ATTRIBUTE_NAME;
@@ -82,7 +82,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
     private static final String COUNTRY_LOCAL_CLAIM_VALUE_AFTER_PUT = "India";
     // Manager claim related constants.
     private static final String MANAGER_CLAIM_ATTRIBUTE_NAME = "manager";
-    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:wso2:schema:manager";
+    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:schemas:extension:custom:User:manager";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME = "email";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI =
             MANAGER_CLAIM_ATTRIBUTE_URI + "." + MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME;
@@ -132,6 +132,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
                     MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI);
             claimMetadataManagementServiceClient.removeExternalClaim(CUSTOM_SCHEMA_URI, MANAGER_CLAIM_ATTRIBUTE_URI);
             claimMetadataManagementServiceClient.removeLocalClaim(MANAGER_LOCAL_CLAIM_URI);
+            claimMetadataManagementServiceClient.removeClaimDialect(CUSTOM_SCHEMA_URI);
         } catch (RemoteException | ClaimMetadataManagementServiceClaimMetadataException e) {
            log.error(e);
         }
@@ -144,7 +145,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
         RestAssured.basePath = basePath;
     }
 
-    @Test(description = "Creates simple attribute and complex attributes in urn:scim:wso2:schema.")
+    @Test(description = "Creates simple attribute and complex attributes in urn:scim:schemas:extension:custom:User.")
     private void createClaims() throws Exception {
 
         AutomationContext context = new AutomationContext("IDENTITY", mode);
@@ -154,6 +155,7 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
         claimMetadataManagementServiceClient = new ClaimMetadataManagementServiceClient(backendURL, cookie);
 
         //Set claims.
+        setCustomDialect();
         setSimpleAttribute();
         setComplexAttribute();
 
@@ -352,6 +354,13 @@ public class SCIM2CustomSchemaMeTestCase extends SCIM2BaseTest {
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
         getResponseOfGet(userIdEndpointURL, SCIM_CONTENT_TYPE).then().assertThat().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    private void setCustomDialect() throws Exception {
+
+        ClaimDialectDTO claimDialectDTO = new ClaimDialectDTO();
+        claimDialectDTO.setClaimDialectURI(CUSTOM_SCHEMA_URI);
+        claimMetadataManagementServiceClient.addClaimDialect(claimDialectDTO);
     }
 
     private void setSimpleAttribute() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/customSchema/SCIM2CustomSchemaUserTestCase.java
@@ -72,8 +72,8 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
     private ClaimMetadataManagementServiceClient claimMetadataManagementServiceClient = null;
 
     // Custom schema related constants.
-    private static final String CUSTOM_SCHEMA_URI = "urn:scim:wso2:schema";
-    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:wso2:schema\"";
+    private static final String CUSTOM_SCHEMA_URI = "urn:scim:schemas:extension:custom:User";
+    private static final String CUSTOM_SCHEMA_URI_WITH_ESCAPE_CHARS = "\"urn:scim:schemas:extension:custom:User\"";
     // Country claim related constants.
     private static final String COUNTRY_CLAIM_ATTRIBUTE_NAME = "country";
     private static final String COUNTRY_CLAIM_ATTRIBUTE_URI = CUSTOM_SCHEMA_URI + ":" + COUNTRY_CLAIM_ATTRIBUTE_NAME;
@@ -83,7 +83,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
     private static final String COUNTRY_LOCAL_CLAIM_VALUE_AFTER_PUT = "India";
     // Manager claim related constants.
     private static final String MANAGER_CLAIM_ATTRIBUTE_NAME = "manager";
-    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:wso2:schema:manager";
+    private static final String MANAGER_CLAIM_ATTRIBUTE_URI = "urn:scim:schemas:extension:custom:User:manager";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME = "email";
     private static final String MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI =
             MANAGER_CLAIM_ATTRIBUTE_URI + "." + MANAGER_EMAIL_CLAIM_ATTRIBUTE_NAME;
@@ -129,6 +129,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
                     MANAGER_EMAIL_CLAIM_ATTRIBUTE_URI);
             claimMetadataManagementServiceClient.removeExternalClaim(CUSTOM_SCHEMA_URI, MANAGER_CLAIM_ATTRIBUTE_URI);
             claimMetadataManagementServiceClient.removeLocalClaim(MANAGER_LOCAL_CLAIM_URI);
+            claimMetadataManagementServiceClient.removeClaimDialect(CUSTOM_SCHEMA_URI);
         } catch (RemoteException | ClaimMetadataManagementServiceClaimMetadataException e) {
             log.error(e);
         }
@@ -141,7 +142,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
         RestAssured.basePath = basePath;
     }
 
-    @Test(description = "Creates simple attribute and complex attributes in urn:scim:wso2:schema.")
+    @Test(description = "Creates simple attribute and complex attributes in urn:scim:schemas:extension:custom:User.")
     private void createClaims() throws Exception {
 
         AutomationContext context = new AutomationContext("IDENTITY", mode);
@@ -151,6 +152,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
         claimMetadataManagementServiceClient = new ClaimMetadataManagementServiceClient(backendURL, cookie);
 
         //Set claims.
+        setCustomDialect();
         setSimpleAttribute();
         setComplexAttribute();
 
@@ -353,6 +355,13 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
         getResponseOfGet(userIdEndpointURL, SCIM_CONTENT_TYPE).then().assertThat().statusCode(HttpStatus.SC_NOT_FOUND);
     }
 
+    private void setCustomDialect() throws Exception {
+
+        ClaimDialectDTO claimDialectDTO = new ClaimDialectDTO();
+        claimDialectDTO.setClaimDialectURI(CUSTOM_SCHEMA_URI);
+        claimMetadataManagementServiceClient.addClaimDialect(claimDialectDTO);
+    }
+
     private void setSimpleAttribute() throws Exception {
 
         // Create country claim- simple attribute
@@ -365,7 +374,7 @@ public class SCIM2CustomSchemaUserTestCase extends SCIM2BaseTest {
 
     private void setComplexAttribute() throws Exception {
 
-        // Create manager claim- complex attribute
+        // Create manager claim complex attribute
         LocalClaimDTO localClaimDTO = new LocalClaimDTO();
         localClaimDTO.setLocalClaimURI(MANAGER_LOCAL_CLAIM_URI);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/apiSwaggerFiles/scim2.yaml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/apiSwaggerFiles/scim2.yaml
@@ -1361,6 +1361,7 @@ definitions:
             - urn:ietf:params:scim:schemas:core:2.0:User
             - urn:ietf:params:scim:schemas:extension:enterprise:2.0:User
             - urn:scim:wso2:schema
+            - urn:scim:schemas:extension:custom:User
       username:
         type: string
         example: "PRIMARY/kim"
@@ -1514,6 +1515,7 @@ definitions:
             - urn:ietf:params:scim:schemas:core:2.0:User
             - urn:ietf:params:scim:schemas:extension:enterprise:2.0:User
             - urn:scim:wso2:schema
+            - urn:scim:schemas:extension:custom:User
       username:
         type: string
         example: "kim"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-add-user.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-add-user.json
@@ -6,7 +6,7 @@
   },
   "userName": "userkim",
   "password": "Wso2@test123",
-  "urn:scim:wso2:schema": {
+  "urn:scim:schemas:extension:custom:User": {
     "country": "France",
     "manager": {
       "email": "piraveena@gmail.com"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-add-attribute.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-add-attribute.json
@@ -6,7 +6,7 @@
     {
       "op": "add",
       "value": {
-        "urn:scim:wso2:schema": {
+        "urn:scim:schemas:extension:custom:User": {
           "manager": {
             "email": "piraveenaAdd@gmail.com"
           }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-remove-attribute.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-remove-attribute.json
@@ -5,11 +5,11 @@
   "Operations": [
     {
       "op": "remove",
-      "path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:country"
+      "path": "urn:scim:wso2:schema:country"
     },
     {
       "op": "remove",
-      "path": "urn:scim:wso2:schema:country"
+      "path": "urn:scim:schemas:extension:custom:User:country"
     }
   ]
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-replace-attribute.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-patch-replace-attribute.json
@@ -6,7 +6,7 @@
     {
       "op": "replace",
       "value": {
-        "urn:scim:wso2:schema": {
+        "urn:scim:schemas:extension:custom:User": {
           "country": "Sri Lanka",
           "manager": {
             "email": "piraveenaReplace@gmail.com"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-put-user.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/customSchema/scim2-custom-schema-put-user.json
@@ -5,7 +5,7 @@
     "familyName": "jackson",
     "givenName": "kim"
   },
-  "urn:scim:wso2:schema": {
+  "urn:scim:schemas:extension:custom:User": {
     "country": "India"
   }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/scim2-patch-replace-identity-claim.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/scim2/rest/api/scim2-patch-replace-identity-claim.json
@@ -6,7 +6,7 @@
         {
             "op": "replace",
             "value": {
-                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+                "urn:scim:wso2:schema": {
                     "verifyEmail": true
                 }
             }

--- a/oidc-conformance-tests/config/user_claim_value_config.json
+++ b/oidc-conformance-tests/config/user_claim_value_config.json
@@ -54,13 +54,20 @@
                 "op": "replace",
                 "value": {
                     "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
-                        "emailVerified": "true",
                         "manager": {
                             "value": "female"
                         },
-                        "phoneVerified": "true",
-                        "dateOfBirth": "1997-11-26",
                         "organization": "organization2"
+                    }
+                }
+            },
+            {
+                "op": "replace",
+                "value": {
+                    "urn:scim:wso2:schema": {
+                        "emailVerified": "true",
+                        "phoneVerified": "true",
+                        "dateOfBirth": "1997-11-26"
                     }
                 }
             },

--- a/pom.xml
+++ b/pom.xml
@@ -2488,8 +2488,8 @@
         <conditional.authentication.functions.version>1.2.73</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.38.3</identity.apps.console.version>
-        <identity.apps.myaccount.version>2.14.13</identity.apps.myaccount.version>
+        <identity.apps.console.version>2.38.5</identity.apps.console.version>
+        <identity.apps.myaccount.version>2.14.15</identity.apps.myaccount.version>
         <identity.apps.core.version>2.10.7</identity.apps.core.version>
         <identity.apps.tests.version>1.6.379</identity.apps.tests.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.106</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.108</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2377,7 +2377,7 @@
         <carbon.consent.mgt.version>2.6.5</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.11.32</identity.governance.version>
+        <identity.governance.version>1.11.33</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.9.8</identity.carbon.auth.saml2.version>
@@ -2392,7 +2392,7 @@
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.14</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.110</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.112</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.11</identity.user.account.association.version>
@@ -2465,7 +2465,7 @@
         <identity.extension.utils>1.0.21</identity.extension.utils>
         <authenticator.auth.otp.commons.version>1.0.10</authenticator.auth.otp.commons.version>
 
-        <identity.org.mgt.version>1.4.68</identity.org.mgt.version>
+        <identity.org.mgt.version>1.4.69</identity.org.mgt.version>
         <identity.org.mgt.core.version>1.1.19</identity.org.mgt.core.version>
         <identity.organization.login.version>1.1.42</identity.organization.login.version>
         <identity.oauth2.grant.organizationswitch.version>1.1.27</identity.oauth2.grant.organizationswitch.version>
@@ -2474,11 +2474,11 @@
         <hashprovider.pbkdf2.version>0.1.7</hashprovider.pbkdf2.version>
 
         <!-- Identity Branding Preference Management Versions -->
-        <identity.branding.preference.management.version>1.1.17</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.1.18</identity.branding.preference.management.version>
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.24</identity.server.api.version>
+        <identity.server.api.version>1.3.25</identity.server.api.version>
         <identity.user.api.version>1.3.49</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
@@ -2488,9 +2488,9 @@
         <conditional.authentication.functions.version>1.2.73</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.37.8</identity.apps.console.version>
-        <identity.apps.myaccount.version>2.14.8</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.10.4</identity.apps.core.version>
+        <identity.apps.console.version>2.38.0</identity.apps.console.version>
+        <identity.apps.myaccount.version>2.14.10</identity.apps.myaccount.version>
+        <identity.apps.core.version>2.10.5</identity.apps.core.version>
         <identity.apps.tests.version>1.6.379</identity.apps.tests.version>
 
         <!-- Charon -->

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.116</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.119</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2392,7 +2392,7 @@
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.14</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.7</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.112</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.113</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.11</identity.user.account.association.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.108</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.110</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.112</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.116</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2377,7 +2377,7 @@
         <carbon.consent.mgt.version>2.6.5</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.11.33</identity.governance.version>
+        <identity.governance.version>1.11.34</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.9.8</identity.carbon.auth.saml2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.119</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.120</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -2488,8 +2488,8 @@
         <conditional.authentication.functions.version>1.2.73</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.38.5</identity.apps.console.version>
-        <identity.apps.myaccount.version>2.14.15</identity.apps.myaccount.version>
+        <identity.apps.console.version>2.38.7</identity.apps.console.version>
+        <identity.apps.myaccount.version>2.14.17</identity.apps.myaccount.version>
         <identity.apps.core.version>2.10.8</identity.apps.core.version>
         <identity.apps.tests.version>1.6.379</identity.apps.tests.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2366,7 +2366,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.110</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.112</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <!--SAML Common Utils Version-->
@@ -2387,7 +2387,7 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.0.217</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.218</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.11.50</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.14</identity.inbound.auth.sts.version>
@@ -2488,9 +2488,9 @@
         <conditional.authentication.functions.version>1.2.73</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.38.0</identity.apps.console.version>
-        <identity.apps.myaccount.version>2.14.10</identity.apps.myaccount.version>
-        <identity.apps.core.version>2.10.5</identity.apps.core.version>
+        <identity.apps.console.version>2.38.3</identity.apps.console.version>
+        <identity.apps.myaccount.version>2.14.13</identity.apps.myaccount.version>
+        <identity.apps.core.version>2.10.7</identity.apps.core.version>
         <identity.apps.tests.version>1.6.379</identity.apps.tests.version>
 
         <!-- Charon -->

--- a/pom.xml
+++ b/pom.xml
@@ -2452,7 +2452,7 @@
         <identity.metadata.saml.version>1.8.4</identity.metadata.saml.version>
 
         <!-- Connector Versions -->
-        <authenticator.totp.version>3.3.32</authenticator.totp.version>
+        <authenticator.totp.version>3.3.33</authenticator.totp.version>
         <authenticator.backupcode.version>0.0.20</authenticator.backupcode.version>
         <authenticator.office365.version>2.1.3</authenticator.office365.version>
         <authenticator.smsotp.version>3.3.32</authenticator.smsotp.version>


### PR DESCRIPTION
### Purpose

Fixes the integration test failures introduced by the below PRs
- https://github.com/wso2/charon/pull/418
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/594

The above two PRs rename the custom schema with uri urn:scim:wso2:schema to system schema and introduces a new schema for the custom schema with uri urn:scim:schemas:extension:custom:User. The system schema contains the SCIM attributes related to the product functionalities while the custom schema is dedicated to customers' scim attributes related to their business flows.

### Related Issues
- https://github.com/wso2/product-is/issues/20850