### PR TITLE
Verify custom claim behavior in shared profile when the value resolving method is changed

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/custom-claim-update-to-resolve-from-origin.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/custom-claim-update-to-resolve-from-origin.json
@@ -1,0 +1,16 @@
+{
+  "claimURI": "http://wso2.org/claims/customAttribute1",
+  "description": "customAttribute1",
+  "displayOrder": 0,
+  "displayName": "customAttribute1",
+  "readOnly": false,
+  "required": false,
+  "supportedByDefault": false,
+  "sharedProfileValueResolvingMethod": "FromOrigin",
+  "attributeMapping": [
+    {
+      "mappedAttribute": "customAttribute1",
+      "userstore": "PRIMARY"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/custom-claim-update-to-resolve-from-shared-profile.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/custom-claim-update-to-resolve-from-shared-profile.json
@@ -1,0 +1,16 @@
+{
+  "claimURI": "http://wso2.org/claims/customAttribute1",
+  "description": "customAttribute1",
+  "displayOrder": 0,
+  "displayName": "customAttribute1",
+  "readOnly": false,
+  "required": false,
+  "supportedByDefault": false,
+  "sharedProfileValueResolvingMethod": "FromSharedProfile",
+  "attributeMapping": [
+    {
+      "mappedAttribute": "customAttribute1",
+      "userstore": "PRIMARY"
+    }
+  ]
+}


### PR DESCRIPTION
$Suject

Part of https://github.com/wso2/product-is/issues/22426

This integration test covers:
1. When claim's  `SharedProfileValueResolvingMethod` meta data is changed from FromFirstFoundInHierarchy to FromOrigin, resolve the value from origin ignoring stored values in shared profile/ other ancestors
2.  When claim's  `SharedProfileValueResolvingMethod` meta data is changed from FromFirstFoundInHierarchy to FromSharedProfile, return the stored values in particular profile