### PR TITLE
Add integration test for shared user profile resolving

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/RoleWithAudience.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/RoleWithAudience.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@ApiModel(description = "Represents a user role within a specific audience (organization or application), defined by its display name and audience type. ")
+public class RoleWithAudience {
+  
+    private String displayName;
+    private RoleWithAudienceAudience audience;
+
+    /**
+    * Display name of the role
+    **/
+    public RoleWithAudience displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "role_1", required = true, value = "Display name of the role")
+    @JsonProperty("displayName")
+    @Valid
+    @NotNull(message = "Property displayName cannot be null.")
+
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RoleWithAudience audience(RoleWithAudienceAudience audience) {
+
+        this.audience = audience;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("audience")
+    @Valid
+    @NotNull(message = "Property audience cannot be null.")
+
+    public RoleWithAudienceAudience getAudience() {
+        return audience;
+    }
+    public void setAudience(RoleWithAudienceAudience audience) {
+        this.audience = audience;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleWithAudience roleWithAudience = (RoleWithAudience) o;
+        return Objects.equals(this.displayName, roleWithAudience.displayName) &&
+            Objects.equals(this.audience, roleWithAudience.audience);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, audience);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleWithAudience {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    audience: ").append(toIndentedString(audience)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/RoleWithAudienceAudience.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/RoleWithAudienceAudience.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class RoleWithAudienceAudience {
+  
+    private String display;
+    private String type;
+
+    /**
+    * Display name of the audience
+    **/
+    public RoleWithAudienceAudience display(String display) {
+
+        this.display = display;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "My Org 1", required = true, value = "Display name of the audience")
+    @JsonProperty("display")
+    @Valid
+    @NotNull(message = "Property display cannot be null.")
+
+    public String getDisplay() {
+        return display;
+    }
+    public void setDisplay(String display) {
+        this.display = display;
+    }
+
+    /**
+    * Type of the audience, e.g., &#39;organization&#39; or &#39;application&#39;
+    **/
+    public RoleWithAudienceAudience type(String type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "organization", required = true, value = "Type of the audience, e.g., 'organization' or 'application'")
+    @JsonProperty("type")
+    @Valid
+    @NotNull(message = "Property type cannot be null.")
+
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleWithAudienceAudience roleWithAudienceAudience = (RoleWithAudienceAudience) o;
+        return Objects.equals(this.display, roleWithAudienceAudience.display) &&
+            Objects.equals(this.type, roleWithAudienceAudience.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(display, type);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleWithAudienceAudience {\n");
+        
+        sb.append("    display: ").append(toIndentedString(display)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/UserShareRequestBodyUserCriteria.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/UserShareRequestBodyUserCriteria.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.Valid;
+
+@ApiModel(description = "Contains a list of user IDs to be shared.")
+public class UserShareRequestBodyUserCriteria {
+  
+    private List<String> userIds = null;
+
+
+    /**
+    * List of user IDs.
+    **/
+    public UserShareRequestBodyUserCriteria userIds(List<String> userIds) {
+
+        this.userIds = userIds;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "List of user IDs.")
+    @JsonProperty("userIds")
+    @Valid
+    public List<String> getUserIds() {
+        return userIds;
+    }
+    public void setUserIds(List<String> userIds) {
+        this.userIds = userIds;
+    }
+
+    public UserShareRequestBodyUserCriteria addUserIdsItem(String userIdsItem) {
+        if (this.userIds == null) {
+            this.userIds = new ArrayList<>();
+        }
+        this.userIds.add(userIdsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserShareRequestBodyUserCriteria userShareRequestBodyUserCriteria = (UserShareRequestBodyUserCriteria) o;
+        return Objects.equals(this.userIds, userShareRequestBodyUserCriteria.userIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userIds);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserShareRequestBodyUserCriteria {\n");
+        
+        sb.append("    userIds: ").append(toIndentedString(userIds)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/UserShareWithAllRequestBody.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/model/UserShareWithAllRequestBody.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@ApiModel(description = "Process a request to share users with all organizations.  The payload contains the roles applicable across all organizations and a policy that defines the scope of sharing. ")
+public class UserShareWithAllRequestBody {
+  
+    private UserShareRequestBodyUserCriteria userCriteria;
+
+@XmlType(name="PolicyEnum")
+@XmlEnum(String.class)
+public enum PolicyEnum {
+
+    @XmlEnumValue("ALL_EXISTING_ORGS_ONLY") ALL_EXISTING_ORGS_ONLY(String.valueOf("ALL_EXISTING_ORGS_ONLY")), @XmlEnumValue("ALL_EXISTING_AND_FUTURE_ORGS") ALL_EXISTING_AND_FUTURE_ORGS(String.valueOf("ALL_EXISTING_AND_FUTURE_ORGS")), @XmlEnumValue("IMMEDIATE_EXISTING_ORGS_ONLY") IMMEDIATE_EXISTING_ORGS_ONLY(String.valueOf("IMMEDIATE_EXISTING_ORGS_ONLY")), @XmlEnumValue("IMMEDIATE_EXISTING_AND_FUTURE_ORGS") IMMEDIATE_EXISTING_AND_FUTURE_ORGS(String.valueOf("IMMEDIATE_EXISTING_AND_FUTURE_ORGS"));
+
+
+    private String value;
+
+    PolicyEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static PolicyEnum fromValue(String value) {
+        for (PolicyEnum b : PolicyEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private PolicyEnum policy;
+    private List<RoleWithAudience> roles = null;
+
+
+    /**
+    **/
+    public UserShareWithAllRequestBody userCriteria(UserShareRequestBodyUserCriteria userCriteria) {
+
+        this.userCriteria = userCriteria;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("userCriteria")
+    @Valid
+    @NotNull(message = "Property userCriteria cannot be null.")
+
+    public UserShareRequestBodyUserCriteria getUserCriteria() {
+        return userCriteria;
+    }
+    public void setUserCriteria(UserShareRequestBodyUserCriteria userCriteria) {
+        this.userCriteria = userCriteria;
+    }
+
+    /**
+    * A policy to specify the sharing scope.
+    **/
+    public UserShareWithAllRequestBody policy(PolicyEnum policy) {
+
+        this.policy = policy;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "A policy to specify the sharing scope.")
+    @JsonProperty("policy")
+    @Valid
+    @NotNull(message = "Property policy cannot be null.")
+
+    public PolicyEnum getPolicy() {
+        return policy;
+    }
+    public void setPolicy(PolicyEnum policy) {
+        this.policy = policy;
+    }
+
+    /**
+    * A list of roles shared across all organizations.
+    **/
+    public UserShareWithAllRequestBody roles(List<RoleWithAudience> roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "A list of roles shared across all organizations.")
+    @JsonProperty("roles")
+    @Valid
+    public List<RoleWithAudience> getRoles() {
+        return roles;
+    }
+    public void setRoles(List<RoleWithAudience> roles) {
+        this.roles = roles;
+    }
+
+    public UserShareWithAllRequestBody addRolesItem(RoleWithAudience rolesItem) {
+        if (this.roles == null) {
+            this.roles = new ArrayList<>();
+        }
+        this.roles.add(rolesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserShareWithAllRequestBody userShareWithAllRequestBody = (UserShareWithAllRequestBody) o;
+        return Objects.equals(this.userCriteria, userShareWithAllRequestBody.userCriteria) &&
+            Objects.equals(this.policy, userShareWithAllRequestBody.policy) &&
+            Objects.equals(this.roles, userShareWithAllRequestBody.roles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userCriteria, policy, roles);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserShareWithAllRequestBody {\n");
+        
+        sb.append("    userCriteria: ").append(toIndentedString(userCriteria)).append("\n");
+        sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -180,6 +180,27 @@ public class SCIM2RestClient extends RestBaseClient {
     }
 
     /**
+     * Update the details of an existing user of a sub organization.
+     *
+     * @param patchUserInfo    User patch request object.
+     * @param userId           ID of the user.
+     * @param switchedM2MToken Switched M2M token for the given organization.
+     * @return JSONObject of the HTTP response.
+     * @throws IOException If an error occurred while updating a user.
+     */
+    public JSONObject updateSubOrgUser(PatchOperationRequestObject patchUserInfo, String userId, String switchedM2MToken)
+            throws Exception {
+
+        String jsonRequest = toJSONString(patchUserInfo);
+        String endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest,
+                getHeadersWithBearerToken(switchedM2MToken))) {
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    /**
      * Search a user and get requested attributes.
      *
      * @param userSearchReq Json String of user search request.
@@ -191,6 +212,26 @@ public class SCIM2RestClient extends RestBaseClient {
         String endPointUrl = getUsersPath() + SCIM2_SEARCH_PATH;
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, userSearchReq, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "User search failed");
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    /**
+     * Search a user and get requested attributes of a sub organization.
+     *
+     * @param userSearchReq    Json String of user search request.
+     * @param switchedM2MToken Switched M2M token for the given organization.
+     * @return JSONObject of the user search response.
+     * @throws Exception If an error occurred while getting a user.
+     */
+    public JSONObject searchSubOrgUser(String userSearchReq, String switchedM2MToken) throws Exception {
+
+        String endPointUrl = getSubOrgUsersPath() + SCIM2_SEARCH_PATH;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, userSearchReq,
+                getHeadersWithBearerToken(switchedM2MToken))) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
                     "User search failed");
             return getJSONObject(EntityUtils.toString(response.getEntity()));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UserSharingRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UserSharingRestClient.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Rest client for user sharing.
+ */
+public class UserSharingRestClient extends RestBaseClient {
+
+    private static final String API_SERVER_BASE_PATH = "/api/server/v1";
+    public static final String USER_SHARE_WITH_ALL_ENDPOINT_URI = "/users/share-with-all";
+    public static final String PATH_SEPARATOR = "/";
+    private final String serverUrl;
+    private final String tenantDomain;
+    private final String username;
+    private final String password;
+    private final String userShareWithAllBasePath;
+
+    public UserSharingRestClient(String serverUrl, Tenant tenantInfo) {
+
+        this.serverUrl = serverUrl;
+        this.tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+
+        userShareWithAllBasePath = serverUrl +
+                ISIntegrationTest.getTenantedRelativePath(API_SERVER_BASE_PATH + USER_SHARE_WITH_ALL_ENDPOINT_URI,
+                        tenantDomain);
+    }
+
+    /**
+     * Share users with all.
+     *
+     * @param userShareWithAllRequestBody User share with all request body.
+     * @throws Exception If an error occurs while sharing users with all.
+     */
+    public void shareUsersWithAll(UserShareWithAllRequestBody userShareWithAllRequestBody) throws Exception {
+
+        String jsonRequest = toJSONString(userShareWithAllRequestBody);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(userShareWithAllBasePath, jsonRequest,
+                getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_ACCEPTED,
+                    "User sharing request accepted.");
+        }
+    }
+
+    /**
+     * Close the HTTP client.
+     *
+     * @throws IOException If an error occurred while closing the Http Client.
+     */
+    public void closeHttpClient() throws IOException {
+
+        client.close();
+    }
+
+    private Header[] getHeaders() {
+
+        Header[] headerList = new Header[2];
+        headerList[0] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[1] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+        return headerList;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -18,6 +18,8 @@
 
 package org.wso2.identity.integration.test.user.profile.mgt;
 
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.Assert;
@@ -27,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
@@ -60,6 +63,7 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
     private SCIM2RestClient scim2RestClient;
     private UserSharingRestClient userSharingRestClient;
     private OrgMgtRestClient orgMgtRestClient;
+    private IdentityProviderMgtServiceClient idpMgtServiceClient;
     private String level1OrgId;
     private String level2OrgId;
     private String switchedM2MTokenForLevel1Org;
@@ -92,6 +96,9 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
         userSharingRestClient = new UserSharingRestClient(serverURL, tenantInfo);
         orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
                 new JSONObject(RESTTestBase.readResource(AUTHORIZED_APIS_JSON, this.getClass())));
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
 
         level1OrgId = orgMgtRestClient.addOrganization(L1_SUB_ORG_NAME);
         level2OrgId = orgMgtRestClient.addSubOrganization(L2_SUB_ORG_NAME, level1OrgId);
@@ -104,7 +111,7 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
     public void atEnd() throws Exception {
 
         scim2RestClient.deleteUser(rootOrgUserId);
-
+        idpMgtServiceClient.deleteIdP("SSO");
         orgMgtRestClient.deleteSubOrganization(level2OrgId, level1OrgId);
         orgMgtRestClient.deleteOrganization(level1OrgId);
         orgMgtRestClient.closeHttpClient();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -111,10 +111,10 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
     public void atEnd() throws Exception {
 
         scim2RestClient.deleteUser(rootOrgUserId);
-        idpMgtServiceClient.deleteIdP("SSO");
         orgMgtRestClient.deleteSubOrganization(level2OrgId, level1OrgId);
         orgMgtRestClient.deleteOrganization(level1OrgId);
         orgMgtRestClient.closeHttpClient();
+        idpMgtServiceClient.deleteIdP("SSO");
         scim2RestClient.closeHttpClient();
         userSharingRestClient.closeHttpClient();
         claimManagementRestClient.closeHttpClient();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -41,9 +41,6 @@ import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.restclients.UserSharingRestClient;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
 
 /**
@@ -181,9 +178,23 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
         UserItemAddGroupobj givenNameUpdatePatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
         givenNameUpdatePatchOp.setPath("name.givenName");
         givenNameUpdatePatchOp.setValue("UpdatedGivenName");
-        org.json.simple.JSONObject userUpdateResponse = scim2RestClient.updateSubOrgUser(
-                new PatchOperationRequestObject().addOperations(givenNameUpdatePatchOp), sharedUserIdInLevel1Org,
+        // Try to update given name of shared user in level 1 org.
+        updateGivenNameInSharedUserProfile(givenNameUpdatePatchOp, sharedUserIdInLevel1Org,
                 switchedM2MTokenForLevel1Org);
-        Assert.assertEquals(userUpdateResponse.get("status"), 400);
+        // Try to update given name of shared user in level 2 org.
+        updateGivenNameInSharedUserProfile(givenNameUpdatePatchOp, sharedUserIdInLevel2Org,
+                switchedM2MTokenForLevel2Org);
+
+    }
+
+    private void updateGivenNameInSharedUserProfile(UserItemAddGroupobj givenNameUpdatePatchOp, String sharedUserId,
+                                                    String switchedM2MTokenForOrg) throws Exception {
+
+        org.json.simple.JSONObject userUpdateResponse = scim2RestClient.updateSubOrgUser(
+                new PatchOperationRequestObject().addOperations(givenNameUpdatePatchOp), sharedUserId,
+                switchedM2MTokenForOrg);
+        Assert.assertEquals(userUpdateResponse.get("status"), "400");
+        Assert.assertEquals(userUpdateResponse.get("detail"),
+                "Claim: http://wso2.org/claims/givenname is not allowed to be updated for shared users.");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.user.profile.mgt;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserItemAddGroupobj;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.ClaimManagementRestClient;
+import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UserSharingRestClient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
+
+/**
+ * Test class to verify shared user profile claim management.
+ */
+public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    private static final String AUTHORIZED_APIS_JSON = "authorized-apis.json";
+    private static final String L1_SUB_ORG_NAME = "L1_Sub_Org";
+    private static final String L2_SUB_ORG_NAME = "L2_Sub_Org";
+    private static final String ROOT_ORG_USERNAME = "alex";
+    private static final String ROOT_ORG_USER_PASSWORD = "Wso2@123";
+    private static final String ROOT_ORG_USER_EMAIL = "alex@gmail.com";
+    private static final String ROOT_ORG_USER_GIVEN_NAME = "Alex";
+    private final TestUserMode userMode;
+    private ClaimManagementRestClient claimManagementRestClient;
+    private SCIM2RestClient scim2RestClient;
+    private UserSharingRestClient userSharingRestClient;
+    private OrgMgtRestClient orgMgtRestClient;
+    private String level1OrgId;
+    private String level2OrgId;
+    private String switchedM2MTokenForLevel1Org;
+    private String switchedM2MTokenForLevel2Org;
+    private String rootOrgUserId;
+    private String sharedUserIdInLevel1Org;
+    private String sharedUserIdInLevel2Org;
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() throws Exception {
+
+        return new Object[][] {
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public SharedUserProfileClaimMgtTestCase(TestUserMode userMode) {
+
+        this.userMode = userMode;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.init(userMode);
+        claimManagementRestClient = new ClaimManagementRestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        userSharingRestClient = new UserSharingRestClient(serverURL, tenantInfo);
+        orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
+                new JSONObject(RESTTestBase.readResource(AUTHORIZED_APIS_JSON, this.getClass())));
+
+        level1OrgId = orgMgtRestClient.addOrganization(L1_SUB_ORG_NAME);
+        level2OrgId = orgMgtRestClient.addSubOrganization(L2_SUB_ORG_NAME, level1OrgId);
+
+        switchedM2MTokenForLevel1Org = orgMgtRestClient.switchM2MToken(level1OrgId);
+        switchedM2MTokenForLevel2Org = orgMgtRestClient.switchM2MToken(level2OrgId);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        scim2RestClient.deleteUser(rootOrgUserId);
+
+        orgMgtRestClient.deleteSubOrganization(level2OrgId, level1OrgId);
+        orgMgtRestClient.deleteOrganization(level1OrgId);
+        orgMgtRestClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        userSharingRestClient.closeHttpClient();
+        claimManagementRestClient.closeHttpClient();
+    }
+
+    @Test(description = "Add a user in root organization and share with level 1 org and level 2 org.")
+    public void testAddUserInRootOrgAndShareWithLevel1AndLevel2Org() throws Exception {
+
+        // Create a user in root organization.
+        UserObject rootUserInfo = new UserObject();
+        rootUserInfo.setUserName(ROOT_ORG_USERNAME);
+        rootUserInfo.setPassword(ROOT_ORG_USER_PASSWORD);
+        rootUserInfo.setName(new Name().givenName(ROOT_ORG_USER_GIVEN_NAME));
+        rootUserInfo.addEmail(new Email().value(ROOT_ORG_USER_EMAIL));
+        rootOrgUserId = scim2RestClient.createUser(rootUserInfo);
+
+        // Share the user with existing sub orgs.
+        UserShareWithAllRequestBody userShareWithAllRequestBody = new UserShareWithAllRequestBody();
+        userShareWithAllRequestBody.setUserCriteria(new UserShareRequestBodyUserCriteria().addUserIdsItem(rootOrgUserId));
+        userShareWithAllRequestBody.setPolicy(ALL_EXISTING_ORGS_ONLY);
+        userSharingRestClient.shareUsersWithAll(userShareWithAllRequestBody);
+
+        String userSearchReq = new JSONObject()
+                .put("schemas", new JSONArray().put("urn:ietf:params:scim:api:messages:2.0:SearchRequest"))
+                .put("attributes", new JSONArray().put("id"))
+                .put("filter", "userName eq " + ROOT_ORG_USERNAME )
+                .toString();
+
+        org.json.simple.JSONObject sharedUserInLevel1Org =
+                scim2RestClient.searchSubOrgUser(userSearchReq, switchedM2MTokenForLevel1Org);
+        sharedUserIdInLevel1Org =
+                ((org.json.simple.JSONObject) ((org.json.simple.JSONArray) sharedUserInLevel1Org.get("Resources")).get(
+                        0)).get("id").toString();
+        Assert.assertNotNull(sharedUserIdInLevel1Org, "Failed sharing user to level 1 organization.");
+
+        org.json.simple.JSONObject sharedUserInLevel2Org =
+                scim2RestClient.searchSubOrgUser(userSearchReq, switchedM2MTokenForLevel2Org);
+        sharedUserIdInLevel2Org =
+                ((org.json.simple.JSONObject) ((org.json.simple.JSONArray) sharedUserInLevel2Org.get("Resources")).get(
+                        0)).get("id").toString();
+        Assert.assertNotNull(sharedUserIdInLevel2Org, "Failed sharing user to level 2 organization.");
+    }
+
+    @Test(dependsOnMethods = {"testAddUserInRootOrgAndShareWithLevel1AndLevel2Org"},
+            description = "Verify the shared users profiles have resolved given name and email from origin.")
+    public void testGivenNameAndEmailResolvedFromOrigin() throws Exception {
+
+        // Validate shared user in level 1 org.
+        validateClaimsResolvedFromOriginInSharedUser(sharedUserIdInLevel1Org, switchedM2MTokenForLevel1Org);
+        // Validate shared user in level 2 org.
+        validateClaimsResolvedFromOriginInSharedUser(sharedUserIdInLevel2Org, switchedM2MTokenForLevel2Org);
+    }
+
+    private void validateClaimsResolvedFromOriginInSharedUser(String sharedUserId,
+                                                              String switchedM2MToken) throws Exception {
+
+        org.json.simple.JSONObject sharedUser = scim2RestClient.getSubOrgUser(sharedUserId, switchedM2MToken);
+        String givenNameOfSharedUser = (String) ((org.json.simple.JSONObject) sharedUser.get("name")).get("givenName");
+        String emailOfSharedUser = (String) ((org.json.simple.JSONArray) sharedUser.get("emails")).get(0);
+        Assert.assertEquals(givenNameOfSharedUser, ROOT_ORG_USER_GIVEN_NAME, "Unexpected given name.");
+        Assert.assertEquals(emailOfSharedUser, ROOT_ORG_USER_EMAIL, "Unexpected email.");
+    }
+
+    @Test(dependsOnMethods = {"testGivenNameAndEmailResolvedFromOrigin"},
+            description = "Verify the claims resolved from origin can't be updated in shared profiles.")
+    public void testClaimsResolvedFromOriginCanNotBeUpdatedInSharedProfiles() throws Exception {
+
+        UserItemAddGroupobj givenNameUpdatePatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
+        givenNameUpdatePatchOp.setPath("name.givenName");
+        givenNameUpdatePatchOp.setValue("UpdatedGivenName");
+        org.json.simple.JSONObject userUpdateResponse = scim2RestClient.updateSubOrgUser(
+                new PatchOperationRequestObject().addOperations(givenNameUpdatePatchOp), sharedUserIdInLevel1Org,
+                switchedM2MTokenForLevel1Org);
+        Assert.assertEquals(userUpdateResponse.get("status"), 400);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/authorized-apis.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/authorized-apis.json
@@ -1,0 +1,23 @@
+{
+  "/api/server/v1/organizations": [
+    "internal_organization_view",
+    "internal_organization_create",
+    "internal_organization_delete"
+  ],
+  "/o/scim2/Users": [
+    "internal_org_user_mgt_create",
+    "internal_org_user_mgt_view",
+    "internal_org_user_mgt_list",
+    "internal_org_user_mgt_update",
+    "internal_org_user_mgt_delete"
+  ],
+  "/o/api/server/v1/organizations": [
+    "internal_org_organization_view",
+    "internal_org_organization_create",
+    "internal_org_organization_delete"
+  ],
+  "/o/api/server/v1/claim-dialects": [
+    "internal_org_claim_meta_view",
+    "internal_org_claim_meta_update"
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -153,6 +153,7 @@
             <class name="org.wso2.identity.integration.test.oidc.OIDCPasswordGrantTest"/>
             <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
             <class name="org.wso2.identity.integration.test.claim.metadata.mgt.ClaimProfilesWithSCIM2SchemaTest"/>
+            <class name="org.wso2.identity.integration.test.user.profile.mgt.SharedUserProfileClaimMgtTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
Part of https://github.com/wso2/product-is/issues/22426

This Integration test covers:
1. Root user sharing with sub organizations
2. Shared user inherit claims from root user if the claim has  "sharedProfileValueResolvingMethod": "FromOrigin"
3. Shared users can't update the values of claims which has "sharedProfileValueResolvingMethod": "FromOrigin"

