### PR TITLE
Update integration test for unification of error descriptions for client authentication failures

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2DeviceFlowTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2DeviceFlowTestCase.java
@@ -370,7 +370,7 @@ public class OAuth2DeviceFlowTestCase extends OAuth2ServiceAbstractIntegrationTe
         String error = responseObject.get(ERROR).toString();
         String errorDescription = responseObject.get(ERROR_DESCRIPTION).toString();
         Assert.assertEquals(error, "invalid_request", "invalid error retrieved");
-        Assert.assertEquals(errorDescription, "A valid OAuth client could not be found for client_id: invalidConsumerKey",
+        Assert.assertEquals(errorDescription, "Client credentials are invalid.",
                 "invalid error description received");
     }
 
@@ -436,7 +436,7 @@ public class OAuth2DeviceFlowTestCase extends OAuth2ServiceAbstractIntegrationTe
         String errorDescription = obj.get("error_description").toString();
         Assert.assertEquals(error, "invalid_client", "Error message is not valid.");
         Assert.assertEquals(errorDescription,
-                "A valid OAuth client could not be found for client_id: invalidConsumerKey",
+                "Client credentials are invalid.",
                 "Error Description is not valid.");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2PushedAuthRequestTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2PushedAuthRequestTestCase.java
@@ -256,7 +256,7 @@ public class OAuth2PushedAuthRequestTestCase extends OAuth2ServiceAbstractIntegr
 
         HttpResponse response = sendPostRequest(OAuth2Constant.PAR_ENDPOINT, urlParameters);
         assertResponse(response, Response.Status.UNAUTHORIZED.getStatusCode(),
-                "A valid OAuth client could not be found for client_id: invalid_consumerKey",
+                "Client credentials are invalid.",
                 "invalid_client");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceClientCredentialTestCase.java
@@ -232,7 +232,7 @@ public class OAuth2ServiceClientCredentialTestCase extends OAuth2ServiceAbstract
         Assert.assertEquals(errorObject.getCode(), "invalid_client",
                 "Invalid access token response doesn't contain required error message.");
         Assert.assertEquals(errorObject.getDescription(),
-                "A valid OAuth client could not be found for client_id: invalidConsumerKey",
+                "Client credentials are invalid.",
                 "Invalid access token response doesn't contain required error description.");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2459,7 +2459,7 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.0.229</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.232</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.11.50</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.11.16</identity.inbound.auth.sts.version>


### PR DESCRIPTION
### Purpose
Update integration tests related client authentication failures with the errorDescription, "A valid OAuth client could not be found for client_id: client_id" to "Client credentials are invalid."

### Related PRs 
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2691

### Related Issue
- https://github.com/wso2/product-is/issues/22336