### PR TITLE
Update integration test error message.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPFailureTest.java
@@ -396,7 +396,7 @@ public class IdPFailureTest extends IdPTestBase {
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .body("message", equalTo("Multiple authenticators found."));
+                .body("message", equalTo("Invalid federated authenticators combination."));
     }
 
     @Test


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23020

Fix the following issue:
If the userDefined is not specified for the federated authenticator PUT request payload, the default value must be SYSTEM. Current implementation is using USER for this PUT request secnario.

Related PR:
- https://github.com/wso2/identity-api-server/pull/840