### PR TITLE
Template the jmxEnabled property for the identity db

### DIFF
--- a/modules/distribution/src/repository/resources/conf/key-mappings.json
+++ b/modules/distribution/src/repository/resources/conf/key-mappings.json
@@ -7,6 +7,7 @@
   "database.shared_db.pool_options.default_auto_commit": "database.shared_db.pool_options.defaultAutoCommit",
   "database.shared_db.validation_query": "database.shared_db.validationQuery",
   "database.identity_db.validation_query": "database.identity_db.validationQuery",
+  "database.identity_db.jmx_enable": "database.identity_db.pool_options.jmxEnabled",
 
   "user_store.connection_url":"user_store.properties.ConnectionURL",
   "user_store.connection_name":"user_store.properties.ConnectionName",


### PR DESCRIPTION
## Purpose

JMX monitoring is enabled for the shared db as follows.

```
[database.shared_db]
...
jmx_enable = true
```

For the identity db, the property to enable JMX is not available in the templates due to which the pool options configurations are used as shown below instead.

```
[database.identity_db.pool_options]
jmxEnabled = true
```

This PR maps the `jmxEnabled` pool option configuration to the `jmx_enable` property under the identity db configurations, which would allow configuring it similar to the shared db in a consistent manner while also maintaining backward compatibility for the `jmxEnabled` property.

```
[database.identity_db]
...
jmx_enable = true
```

## Related Issues

- https://github.com/wso2/product-is/issues/22220