### PR TITLE
Test unable to modify managed org claim in shared profiles

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -334,7 +334,7 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
 
         org.json.simple.JSONObject customClaimInSubOrg =
                 claimManagementRestClient.getSubOrgLocalClaim(customClaimId, switchedM2MToken);
-        Assert.assertNotNull(customClaimInSubOrg, "Failed to get custom claim in sub org at level.");
+        Assert.assertNotNull(customClaimInSubOrg, "Failed to get custom claim in sub org level.");
         Assert.assertEquals(customClaimInSubOrg.get("claimURI"), CUSTOM_CLAIM_URI);
         Assert.assertEquals(customClaimInSubOrg.get("id"), customClaimId);
         Assert.assertEquals(customClaimInSubOrg.get("sharedProfileValueResolvingMethod"),


### PR DESCRIPTION
Part of https://github.com/wso2/product-is/issues/22426

This integration test covers:
1. Inability to modify the managedOrg claim in shared profiles even though the SharedProfileValueResolvingMethod value is From Shared Profile