### PR TITLE
Hide Entitlement UIs from carbon console

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -36,7 +36,8 @@
     "server-roles-mgt_menu",
     "logging_config_menu",
     "multitenancy_menu",
-    "resource_browser_menu"
+    "resource_browser_menu",
+    "identity_entitlement_menu"
   ],
   "http_access_log.directory": "${carbon.home}/repository/logs",
   "http_access_log.prefix": "http_access_",

--- a/modules/distribution/src/repository/resources/conf/infer.json
+++ b/modules/distribution/src/repository/resources/conf/infer.json
@@ -53,7 +53,8 @@
         "server-roles-mgt_menu",
         "logging_config_menu",
         "multitenancy_menu",
-        "resource_browser_menu"
+        "resource_browser_menu",
+        "identity_entitlement_menu"
       ]
     }
   }


### PR DESCRIPTION
$subject since alternative UI onboarded to the new console.

Related to,
- https://github.com/wso2/product-is/issues/23097

