### PR TITLE
[Bump] Identity Organization Management version to 1.4.123

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2545,7 +2545,7 @@
         <identity.extension.utils>1.0.21</identity.extension.utils>
         <authenticator.auth.otp.commons.version>1.0.10</authenticator.auth.otp.commons.version>
 
-        <identity.org.mgt.version>1.4.122</identity.org.mgt.version>
+        <identity.org.mgt.version>1.4.123</identity.org.mgt.version>
         <identity.org.mgt.core.version>1.1.24</identity.org.mgt.core.version>
         <identity.organization.login.version>1.1.43</identity.organization.login.version>
         <identity.oauth2.grant.organizationswitch.version>1.1.27</identity.oauth2.grant.organizationswitch.version>


### PR DESCRIPTION
Bump idn.org.mgt version from 1.4.122 to 1.4.123.