### PR TITLE
Add integration tests for offline user invite with pre update password action

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/dataprovider/model/ExpectedPasswordUpdateResponse.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/dataprovider/model/ExpectedPasswordUpdateResponse.java
@@ -18,18 +18,20 @@
 
 package org.wso2.identity.integration.test.actions.dataprovider.model;
 
+import javax.servlet.http.HttpServletResponse;
+
 public class ExpectedPasswordUpdateResponse {
 
-    private final String statusCode;
+    private final Integer statusCode;
     private final String errorDetail;
 
-    public ExpectedPasswordUpdateResponse(String statusCode, String errorDetail) {
+    public ExpectedPasswordUpdateResponse(Integer statusCode, String errorDetail) {
 
         this.statusCode = statusCode;
         this.errorDetail = errorDetail;
     }
 
-    public String getStatusCode() {
+    public Integer getStatusCode() {
 
         return statusCode;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/dataprovider/model/ExpectedPasswordUpdateResponse.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/dataprovider/model/ExpectedPasswordUpdateResponse.java
@@ -22,16 +22,16 @@ import javax.servlet.http.HttpServletResponse;
 
 public class ExpectedPasswordUpdateResponse {
 
-    private final Integer statusCode;
+    private final int statusCode;
     private final String errorDetail;
 
-    public ExpectedPasswordUpdateResponse(Integer statusCode, String errorDetail) {
+    public ExpectedPasswordUpdateResponse(int statusCode, String errorDetail) {
 
         this.statusCode = statusCode;
         this.errorDetail = errorDetail;
     }
 
-    public Integer getStatusCode() {
+    public int getStatusCode() {
 
         return statusCode;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -68,7 +68,24 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     private static final String SCIM2_USERS_API = "/scim2/Users";
     private static final String INTERNAL_USER_MANAGEMENT_UPDATE = "internal_user_mgt_update";
     private static final String APP_CALLBACK_URL = "http://localhost:8490/playground2/oauth2client";
-    private static final String PRE_UPDATE_PASSWORD_API_PATH = "preUpdatePassword";
+
+    protected static final String TEST_USER1_USERNAME = "testUsername";
+    protected static final String TEST_USER2_USERNAME = "testUsername2";
+    protected static final String TEST_USER_PASSWORD = "TestPassword@123";
+    protected static final String TEST_USER_UPDATED_PASSWORD = "UpdatedTestPassword@123";
+    protected static final String RESET_PASSWORD = "ResetTestPassword@123";
+    protected static final String TEST_USER_GIVEN_NAME = "test_user_given_name";
+    protected static final String TEST_USER_LASTNAME = "test_user_last_name";
+    protected static final String TEST_USER_EMAIL = "test.user@gmail.com";
+    protected static final String PRIMARY_USER_STORE_ID = "UFJJTUFSWQ==";
+    protected static final String PRIMARY_USER_STORE_NAME = "PRIMARY";
+    protected static final String USER_SYSTEM_SCHEMA_ATTRIBUTE ="urn:scim:wso2:schema";
+    protected static final String FORCE_PASSWORD_RESET_ATTRIBUTE = "forcePasswordReset";
+    protected static final String PRE_UPDATE_PASSWORD_API_PATH = "preUpdatePassword";
+    protected static final String ACTION_NAME = "Pre Update Password Action";
+    protected static final String ACTION_DESCRIPTION = "This is a test for pre update password action type";
+    protected static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+    protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
 
     protected CloseableHttpClient client;
     protected IdentityGovernanceRestClient identityGovernanceRestClient;
@@ -98,7 +115,6 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
                 .build();
 
         identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
-
     }
 
     protected void updatePasswordRecoveryFeatureStatus(boolean enable) throws IOException {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -180,7 +180,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(), TEST_USER_PASSWORD);
 
         assertNotNull(response);
-        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode().toString());
+        assertEquals(response.get("status"), String.valueOf(expectedPasswordUpdateResponse.getStatusCode()));
         assertTrue(response.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
         assertActionRequestPayload(userId, TEST_USER_UPDATED_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
                 PreUpdatePasswordEvent.Action.UPDATE);
@@ -199,7 +199,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         org.json.simple.JSONObject response = scim2RestClient.updateUserAndReturnResponse(patchUserInfo, userId);
 
         assertNotNull(response);
-        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode().toString());
+        assertEquals(response.get("status"), String.valueOf(expectedPasswordUpdateResponse.getStatusCode()));
         assertTrue(response.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
         assertActionRequestPayload(userId, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
                 PreUpdatePasswordEvent.Action.UPDATE);
@@ -275,7 +275,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
 
         assertNotNull(response);
-        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode().toString());
+        assertEquals(response.get("status"), String.valueOf(expectedPasswordUpdateResponse.getStatusCode()));
         assertTrue(response.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
         assertActionRequestPayload(userId, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION,
                 PreUpdatePasswordEvent.Action.UPDATE);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/actions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -34,6 +34,7 @@ import org.wso2.identity.integration.test.rest.api.server.application.management
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.rest.api.user.common.model.*;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UsersRestClient;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.FileUtils;
 
@@ -41,6 +42,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -53,41 +56,22 @@ import static org.testng.Assert.assertTrue;
  */
 public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordActionBaseTestCase {
 
-    private static final String TEST_USER1_USERNAME = "testUsername";
-    private static final String TEST_USER2_USERNAME = "testUsername2";
-    private static final String TEST_USER_PASSWORD = "TestPassword@123";
-    private static final String TEST_USER_UPDATED_PASSWORD = "UpdatedTestPassword@123";
-    private static final String RESET_PASSWORD = "ResetTestPassword@123";
-    private static final String TEST_USER_GIVEN_NAME = "test_user_given_name";
-    private static final String TEST_USER_LASTNAME = "test_user_last_name";
-    private static final String TEST_USER_EMAIL = "test.user@gmail.com";
-    private static final String PASSWORD_PROPERTY = "password";
-    private static final String PRIMARY_USER_STORE_ID = "UFJJTUFSWQ==";
-    private static final String PRIMARY_USER_STORE_NAME = "PRIMARY";
-    private static final String ACTION_NAME = "Pre Update Password Action";
-    private static final String ACTION_DESCRIPTION = "This is a test for pre update password action type";
-    private static final String PRE_UPDATE_PASSWORD_API_PATH = "preUpdatePassword";
-    private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
-    private static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
-    private static final String EMAIL_INVITE_PASSWORD_RESET_ERROR = "The server encountered an internal error.";
+    private static final String PASSWORD_RESET_ERROR = "The server encountered an internal error.";
 
     private final String tenantId;
     private final TestUserMode userMode;
 
     private SCIM2RestClient scim2RestClient;
+    private UsersRestClient usersRestClient;
 
     private String clientId;
     private String clientSecret;
     private String actionId;
-    private String applicationId;
     private String userId;
     private ApplicationResponseModel application;
     private ActionsMockServer actionsMockServer;
     private final ActionResponse actionResponse;
     private final ExpectedPasswordUpdateResponse expectedPasswordUpdateResponse;
-
-    private static final String USER_SYSTEM_SCHEMA_ATTRIBUTE = "urn:scim:wso2:schema";
-    private static final String FORCE_PASSWORD_RESET_ATTRIBUTE = "forcePasswordReset";
 
     @Factory(dataProvider = "testExecutionContextProvider")
     public PreUpdatePasswordActionFailureTestCase(TestUserMode testUserMode, ActionResponse actionResponse,
@@ -103,45 +87,43 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
     public static Object[][] getTestExecutionContext() throws IOException, URISyntaxException {
 
         return new Object[][]{
-                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(200,
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(HttpServletResponse.SC_OK,
                         FileUtils.readFileInClassPathAsString("actions/response/failure-response.json")),
-                        new ExpectedPasswordUpdateResponse("400", "Some failure reason. " +
-                                "Some description")},
-                {TestUserMode.TENANT_USER, new ActionResponse(200,
+                        new ExpectedPasswordUpdateResponse(HttpServletResponse.SC_BAD_REQUEST,
+                                "Some failure reason. Some description")},
+                {TestUserMode.TENANT_USER, new ActionResponse(HttpServletResponse.SC_OK,
                         FileUtils.readFileInClassPathAsString("actions/response/failure-response.json")),
-                        new ExpectedPasswordUpdateResponse("400", "Some failure reason. " +
-                                "Some description")},
-                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(500,
+                        new ExpectedPasswordUpdateResponse(HttpServletResponse.SC_BAD_REQUEST,
+                                "Some failure reason. Some description")},
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                         FileUtils.readFileInClassPathAsString("actions/response/error-response.json")),
-                        new ExpectedPasswordUpdateResponse("500", "Error while updating " +
-                                "attributes of user")},
-                {TestUserMode.TENANT_USER, new ActionResponse(500,
+                        new ExpectedPasswordUpdateResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                                "Error while updating attributes of user")},
+                {TestUserMode.TENANT_USER, new ActionResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                         FileUtils.readFileInClassPathAsString("actions/response/error-response.json")),
-                        new ExpectedPasswordUpdateResponse("500", "Error while updating " +
-                                "attributes of user")},
+                        new ExpectedPasswordUpdateResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                                "Error while updating attributes of user")},
         };
     }
 
     @BeforeClass(alwaysRun = true)
     public void testInit() throws Exception {
 
-        Utils.getMailServer().purgeEmailFromAllMailboxes();
         super.init(userMode);
 
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        usersRestClient = new UsersRestClient(serverURL, tenantInfo);
 
         application = addApplicationWithGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
-        applicationId = application.getId();
-        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(application.getId());
         clientId = oidcConfig.getClientId();
         clientSecret = oidcConfig.getClientSecret();
 
-        UserObject userInfo = new UserObject();
-        userInfo.setUserName(TEST_USER1_USERNAME);
-        userInfo.setPassword(TEST_USER_PASSWORD);
-        userInfo.setName(new Name().givenName(TEST_USER_GIVEN_NAME));
-        userInfo.getName().setFamilyName(TEST_USER_LASTNAME);
-        userInfo.addEmail(new Email().value(TEST_USER_EMAIL));
+        UserObject userInfo = new UserObject()
+                .userName(TEST_USER1_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
+                .addEmail(new Email().value(TEST_USER_EMAIL));
         userId = scim2RestClient.createUser(userInfo);
 
         updatePasswordRecoveryFeatureStatus(true);
@@ -173,7 +155,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         updateAdminInitiatedPasswordResetEmailFeatureStatus(false);
 
         deleteAction(PRE_UPDATE_PASSWORD_API_PATH, actionId);
-        deleteApp(applicationId);
+        deleteApp(application.getId());
         scim2RestClient.deleteUser(userId);
         restClient.closeHttpClient();
         identityGovernanceRestClient.closeHttpClient();
@@ -188,16 +170,17 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
     @Test(description = "Verify the password update in self service portal with pre update password action")
     public void testUserUpdatePassword() throws Exception {
 
-        UserItemAddGroupobj updateUserPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
         Map<String, String> passwordValue = new HashMap<>();
         passwordValue.put(PASSWORD_PROPERTY, TEST_USER_UPDATED_PASSWORD);
-        updateUserPatchOp.setValue(passwordValue);
-        org.json.simple.JSONObject response = scim2RestClient.updateUserMe(new PatchOperationRequestObject()
-                        .addOperations(updateUserPatchOp), TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(),
-                TEST_USER_PASSWORD);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(new UserItemAddGroupobj()
+                        .op(UserItemAddGroupobj.OpEnum.REPLACE)
+                        .value(passwordValue));
+        org.json.simple.JSONObject response = scim2RestClient.updateUserMe(patchUserInfo,
+                TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(), TEST_USER_PASSWORD);
 
         assertNotNull(response);
-        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode());
+        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode().toString());
         assertTrue(response.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
         assertActionRequestPayload(userId, TEST_USER_UPDATED_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
                 PreUpdatePasswordEvent.Action.UPDATE);
@@ -207,15 +190,16 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the admin update password with pre update password action")
     public void testAdminUpdatePassword() throws Exception {
 
-        UserItemAddGroupobj updateUserPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
         Map<String, String> passwordValue = new HashMap<>();
         passwordValue.put(PASSWORD_PROPERTY, TEST_USER_PASSWORD);
-        updateUserPatchOp.setValue(passwordValue);
-        org.json.simple.JSONObject response = scim2RestClient.updateUserAndReturnResponse(
-                new PatchOperationRequestObject().addOperations(updateUserPatchOp), userId);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(new UserItemAddGroupobj()
+                        .op(UserItemAddGroupobj.OpEnum.REPLACE)
+                        .value(passwordValue));
+        org.json.simple.JSONObject response = scim2RestClient.updateUserAndReturnResponse(patchUserInfo, userId);
 
         assertNotNull(response);
-        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode());
+        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode().toString());
         assertTrue(response.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
         assertActionRequestPayload(userId, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
                 PreUpdatePasswordEvent.Action.UPDATE);
@@ -230,14 +214,8 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
 
         String recoveryLink = getRecoveryURLFromEmail();
         HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
-        String htmlContent = EntityUtils.toString(postResponse.getEntity());
-        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), 200);
-
-        if (expectedPasswordUpdateResponse.getStatusCode().equals("400")) {
-            assertTrue(htmlContent.contains(expectedPasswordUpdateResponse.getErrorDetail()));
-        } else {
-            assertTrue(htmlContent.contains(EMAIL_INVITE_PASSWORD_RESET_ERROR));
-        }
+        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        assertErrors(postResponse);
 
         assertActionRequestPayload(userId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
                 PreUpdatePasswordEvent.Action.RESET);
@@ -247,21 +225,17 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the admin force password reset with pre update password action")
     public void testAdminForcePasswordReset() throws Exception {
 
-        UserItemAddGroupobj updateUserPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
-        updateUserPatchOp.setPath(USER_SYSTEM_SCHEMA_ATTRIBUTE + ":" + FORCE_PASSWORD_RESET_ATTRIBUTE);
-        updateUserPatchOp.setValue(true);
-        scim2RestClient.updateUser(new PatchOperationRequestObject().addOperations(updateUserPatchOp), userId);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(new UserItemAddGroupobj()
+                        .op(UserItemAddGroupobj.OpEnum.REPLACE)
+                        .path(USER_SYSTEM_SCHEMA_ATTRIBUTE + ":" + FORCE_PASSWORD_RESET_ATTRIBUTE)
+                        .value(true));
+        scim2RestClient.updateUser(patchUserInfo, userId);
 
         String recoveryLink = getRecoveryURLFromEmail();
         HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
-        String htmlContent = EntityUtils.toString(postResponse.getEntity());
-        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), 200);
-
-        if (expectedPasswordUpdateResponse.getStatusCode().equals("400")) {
-            assertTrue(htmlContent.contains(expectedPasswordUpdateResponse.getErrorDetail()));
-        } else {
-            assertTrue(htmlContent.contains(EMAIL_INVITE_PASSWORD_RESET_ERROR));
-        }
+        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        assertErrors(postResponse);
 
         assertActionRequestPayload(userId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
                 PreUpdatePasswordEvent.Action.RESET);
@@ -271,49 +245,65 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the admin invite user to set password with pre update password action")
     public void testAdminInviteUserToSetPassword() throws Exception {
 
-        UserObject userInfo = new UserObject();
-        userInfo.setUserName(TEST_USER2_USERNAME);
-        userInfo.setPassword(TEST_USER_PASSWORD);
-        userInfo.setName(new Name().givenName(TEST_USER_GIVEN_NAME));
-        userInfo.getName().setFamilyName(TEST_USER_LASTNAME);
-        userInfo.setScimSchemaExtensionSystem(new ScimSchemaExtensionSystem().askPassword(true));
-        userInfo.addEmail(new Email().value(TEST_USER_EMAIL));
-        String tempUserId = scim2RestClient.createUser(userInfo);
+        UserObject adminInvitedUserInfo = new UserObject()
+                .userName(TEST_USER2_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
+                .addEmail(new Email().value(TEST_USER_EMAIL))
+                .scimSchemaExtensionSystem(new ScimSchemaExtensionSystem().askPassword(true));
+        String adminInvitedUserId = scim2RestClient.createUser(adminInvitedUserInfo);
 
         String recoveryLink = getRecoveryURLFromEmail();
         HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
-        String htmlContent = EntityUtils.toString(postResponse.getEntity());
-        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), 200);
+        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        assertErrors(postResponse);
 
-        if (expectedPasswordUpdateResponse.getStatusCode().equals("400")) {
-            assertTrue(htmlContent.contains(expectedPasswordUpdateResponse.getErrorDetail()));
-        } else {
-            assertTrue(htmlContent.contains(EMAIL_INVITE_PASSWORD_RESET_ERROR));
-        }
-
-        assertActionRequestPayload(tempUserId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
+        assertActionRequestPayload(adminInvitedUserId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
                 PreUpdatePasswordEvent.Action.INVITE);
-        scim2RestClient.deleteUser(tempUserId);
+        scim2RestClient.deleteUser(adminInvitedUserId);
     }
 
     @Test(dependsOnMethods = "testAdminInviteUserToSetPassword",
             description = "Verify the password update by an authorized application with pre update password action")
     public void testApplicationUpdatePassword() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(applicationId, clientId, clientSecret);
-
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         Map<String, String> passwordValue = new HashMap<>();
         passwordValue.put(PASSWORD_PROPERTY, TEST_USER_PASSWORD);
-        UserItemAddGroupobj updateUserPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
-        updateUserPatchOp.setValue(passwordValue);
-        org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(
-                new PatchOperationRequestObject().addOperations(updateUserPatchOp), userId, token);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE).value(passwordValue));
+        org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
 
         assertNotNull(response);
-        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode());
+        assertEquals(response.get("status"), expectedPasswordUpdateResponse.getStatusCode().toString());
         assertTrue(response.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
         assertActionRequestPayload(userId, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION,
                 PreUpdatePasswordEvent.Action.UPDATE);
+    }
+
+    @Test(dependsOnMethods = "testApplicationUpdatePassword",
+            description = "Verify the user password set with pre update password action via offline invite link")
+    public void testUserSetPasswordViaOfflineInviteLink() throws Exception {
+
+        UserObject offlineInvitingUserInfo = new UserObject()
+                .userName(TEST_USER2_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
+                .addEmail(new Email().value(TEST_USER_EMAIL));
+        String offlineInvitingUserId = scim2RestClient.createUser(offlineInvitingUserInfo);
+
+        InvitationRequest invitationRequest = new InvitationRequest()
+                .username(offlineInvitingUserInfo.getUserName())
+                .userstore(PRIMARY_USER_STORE_NAME);
+        String inviteLink = usersRestClient.generateOfflineInviteLink(invitationRequest);
+
+        HttpResponse postResponse = resetPassword(inviteLink, RESET_PASSWORD);
+        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        assertErrors(postResponse);
+
+        assertActionRequestPayload(offlineInvitingUserId, RESET_PASSWORD,
+                PreUpdatePasswordEvent.FlowInitiatorType.ADMIN, PreUpdatePasswordEvent.Action.INVITE);
+        scim2RestClient.deleteUser(offlineInvitingUserId);
     }
 
     private void assertActionRequestPayload(String userId, String updatedPassword,
@@ -338,5 +328,20 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         assertEquals(user.getUpdatingCredential().getValue(), updatedPassword.toCharArray());
         assertEquals(actionRequest.getEvent().getInitiatorType(), initiatorType);
         assertEquals(actionRequest.getEvent().getAction(), action);
+    }
+
+    private void assertErrors(HttpResponse postResponse) throws IOException {
+
+        String htmlContent = EntityUtils.toString(postResponse.getEntity());
+        switch (expectedPasswordUpdateResponse.getStatusCode()) {
+            case HttpServletResponse.SC_BAD_REQUEST:
+                assertTrue(htmlContent.contains(expectedPasswordUpdateResponse.getErrorDetail()));
+                break;
+            case HttpServletResponse.SC_INTERNAL_SERVER_ERROR:
+                assertTrue(htmlContent.contains(PASSWORD_RESET_ERROR));
+                break;
+            default:
+                Assert.fail("Unexpected response status code: " + postResponse.getStatusLine().getStatusCode());
+        }
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/InvitationRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/common/model/InvitationRequest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.user.common.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * InvitationRequest model.
+ */
+public class InvitationRequest {
+  
+    private String username;
+    private String userstore;
+
+    public InvitationRequest username(String username) {
+
+        this.username = username;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "JohnDoe123", required = true, value = "")
+    @JsonProperty("username")
+    @Valid
+    @NotNull(message = "Property username cannot be null.")
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public InvitationRequest userstore(String userstore) {
+
+        this.userstore = userstore;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PRIMARY", required = true, value = "")
+    @JsonProperty("userstore")
+    @Valid
+    @NotNull(message = "Property userstore cannot be null.")
+    public String getUserstore() {
+        return userstore;
+    }
+    public void setUserstore(String userstore) {
+        this.userstore = userstore;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InvitationRequest invitationRequest = (InvitationRequest) o;
+        return Objects.equals(this.username, invitationRequest.username) &&
+            Objects.equals(this.userstore, invitationRequest.userstore);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, userstore);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InvitationRequest {\n");
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    userstore: ").append(toIndentedString(userstore)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "    \n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UsersRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UsersRestClient.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.identity.integration.test.rest.api.user.common.model.InvitationRequest;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class UsersRestClient extends RestBaseClient {
+
+    private static final String API_USERS_BASE_PATH = "api/users/v1";
+    private static final String OFFLINE_INVITE_LINK_PATH = "/offline-invite-link";
+
+    private final String offlineInviteLinkPath;
+    private final String username;
+    private final String password;
+
+    public UsersRestClient(String serverUrl, Tenant tenantInfo) {
+
+        String tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+        this.offlineInviteLinkPath = getOfflineInviteLinkPath(serverUrl, tenantDomain);
+    }
+
+    /**
+     * Generate offline invite link for the given user to set password.
+     *
+     * @param invitationRequest Invitation request.
+     * @return Offline invite link.
+     * @throws IOException   If an error occurred while generating the offline invite link.
+     */
+    public String generateOfflineInviteLink(InvitationRequest invitationRequest) throws IOException {
+
+        String jsonRequest = toJSONString(invitationRequest);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(offlineInviteLinkPath, jsonRequest, getHeaders())) {
+
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
+                    "Offline link generation failed.");
+            return EntityUtils.toString(response.getEntity());
+        }
+    }
+
+    private String getOfflineInviteLinkPath(String serverUrl, String tenantDomain) {
+
+        if (tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return serverUrl + API_USERS_BASE_PATH + OFFLINE_INVITE_LINK_PATH;
+        } else {
+            return serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR + API_USERS_BASE_PATH +
+                    OFFLINE_INVITE_LINK_PATH;
+        }
+    }
+
+    private Header[] getHeaders() {
+
+        Header[] headerList = new Header[3];
+        headerList[0] = new BasicHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
+        headerList[1] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+}


### PR DESCRIPTION
### Purpose

1. Add integration tests for offline user invite with pre update password action
2. Minor refactoring in pre update password test cases

### Related Issue
- https://github.com/wso2/product-is/issues/22638