### PR TITLE
Onboard Certificate Validation Management API to the Product

### DIFF
--- a/modules/api-resources/api-resources-full/pom.xml
+++ b/modules/api-resources/api-resources-full/pom.xml
@@ -366,6 +366,14 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.certificate.validation.management.v1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.certificate.validation.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.server.tenant.management.common</artifactId>
         </dependency>
         <dependency>

--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
@@ -70,6 +70,7 @@
                 org.wso2.carbon.identity.api.server.organization.selfservice.v1.SelfServiceApi,
                 org.wso2.carbon.identity.api.server.api.resource.v1.MetaApi,
                 org.wso2.carbon.identity.api.server.action.management.v1.ActionsApi,
+                org.wso2.carbon.identity.api.server.certificate.validation.management.v1.CertificateValidationApi,
                 org.wso2.carbon.identity.api.server.rule.metadata.v1.RulesApi,
                 org.wso2.carbon.identity.api.server.api.resource.v1.AuthorizationDetailsTypesApi
             </param-value>

--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -397,6 +397,16 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.certificate.validation.management.v1</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.certificate.validation.management.common</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.secret.management.v1</artifactId>
                 <version>${identity.server.api.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2536,7 +2536,7 @@
         <authenticator.local.auth.emailotp.version>1.0.28</authenticator.local.auth.emailotp.version>
         <authenticator.local.auth.smsotp.version>1.0.17</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.1.2</authenticator.twitter.version>
-        <authenticator.x509.version>3.1.25</authenticator.x509.version>
+        <authenticator.x509.version>3.1.26</authenticator.x509.version>
         <identity.extension.utils>1.0.21</identity.extension.utils>
         <authenticator.auth.otp.commons.version>1.0.10</authenticator.auth.otp.commons.version>
 
@@ -2553,13 +2553,13 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.71</identity.server.api.version>
+        <identity.server.api.version>1.3.72</identity.server.api.version>
         <identity.user.api.version>1.3.58</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.10</identity.tool.samlsso.validator.version>
         <identity.oauth.addons.version>2.5.22</identity.oauth.addons.version>
-        <org.wso2.carbon.extension.identity.x509certificate.version>1.1.18</org.wso2.carbon.extension.identity.x509certificate.version>
+        <org.wso2.carbon.extension.identity.x509certificate.version>1.1.19</org.wso2.carbon.extension.identity.x509certificate.version>
         <conditional.authentication.functions.version>1.2.73</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->


### PR DESCRIPTION
### Purpose

API - https://app.swaggerhub.com/apis-docs/SachinMamoru-42f/X509-Certificate-Authenticator/v3#/

- https://github.com/wso2/product-is/issues/22729

This pull request includes several changes to the `pom.xml` files and the `web.xml` file to add new dependencies and update existing versions. The most important changes are the addition of new dependencies for certificate validation management and updates to the versions of existing dependencies.

### New Dependencies:
* Added `org.wso2.carbon.identity.api.server.certificate.validation.management.v1` and `org.wso2.carbon.identity.api.server.certificate.validation.management.common` dependencies in `modules/api-resources/api-resources-full/pom.xml` and `modules/api-resources/pom.xml`. [[1]](diffhunk://#diff-1a127a653e6af3570956cd84a19fbac981ee8cf417b036916f5a2c6bf8e76486R367-R374) [[2]](diffhunk://#diff-0f342fd521bd011d4f5d5af9b66cbc714cb279564cecad7b975debc9384bd515R398-R407)

### Configuration Updates:
* Added `org.wso2.carbon.identity.api.server.certificate.validation.management.v1.CertificateValidationApi` to the `web.xml` configuration.

### Version Updates:
* Updated the version of `authenticator.x509` from `3.1.25` to `3.1.26` in the root `pom.xml`.
* Updated the version of `identity.server.api` from `1.3.71` to `1.3.72` and `org.wso2.carbon.extension.identity.x509certificate` from `1.1.18` to `1.1.19` in the root `pom.xml`.