### PR TITLE
Fix packing database-utils jar twice

### DIFF
--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -441,9 +441,6 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.consent.mgt.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.utils:org.wso2.carbon.database.utils.feature:${carbon.database.utils.version}
-                                </featureArtifactDef>
 
                                 <featureArtifactDef>
                                     org.wso2.carbon.extension.identity.x509certificate:org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature:${org.wso2.carbon.extension.identity.x509certificate.version}
@@ -1066,10 +1063,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.consent.mgt.server.feature.group</id>
                                     <version>${carbon.identity.framework.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.database.utils.feature.group</id>
-                                    <version>${carbon.database.utils.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1842,6 +1842,7 @@
                 <groupId>org.wso2.carbon.utils</groupId>
                 <artifactId>org.wso2.carbon.database.utils</artifactId>
                 <version>${carbon.database.utils.version}</version>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.registry</groupId>


### PR DESCRIPTION
### Purpose
- Resolves: https://github.com/wso2/product-is/issues/22741


### Notes 

Getting below error when building the product-is

```
Installation failed.
Cannot complete the install because one or more required items could not be found.
 Software being installed: OAuth Feature 7.0.229 (org.wso2.carbon.identity.oauth.feature.group 7.0.229)
 Missing requirement: WSO2 Carbon - Consent Management Server Feature 2.6.6 (org.wso2.carbon.consent.mgt.server.feature.group 2.6.6) requires 'org.wso2.carbon.database.utils.feature.group [2.1.0,3.0.0)' but it could not be found
 Cannot satisfy dependency:
  From: Application Authentication Framework Server Feature 7.7.186 (org.wso2.carbon.identity.application.authentication.framework.server.feature.group 7.7.186)
  To: org.wso2.carbon.consent.mgt.server.feature.group [2.2.16,3.0.0)
 Cannot satisfy dependency:
  From: Identity OAuth DCR Server Feature 7.0.229 (org.wso2.carbon.identity.oauth.dcr.server.feature.group 7.0.229)
  To: org.wso2.carbon.identity.application.authentication.framework.server.feature.group 7.7.140
 Cannot satisfy dependency:
  From: OAuth Feature 7.0.229 (org.wso2.carbon.identity.oauth.feature.group 7.0.229)
  To: org.wso2.carbon.identity.oauth.dcr.server.feature.group [7.0.229]
Application failed, log file location: /private/var/folders/rp/hd3dsffn0dx5zbvtdljd91gh0000gn/T/tycho-p2-runtime15486349596303848289.tmp/configuration/1738746161667.log
```