### PR TITLE
Add integration test to configuring roles and groups to shared user and validate them in switched tokens

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -168,19 +168,19 @@ public class SCIM2RestClient extends RestBaseClient {
      * Get the details of a user of a sub organization.
      *
      * @param userId           ID of the user.
-     * @param attribute Requested user attributes.
+     * @param attributes Requested user attributes.
      * @param switchedM2MToken Switched M2M token for the given organization.
      * @return JSONObject of the HTTP response.
      * @throws Exception If an error occurred while getting a user.
      */
-    public JSONObject getSubOrgUser(String userId, String attribute, String switchedM2MToken) throws Exception {
+    public JSONObject getSubOrgUser(String userId, String attributes, String switchedM2MToken) throws Exception {
 
         String endPointUrl;
 
-        if (StringUtils.isEmpty(attribute)) {
+        if (StringUtils.isEmpty(attributes)) {
             endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId;
         } else {
-            endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId + ATTRIBUTES_PART + attribute;
+            endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId + ATTRIBUTES_PART + attributes;
         }
 
         try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -29,6 +29,7 @@ import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.identity.integration.test.rest.api.server.roles.v2.model.RoleV2;
 import org.wso2.identity.integration.test.rest.api.user.common.model.GroupRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.PatchOperationRequestObject;
 import org.wso2.identity.integration.test.rest.api.user.common.model.RoleRequestObject;
@@ -45,6 +46,7 @@ public class SCIM2RestClient extends RestBaseClient {
     private static final String SCIM2_ME_ENDPOINT  = "scim2/Me";
     private static final String SCIM2_USERS_ENDPOINT = "scim2/Users";
     private static final String SCIM2_ROLES_ENDPOINT = "scim2/Roles";
+    private static final String SCIM2_V2_ROLES_ENDPOINT = "scim2/v2/Roles";
     private static final String SCIM2_GROUPS_ENDPOINT = "scim2/Groups";
     private static final String SCIM2_SEARCH_PATH = "/.search";
     public static final String SCHEMAS_ENDPOINT = "scim2/Schemas";
@@ -55,8 +57,10 @@ public class SCIM2RestClient extends RestBaseClient {
     private static final String SCIM_SCHEMA_EXTENSION_ENTERPRISE = "scimSchemaExtensionEnterprise";
     private static final String SCIM_SCHEMA_EXTENSION_SYSTEM = "scimSchemaExtensionSystem";
     private static final String DISPLAY_NAME_ATTRIBUTE = "displayName";
+    private static final String AUDIENCE_VALUE_ATTRIBUTE = "audience.value";
     private static final String ATTRIBUTES_PART = "?attributes=";
     private static final String EQ_OP = "eq";
+    private static final String AND_OP = "and";
     private static final int TIMEOUT_MILLIS = 30000;
     private static final int POLLING_INTERVAL_MILLIS = 500;
     private final String serverUrl;
@@ -147,6 +151,7 @@ public class SCIM2RestClient extends RestBaseClient {
     }
 
     /**
+     * @deprecated Use {@link #getSubOrgUser(String, String, String)} instead.
      * Get the details of a user of a sub organization.
      *
      * @param userId           ID of the user.
@@ -156,7 +161,27 @@ public class SCIM2RestClient extends RestBaseClient {
      */
     public JSONObject getSubOrgUser(String userId, String switchedM2MToken) throws Exception {
 
-        String endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId;
+        return getSubOrgUser(userId, null, switchedM2MToken);
+    }
+
+    /**
+     * Get the details of a user of a sub organization.
+     *
+     * @param userId           ID of the user.
+     * @param attribute Requested user attributes.
+     * @param switchedM2MToken Switched M2M token for the given organization.
+     * @return JSONObject of the HTTP response.
+     * @throws Exception If an error occurred while getting a user.
+     */
+    public JSONObject getSubOrgUser(String userId, String attribute, String switchedM2MToken) throws Exception {
+
+        String endPointUrl;
+
+        if (StringUtils.isEmpty(attribute)) {
+            endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId;
+        } else {
+            endPointUrl = getSubOrgUsersPath() + PATH_SEPARATOR + userId + ATTRIBUTES_PART + attribute;
+        }
 
         try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl,
                 getHeadersWithBearerToken(switchedM2MToken))) {
@@ -408,6 +433,109 @@ public class SCIM2RestClient extends RestBaseClient {
         try (CloseableHttpResponse response = getResponseOfHttpDelete(endPointUrl, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_NO_CONTENT,
                     "Role deletion failed");
+        }
+    }
+
+    /**
+     * Add a new role in v2.
+     *
+     * @param role Role request object.
+     * @return Role id.
+     * @throws IOException If an error occurred while adding a role.
+     */
+    public String addV2Role(RoleV2 role) throws IOException {
+
+        String jsonRequest = toJSONString(role);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(getRolesV2Path(), jsonRequest,
+                getHeaders())) {
+            String[] locationElements = response.getHeaders(LOCATION_HEADER)[0].toString().split(PATH_SEPARATOR);
+            return locationElements[locationElements.length - 1];
+        }
+    }
+
+    /**
+     * Update users of a role v2.
+     *
+     * @param roleId        Role id.
+     * @param patchRoleInfo Role patch request object.
+     * @throws IOException If an error occurred while updating users of a role.
+     */
+    public void updateUsersOfRoleV2(String roleId, PatchOperationRequestObject patchRoleInfo) throws IOException {
+
+        String jsonRequest = toJSONString(patchRoleInfo);
+        String endPointUrl = getRolesV2Path() + PATH_SEPARATOR + roleId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Role update failed.");
+        }
+    }
+
+    /**
+     * Update users of a role v2 in sub organization.
+     *
+     * @param roleId           Role id.
+     * @param patchRoleInfo    Role patch request object.
+     * @param switchedM2MToken Switched M2M token for the given organization.
+     * @throws IOException If an error occurred while updating users of a role.
+     */
+    public void updateUsersOfRoleV2InSubOrg(String roleId, PatchOperationRequestObject patchRoleInfo,
+                                            String switchedM2MToken) throws IOException {
+
+        String jsonRequest = toJSONString(patchRoleInfo);
+        String endPointUrl = getSubOrgRolesV2Path() + PATH_SEPARATOR + roleId;
+        try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest,
+                getHeadersWithBearerToken(switchedM2MToken))) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Role update failed.");
+        }
+    }
+
+    /**
+     * Delete an existing role in v2.
+     *
+     * @param roleId Role id.
+     * @throws IOException If an error occurred while deleting a role.
+     */
+    public void deleteV2Role(String roleId) throws IOException {
+
+        String endPointUrl = getRolesV2Path() + PATH_SEPARATOR + roleId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpDelete(endPointUrl, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_NO_CONTENT,
+                    "Role deletion failed");
+        }
+    }
+
+    /**
+     * Search the details of a v2 role in sub org by name and audience value.
+     *
+     * @param roleName         Role name.
+     * @param audienceValue    Audience value.
+     * @param switchedM2MToken Switched M2M token for the given organization.
+     * @return Role id.
+     */
+    public String getRoleIdByNameAndAudienceInSubOrg(String roleName, String audienceValue, String switchedM2MToken)
+            throws Exception {
+
+        RoleSearchRequestObject roleSearchObj = new RoleSearchRequestObject();
+        roleSearchObj.addSchemas(ROLE_SEARCH_SCHEMA);
+
+        String filterString =
+                DISPLAY_NAME_ATTRIBUTE + " " + EQ_OP + " " + roleName + " " + AND_OP + " " + AUDIENCE_VALUE_ATTRIBUTE +
+                        " " + EQ_OP + " " + audienceValue;
+        roleSearchObj.setFilter(filterString);
+
+        String jsonRequest = toJSONString(roleSearchObj);
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(getSubOrgRolesV2Path() + SCIM2_SEARCH_PATH,
+                jsonRequest, getHeadersWithBearerToken(switchedM2MToken))) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Role search failed");
+            JSONObject jsonResponse = getJSONObject(EntityUtils.toString(response.getEntity()));
+            JSONObject searchResult = (JSONObject) ((JSONArray) jsonResponse.get("Resources")).get(0);
+
+            return searchResult.get("id").toString();
         }
     }
 
@@ -677,6 +805,22 @@ public class SCIM2RestClient extends RestBaseClient {
         } else {
             return serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR + SCIM2_ROLES_ENDPOINT;
         }
+    }
+
+    private String getRolesV2Path() {
+
+        if (tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return serverUrl + SCIM2_V2_ROLES_ENDPOINT;
+        }
+        return serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR + SCIM2_V2_ROLES_ENDPOINT;
+    }
+
+    private String getSubOrgRolesV2Path() {
+
+        if (tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return serverUrl + ORGANIZATION_PATH + SCIM2_V2_ROLES_ENDPOINT;
+        }
+        return serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR + ORGANIZATION_PATH + SCIM2_V2_ROLES_ENDPOINT;
     }
 
     private String getGroupsPath() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -896,12 +896,12 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
                                                           String clientSecret) throws Exception {
 
         List<NameValuePair> parameters = new ArrayList<>();
-        parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_RESOURCE_OWNER));
+        parameters.add(new BasicNameValuePair(OAuth2Constant.GRANT_TYPE_NAME, OAuth2Constant.OAUTH2_GRANT_TYPE_RESOURCE_OWNER));
         parameters.add(new BasicNameValuePair("username", username));
         parameters.add(new BasicNameValuePair("password", password));
 
         String scopes = String.join(" ", requestedScopes);
-        parameters.add(new BasicNameValuePair("scope", scopes));
+        parameters.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_SCOPE, scopes));
 
         List<Header> headers = new ArrayList<>();
         headers.add(new BasicHeader(AUTHORIZATION_HEADER,
@@ -919,9 +919,9 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
 
         List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair(OAuth2Constant.GRANT_TYPE_NAME, "organization_switch"));
-        parameters.add(new BasicNameValuePair("token", currentToken));
+        parameters.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_RESPONSE_TYPE_TOKEN, currentToken));
         String scopes = String.join(" ", requestedScopes);
-        parameters.add(new BasicNameValuePair("scope", scopes));
+        parameters.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_SCOPE, scopes));
         parameters.add(new BasicNameValuePair("switching_organization", switchingOrganizationId));
 
         List<Header> headers = new ArrayList<>();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/store/OrganizationSecondaryUserStoreTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/store/OrganizationSecondaryUserStoreTestCase.java
@@ -239,7 +239,7 @@ public class OrganizationSecondaryUserStoreTestCase extends OAuth2ServiceAbstrac
             description = "Get a sub organization user in the secondary JDBC user store.")
     public void testGetUserSecondaryJDBCUserStore() throws Exception {
 
-        org.json.simple.JSONObject userResponse = scim2RestClient.getSubOrgUser(userId, null ,switchedM2MToken);
+        org.json.simple.JSONObject userResponse = scim2RestClient.getSubOrgUser(userId, null, switchedM2MToken);
 
         // Assert username.
         Assert.assertNotNull(userResponse.get(USER_NAME), "User name is null.");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/store/OrganizationSecondaryUserStoreTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/store/OrganizationSecondaryUserStoreTestCase.java
@@ -239,7 +239,7 @@ public class OrganizationSecondaryUserStoreTestCase extends OAuth2ServiceAbstrac
             description = "Get a sub organization user in the secondary JDBC user store.")
     public void testGetUserSecondaryJDBCUserStore() throws Exception {
 
-        org.json.simple.JSONObject userResponse = scim2RestClient.getSubOrgUser(userId, switchedM2MToken);
+        org.json.simple.JSONObject userResponse = scim2RestClient.getSubOrgUser(userId, null ,switchedM2MToken);
 
         // Assert username.
         Assert.assertNotNull(userResponse.get(USER_NAME), "User name is null.");

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/authorized-apis.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/authorized-apis.json
@@ -16,6 +16,20 @@
     "internal_org_organization_create",
     "internal_org_organization_delete"
   ],
+  "/o/scim2/Roles": [
+    "internal_org_role_mgt_view",
+    "internal_org_role_mgt_update"
+  ],
+  "/o/scim2/Groups": [
+    "internal_org_group_mgt_create",
+    "internal_org_group_mgt_view",
+    "internal_org_group_mgt_update",
+    "internal_org_group_mgt_delete"
+  ],
+  "/o/api/server/v1/applications": [
+    "internal_org_application_mgt_view",
+    "internal_org_application_mgt_update"
+  ],
   "/o/api/server/v1/claim-dialects": [
     "internal_org_claim_meta_view",
     "internal_org_claim_meta_update"


### PR DESCRIPTION
Part of https://github.com/wso2/product-is/issues/22426

This integration test covers:

1. Ability to configure groups, app audience roles and org audience roles for shared user
2. Retrieving groups, app audience roles and org audience roles of a shared user via scim user get call
3. Token obtained with password grant type by a user who has shared access to a sub org switch the token to sub org, and validate returned roles and groups in id token. This test is done against app role consuming app and organization role consuming app