### PR TITLE
[Bump] Identity organization Management Core version to 1.1.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2536,7 +2536,7 @@
         <authenticator.auth.otp.commons.version>1.0.10</authenticator.auth.otp.commons.version>
 
         <identity.org.mgt.version>1.4.105</identity.org.mgt.version>
-        <identity.org.mgt.core.version>1.1.22</identity.org.mgt.core.version>
+        <identity.org.mgt.core.version>1.1.23</identity.org.mgt.core.version>
         <identity.organization.login.version>1.1.42</identity.organization.login.version>
         <identity.oauth2.grant.organizationswitch.version>1.1.27</identity.oauth2.grant.organizationswitch.version>
 


### PR DESCRIPTION
Bump identity.org.mgt.core.version to 1.1.22 from 1.1.23.