### PR TITLE
Remove leading/trailing whitespace from SMS content in username recovery integration test.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/UsernameRecoveryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/UsernameRecoveryTestCase.java
@@ -548,6 +548,10 @@ public class UsernameRecoveryTestCase extends OIDCAbstractIntegrationTest {
         Thread.sleep(5000);
         String body = mockSMSProvider.getSmsContent();
 
+        if (body != null) {
+            body = body.trim();
+        }
+
         // Regex to match "domain/user1" format.
         String regex = "([a-zA-Z0-9.-]+/[^@]+)";
 
@@ -555,7 +559,7 @@ public class UsernameRecoveryTestCase extends OIDCAbstractIntegrationTest {
         java.util.regex.Matcher matcher = pattern.matcher(body);
 
         if (matcher.find()) {
-            return matcher.group(1);
+            return matcher.group(1).trim();
         }
 
         return null;

--- a/pom.xml
+++ b/pom.xml
@@ -2475,7 +2475,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.9.14</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.9.40</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.9.41</identity.event.handler.notification.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
### Purpose 

- $Subject