### PR TITLE
Temporarily disable the adaptive auth metadata test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationMetadataPositiveTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/ApplicationMetadataPositiveTest.java
@@ -206,33 +206,34 @@ public class ApplicationMetadataPositiveTest extends ApplicationManagementBaseTe
 //        }
 //    }
 
-    @Test
-    public void testGetAdaptiveAuthTemplates() throws IOException, JSONException {
-
-        Response response = getResponseOfGet(METADATA_API_BASE_PATH + PATH_SEPARATOR + ADAPTIVE_AUTH_PATH);
-        response.then()
-                .log()
-                .ifValidationFails()
-                .assertThat()
-                .statusCode(HttpStatus.SC_OK);
-
-        JSONObject expected = new JSONObject(new JSONObject(readResource("adaptive-metadata.json")).get(
-                JSON_KEY_TEMPLATES_JSON).toString());
-        JSONObject received = new JSONObject(new JSONObject(response.asString()).get(
-                JSON_KEY_TEMPLATES_JSON).toString());
-        Iterator<String> iterator = expected.keys();
-
-        while (iterator.hasNext()) {
-            String result = iterator.next();
-            if (!"uncategorized".equals(result)) {
-                JSONArray expectedTemplates = expected.getJSONObject(result).getJSONArray(JSON_KEY_TEMPLATES);
-                JSONArray receivedTemplates = received.getJSONObject(result).getJSONArray(JSON_KEY_TEMPLATES);
-
-                Assert.assertTrue(equalSets(expectedTemplates, receivedTemplates),
-                        "Adaptive auth templates returned from the API doesn't match.");
-            }
-        }
-    }
+      // Temporarily disabling the test due to change in the Adaptive Auth templates.
+//    @Test
+//    public void testGetAdaptiveAuthTemplates() throws IOException, JSONException {
+//
+//        Response response = getResponseOfGet(METADATA_API_BASE_PATH + PATH_SEPARATOR + ADAPTIVE_AUTH_PATH);
+//        response.then()
+//                .log()
+//                .ifValidationFails()
+//                .assertThat()
+//                .statusCode(HttpStatus.SC_OK);
+//
+//        JSONObject expected = new JSONObject(new JSONObject(readResource("adaptive-metadata.json")).get(
+//                JSON_KEY_TEMPLATES_JSON).toString());
+//        JSONObject received = new JSONObject(new JSONObject(response.asString()).get(
+//                JSON_KEY_TEMPLATES_JSON).toString());
+//        Iterator<String> iterator = expected.keys();
+//
+//        while (iterator.hasNext()) {
+//            String result = iterator.next();
+//            if (!"uncategorized".equals(result)) {
+//                JSONArray expectedTemplates = expected.getJSONObject(result).getJSONArray(JSON_KEY_TEMPLATES);
+//                JSONArray receivedTemplates = received.getJSONObject(result).getJSONArray(JSON_KEY_TEMPLATES);
+//
+//                Assert.assertTrue(equalSets(expectedTemplates, receivedTemplates),
+//                        "Adaptive auth templates returned from the API doesn't match.");
+//            }
+//        }
+//    }
 
     private boolean equalSets(JSONArray ja1, JSONArray ja2) throws JSONException {
 


### PR DESCRIPTION
Temporarily disable the adaptive auth metadata test due to template change happening in [1]

The test will be updated and re-enabled after the PR [1] is merged and the new artifact is released.

[1] - https://github.com/wso2/carbon-identity-framework/pull/6441