### PR TITLE
Bump Console Version to 2.40.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2563,7 +2563,7 @@
         <conditional.authentication.functions.version>1.2.73</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.40.27</identity.apps.console.version>
+        <identity.apps.console.version>2.40.30</identity.apps.console.version>
         <identity.apps.myaccount.version>2.16.25</identity.apps.myaccount.version>
         <identity.apps.core.version>2.12.6</identity.apps.core.version>
 


### PR DESCRIPTION
### Description
This PR bumps the version of the console from 2.40.27 to 2.40.30