### PR TITLE
Add Integration Tests for User Sharing API

### DIFF
--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -987,6 +987,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
         </dependency>

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingBaseTest.java
@@ -21,16 +21,20 @@ package org.wso2.identity.integration.test.rest.api.server.user.sharing.manageme
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -46,7 +50,14 @@ import org.wso2.identity.integration.test.rest.api.server.application.management
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.RequestedClaimConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
-import org.wso2.identity.integration.test.rest.api.server.roles.v2.model.Permission;
+import org.wso2.identity.integration.test.rest.api.server.roles.v2.model.Audience;
+import org.wso2.identity.integration.test.rest.api.server.roles.v2.model.RoleV2;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudience;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudienceAudience;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareRequestBodyUserCriteria;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
@@ -58,90 +69,122 @@ import org.wso2.identity.integration.test.utils.OAuth2Constant;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.everyItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.API_DEFINITION_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.API_PACKAGE_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.API_SERVER_V1_BASE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APPLICATION_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ATTRIBUTE_USER_EMAIL_DOMAIN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ATTRIBUTE_USER_PASSWORD;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ATTRIBUTE_USER_SCHEMA_SCIM2_USER;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.CLAIM_COUNTRY_URI;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.CLAIM_EMAIL_URI;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.CLAIM_GROUPS_URI;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.CLAIM_ROLES_URI;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ERROR_SETUP_SWAGGER_DEFINITION;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.GRANT_AUTHORIZATION_CODE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.GRANT_CLIENT_CREDENTIALS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.GRANT_IMPLICIT;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.GRANT_ORGANIZATION_SWITCH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.GRANT_PASSWORD;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.GRANT_REFRESH_TOKEN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.HEADER_AUTHORIZATION;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.HEADER_AUTHORIZATION_VALUE_BEARER;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.HEADER_CONTENT_TYPE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_APP_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_APP_DETAILS_OF_SUB_ORGS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_APP_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_APP_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_APP_SUB_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_CLIENT_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_CLIENT_SECRET;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_ROLE_IDS_BY_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_APP_DETAILS_KEY_ROLE_NAMES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_COUNT;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_IDS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_NAMES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_GENERAL_POLICY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_GENERAL_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_POLICY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_ORG_DETAILS_KEY_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_ORG_DETAILS_KEY_ORG_LEVEL;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_ORG_DETAILS_KEY_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_ORG_DETAILS_KEY_PARENT_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_DOMAIN_QUALIFIED_USER_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_IS_ROOT_ORG_USER;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_USER_DOMAIN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_USER_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_USER_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_USER_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_USER_ORG_LEVEL;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DETAILS_KEY_USER_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_DOMAIN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORGANIZATION_API_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORGANIZATION_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.PATH_SEPARATOR;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.QUERY_PARAM_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.QUERY_PARAM_SEPARATOR;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.QUERY_PARAM_VALUE_SEPARATOR;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_EMPTY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ROLES_AUDIENCE_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ROLES_AUDIENCE_TYPE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ROLES_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ROLES_REF;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_ROLES_SIZE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_SHARED_TYPE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SHARED_ORGS_SIZE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_LINKS_SIZE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARED_ORGANIZATIONS_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARED_ROLES_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARED_TYPE_SHARED;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARED_USER_ID_JSON_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.UNDERSCORE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.USER_SHARING_API_BASE_PATH;
+import static org.wso2.identity.integration.test.restclients.RestBaseClient.TENANT_PATH;
 import static org.wso2.identity.integration.test.restclients.RestBaseClient.USER_AGENT_ATTRIBUTE;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Base test class for the User Sharing REST APIs.
  */
 public class UserSharingBaseTest extends RESTAPIServerTestBase {
 
-    private static final String API_DEFINITION_NAME = "organization-user-share.yaml";
-    protected static final String AUTHORIZED_APIS_JSON = "user-sharing-apis.json";
-    static final String API_VERSION = "v1";
-    private static final String API_PACKAGE_NAME =
-            "org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1";
-
-    static final String USER_SHARING_API_BASE_PATH = "/users";
-    static final String SHARE_PATH = "/share";
-    static final String SHARE_WITH_ALL_PATH = "/share-with-all";
-    static final String UNSHARE_PATH = "/unshare";
-    static final String UNSHARE_WITH_ALL_PATH = "/unshare-with-all";
-    static final String SHARED_ORGANIZATIONS_PATH = "/shared-organizations";
-    static final String SHARED_ROLES_PATH = "/shared-roles";
-
-    protected static final String USER_ID = "userId";
-    protected static final String ORG_ID = "orgId";
-    protected static final String LIMIT_QUERY_PARAM = "limit";
-    protected static final String AFTER_QUERY_PARAM = "after";
-    protected static final String BEFORE_QUERY_PARAM = "before";
-    protected static final String FILTER_QUERY_PARAM = "filter";
-    protected static final String RECURSIVE_QUERY_PARAM = "recursive";
-
-    protected static final String ERROR_CODE_BAD_REQUEST = "UE-10000";
-    protected static final String ERROR_CODE_INVALID_PAGINATION_CURSOR = "ORG-60026";
-    protected static final String ERROR_CODE_SERVER_ERROR = "SE-50000";
-
-    protected static final String ROOT_ORG_NAME = "Root - Organization";
-    protected static final String L1_ORG_1_NAME = "L1 - Organization 1";
-    protected static final String L1_ORG_2_NAME = "L1 - Organization 2";
-    protected static final String L2_ORG_1_NAME = "L2 - Organization 1";
-    protected static final String L2_ORG_2_NAME = "L2 - Organization 2";
-    protected static final String L2_ORG_3_NAME = "L2 - Organization 3";
-    protected static final String L3_ORG_1_NAME = "L3 - Organization 1";
-
-    protected static final String APP_1_NAME = "App 1";
-    protected static final String APP_2_NAME = "App 2";
-
-    protected static final String SUPER_ORG = "Super";
-
-    protected static final String APPLICATION_AUDIENCE = "APPLICATION";
-    protected static final String ORGANIZATION_AUDIENCE = "ORGANIZATION";
-
-    protected static final String APP_ROLE_1 = "app-role-1";
-    protected static final String APP_ROLE_2 = "app-role-2";
-    protected static final String APP_ROLE_3 = "app-role-3";
-    protected static final String ORG_ROLE_1 = "org-role-1";
-    protected static final String ORG_ROLE_2 = "org-role-2";
-    protected static final String ORG_ROLE_3 = "org-role-3";
-
-    protected static final String ROOT_ORG_USERNAME = "rootUser";
-    protected static final String L1_ORG_1_USERNAME = "l1Org1User";
-
-    protected static final String INTERNAL_USER_SHARE = "internal_user_share";
-    protected static final String INTERNAL_USER_UNSHARE = "internal_user_unshare";
-    protected static final String INTERNAL_USER_SHARED_ACCESS_VIEW = "internal_user_shared_access_view";
-    protected static final String INTERNAL_ORG_USER_SHARE = "internal_org_user_share";
-    protected static final String INTERNAL_ORG_USER_UNSHARE = "internal_org_user_unshare";
-    protected static final String INTERNAL_ORG_USER_SHARED_ACCESS_VIEW = "internal_org_user_shared_access_view";
-
-    protected static final String EMAIL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
-    protected static final String COUNTRY_CLAIM_URI = "http://wso2.org/claims/country";
-    protected static final String ROLES_CLAIM_URI = "http://wso2.org/claims/roles";
-    protected static final String GROUPS_CLAIM_URI = "http://wso2.org/claims/groups";
-
     protected static String swaggerDefinition;
+
     protected OAuth2RestClient oAuth2RestClient;
     protected SCIM2RestClient scim2RestClient;
     protected OrgMgtRestClient orgMgtRestClient;
+    protected HttpClient httpClient;
+
+    protected Map<String, Map<String, Object>> userDetails;
+    protected Map<String, Map<String, Object>> orgDetails;
+    protected Map<String, Map<String, Object>> appDetails;
+    protected Map<String, Map<String, Object>> roleDetails;
 
     static {
         try {
             swaggerDefinition = getAPISwaggerDefinition(API_PACKAGE_NAME, API_DEFINITION_NAME);
         } catch (IOException e) {
-            Assert.fail(String.format("Unable to read the swagger definition %s from %s", API_DEFINITION_NAME,
-                    API_PACKAGE_NAME), e);
+            Assert.fail(String.format(ERROR_SETUP_SWAGGER_DEFINITION, API_DEFINITION_NAME, API_PACKAGE_NAME), e);
         }
     }
 
@@ -163,19 +206,18 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
         RestAssured.basePath = StringUtils.EMPTY;
     }
 
-    protected String getAppClientId(String applicationId) throws Exception {
+    // Request Sending Methods.
 
-        OpenIDConnectConfiguration oidcConfig = oAuth2RestClient.getOIDCInboundDetails(applicationId);
-        return oidcConfig.getClientId();
+    protected HttpResponse getResponseOfPostToSubOrg(String path, String body, String token) throws Exception {
+
+        HttpPost request = new HttpPost(
+                serverURL + TENANT_PATH + tenant + ORGANIZATION_API_PATH + API_SERVER_V1_BASE_PATH + path);
+        request.setHeaders(getHeaders(token));
+        request.setEntity(new StringEntity(body));
+        return httpClient.execute(request);
     }
 
-    protected String getAppClientSecret(String applicationId) throws Exception {
-
-        OpenIDConnectConfiguration oidcConfig = oAuth2RestClient.getOIDCInboundDetails(applicationId);
-        return oidcConfig.getClientSecret();
-    }
-
-    protected HttpResponse sendGetRequest(String endpointURL, HttpClient client) throws IOException {
+    protected HttpResponse sendGetRequest(String endpointURL, HttpClient client) throws Exception {
 
         HttpGet request = new HttpGet(endpointURL);
         request.setHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
@@ -183,7 +225,7 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
     }
 
     protected HttpResponse sendPostRequest(String endpointURL, List<NameValuePair> urlParameters, HttpClient client)
-            throws IOException {
+            throws Exception {
 
         HttpPost request = new HttpPost(endpointURL);
         request.setHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
@@ -191,53 +233,197 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
         return client.execute(request);
     }
 
-    protected HttpResponse sendPutRequest(String endpointURL, String body, HttpClient client) throws IOException {
+    // Methods to add organizations and sub organizations for testing purposes.
 
-        HttpPut request = new HttpPut(endpointURL);
-        request.setHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
-        request.setHeader("Content-Type", "application/json");
-        request.setEntity(new StringEntity(body));
-        return client.execute(request);
+    protected String addOrganization(String orgName) throws Exception {
+
+        String orgId = orgMgtRestClient.addOrganization(orgName);
+        setOrgDetails(orgName, orgId, ROOT_ORG_ID, 1);
+        return orgId;
     }
 
-    protected HttpResponse sendDeleteRequest(String endpointURL, HttpClient client) throws IOException {
+    protected String addSubOrganization(String orgName, String parentId, int orgLevel) throws Exception {
 
-        HttpDelete request = new HttpDelete(endpointURL);
-        request.setHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
-        return client.execute(request);
+        String orgId = orgMgtRestClient.addSubOrganization(orgName, parentId);
+        setOrgDetails(orgName, orgId, parentId, orgLevel);
+        return orgId;
     }
 
-    /**
-     * Ged permissions based on the provided custom scopes.
-     *
-     * @return A list of permissions including predefined permissions
-     */
-    protected List<Permission> getPermissions() {
+    protected String getOrgId(String orgName) {
 
-        List<Permission> userPermissions = new ArrayList<>();
-
-        Collections.addAll(userPermissions,
-                new Permission(INTERNAL_USER_SHARE),
-                new Permission(INTERNAL_USER_UNSHARE),
-                new Permission(INTERNAL_USER_SHARED_ACCESS_VIEW));
-
-        return userPermissions;
+        return orgDetails.get(orgName).get(MAP_ORG_DETAILS_KEY_ORG_ID).toString();
     }
 
-    protected List<String> getRoleV2Schema() {
+    protected void setOrgDetails(String orgName, String orgId, String parentId, int orgLevel) throws Exception {
 
-        List<String> schemas = new ArrayList<>();
-        schemas.add("urn:ietf:params:scim:schemas:extension:2.0:Role");
-        return schemas;
+        Map<String, Object> orgDetail = new HashMap<>();
+        orgDetail.put(MAP_ORG_DETAILS_KEY_ORG_NAME, orgName);
+        orgDetail.put(MAP_ORG_DETAILS_KEY_ORG_ID, orgId);
+        orgDetail.put(MAP_ORG_DETAILS_KEY_PARENT_ORG_ID, parentId);
+        orgDetail.put(MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN, orgMgtRestClient.switchM2MToken(orgId));
+        orgDetail.put(MAP_ORG_DETAILS_KEY_ORG_LEVEL, orgLevel);
+        orgDetails.put(orgName, orgDetail);
     }
 
-    protected ApplicationResponseModel addApplication(String appName) throws Exception {
+    // Methods to add applications and roles for testing purposes.
+
+    protected Map<String, Object> createApplication(String appName, String audience, List<String> roleNames)
+            throws Exception {
+
+        Map<String, Object> createdAppDetails = new HashMap<>();
+        String rootOrgAppName = appName + UNDERSCORE + ROOT_ORG_NAME;
+
+        ApplicationResponseModel application = addApplication(appName);
+        String appId = application.getId();
+        OpenIDConnectConfiguration oidcConfig = oAuth2RestClient.getOIDCInboundDetails(appId);
+        String clientId = oidcConfig.getClientId();
+        String clientSecret = oidcConfig.getClientSecret();
+        Map<String, String> roleIdsByName = new HashMap<>();
+
+        if (StringUtils.equalsIgnoreCase(APPLICATION_AUDIENCE, audience)) {
+            Audience appRoleAudience = new Audience(APPLICATION_AUDIENCE, appId);
+            for (String roleName : roleNames) {
+                RoleV2 appRole =
+                        new RoleV2(appRoleAudience, roleName, Collections.emptyList(), Collections.emptyList());
+                String roleId = scim2RestClient.addV2Role(appRole);
+                roleIdsByName.put(roleName, roleId);
+            }
+            storeRoleDetails(APPLICATION_AUDIENCE, rootOrgAppName, roleIdsByName);
+            createdAppDetails.put(MAP_APP_DETAILS_KEY_APP_AUDIENCE, APPLICATION_AUDIENCE);
+        } else {
+            switchApplicationAudience(appId, AssociatedRolesConfig.AllowedAudienceEnum.ORGANIZATION);
+            for (String roleName : roleNames) {
+                String roleId = scim2RestClient.getRoleIdByName(roleName);
+                roleIdsByName.put(roleName, roleId);
+            }
+            createdAppDetails.put(MAP_APP_DETAILS_KEY_APP_AUDIENCE, ORGANIZATION_AUDIENCE);
+        }
+
+        // Mark roles and groups as requested claims for the app 2.
+        updateRequestedClaimsOfApp(appId, getClaimConfigurationsWithRolesAndGroups());
+        shareApplication(appId);
+
+        // Get sub org details of Applications.
+        Map<String, Object> appDetailsOfSubOrgs = new HashMap<>();
+        for (Map.Entry<String, Map<String, Object>> entry : orgDetails.entrySet()) {
+            String orgName = entry.getKey();
+            Map<String, Object> orgDetail = entry.getValue();
+
+            Map<String, Object> appDetailsOfSubOrg = getAppDetailsOfSubOrg(appName, audience, roleNames, orgDetail);
+            appDetailsOfSubOrgs.put(orgName, appDetailsOfSubOrg);
+        }
+
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_APP_NAME, appName);
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_APP_ID, appId);
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_CLIENT_ID, clientId);
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_CLIENT_SECRET, clientSecret);
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_ROLE_NAMES, roleNames);
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_ROLE_IDS_BY_NAME, roleIdsByName);
+        createdAppDetails.put(MAP_APP_DETAILS_KEY_APP_DETAILS_OF_SUB_ORGS, appDetailsOfSubOrgs);
+
+        appDetails.put(appName, createdAppDetails);
+        return createdAppDetails;
+    }
+
+    protected Map<String, Object> getAppDetailsOfSubOrg(String appName, String audience, List<String> roleNames,
+                                                        Map<String, Object> orgDetail) throws Exception {
+
+        Map<String, Object> subOrgAppDetails = new HashMap<>();
+
+        String subOrgName = (String) orgDetail.get(MAP_ORG_DETAILS_KEY_ORG_NAME);
+        String subOrgId = (String) orgDetail.get(MAP_ORG_DETAILS_KEY_ORG_ID);
+        String subOrgSwitchToken = (String) orgDetail.get(MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN);
+        String subOrgAppName = appName + PATH_SEPARATOR + subOrgName;
+
+        String subOrgAppId = oAuth2RestClient.getAppIdUsingAppNameInOrganization(appName, subOrgSwitchToken);
+
+        Map<String, String> subOrgRoleIdsByName = StringUtils.equalsIgnoreCase(APPLICATION_AUDIENCE, audience) ?
+                getSubOrgRoleIdsByName(roleNames, APPLICATION_AUDIENCE, subOrgAppName, subOrgAppId, subOrgSwitchToken) :
+                getSubOrgRoleIdsByName(roleNames, ORGANIZATION_AUDIENCE, subOrgName, subOrgId, subOrgSwitchToken);
+
+        subOrgAppDetails.put(MAP_APP_DETAILS_KEY_APP_SUB_ORG_NAME, subOrgName);
+        subOrgAppDetails.put(MAP_APP_DETAILS_KEY_APP_NAME, appName);
+        subOrgAppDetails.put(MAP_APP_DETAILS_KEY_APP_ID, subOrgAppId);
+        subOrgAppDetails.put(MAP_APP_DETAILS_KEY_ROLE_NAMES, roleNames);
+        subOrgAppDetails.put(MAP_APP_DETAILS_KEY_ROLE_IDS_BY_NAME, subOrgRoleIdsByName);
+        subOrgAppDetails.put(MAP_APP_DETAILS_KEY_APP_AUDIENCE, audience);
+
+        return subOrgAppDetails;
+    }
+
+    protected Map<String, String> getSubOrgRoleIdsByName(List<String> roleNames, String audienceType,
+                                                         String audienceName, String audienceValue,
+                                                         String subOrgSwitchToken) throws Exception {
+
+        Map<String, String> roleIdsByName = new HashMap<>();
+        for (String roleName : roleNames) {
+            String sharedAppRoleId =
+                    scim2RestClient.getRoleIdByNameAndAudienceInSubOrg(roleName, audienceValue, subOrgSwitchToken);
+            roleIdsByName.put(roleName, sharedAppRoleId);
+        }
+
+        if (StringUtils.equalsIgnoreCase(APPLICATION_AUDIENCE, audienceType)) {
+            storeRoleDetails(APPLICATION_AUDIENCE, audienceName, roleIdsByName);
+        } else {
+            storeRoleDetails(ORGANIZATION_AUDIENCE, audienceName, roleIdsByName);
+        }
+
+        return roleIdsByName;
+    }
+
+    protected Map<String, String> setUpOrganizationRoles(String orgName, List<String> orgRoleNames)
+            throws Exception {
+
+        Map<String, String> orgRoleIdsByName = new HashMap<>();
+        for (String orgRoleName : orgRoleNames) {
+            RoleV2 orgRole = new RoleV2(null, orgRoleName, Collections.emptyList(), Collections.emptyList());
+            String orgRoleId = scim2RestClient.addV2Role(orgRole);
+            orgRoleIdsByName.put(orgRoleName, orgRoleId);
+        }
+
+        storeRoleDetails(ORGANIZATION_AUDIENCE, orgName, orgRoleIdsByName);
+
+        return orgRoleIdsByName;
+    }
+
+    protected RoleWithAudience createRoleWithAudience(String roleName, String display, String type) {
+
+        RoleWithAudienceAudience audience = new RoleWithAudienceAudience();
+        audience.setDisplay(display);
+        audience.setType(type);
+
+        RoleWithAudience roleWithAudience = new RoleWithAudience();
+        roleWithAudience.setDisplayName(roleName);
+        roleWithAudience.setAudience(audience);
+
+        return roleWithAudience;
+    }
+
+    protected String getSharedOrgsRolesRef(String userId, String orgId) {
+
+        return API_SERVER_V1_BASE_PATH + USER_SHARING_API_BASE_PATH + PATH_SEPARATOR + userId + SHARED_ROLES_PATH +
+                QUERY_PARAM_SEPARATOR + QUERY_PARAM_ORG_ID + QUERY_PARAM_VALUE_SEPARATOR + orgId;
+    }
+
+    protected void storeRoleDetails(String audienceType, String audienceName, Map<String, String> rolesOfAudience) {
+
+        String key = StringUtils.equalsIgnoreCase(APPLICATION_AUDIENCE, audienceType)
+                ? APPLICATION_AUDIENCE
+                : ORGANIZATION_AUDIENCE;
+
+        Map<String, Object> rolesMapOfAudienceType = new HashMap<>();
+        rolesMapOfAudienceType.put(audienceName, rolesOfAudience);
+
+        roleDetails.computeIfAbsent(key, k -> new HashMap<>()).putAll(rolesMapOfAudienceType);
+    }
+
+    private ApplicationResponseModel addApplication(String appName) throws Exception {
 
         ApplicationModel application = new ApplicationModel();
 
         List<String> grantTypes = new ArrayList<>();
-        Collections.addAll(grantTypes, "authorization_code", "implicit", "password", "client_credentials",
-                "refresh_token", "organization_switch");
+        Collections.addAll(grantTypes, GRANT_AUTHORIZATION_CODE, GRANT_IMPLICIT, GRANT_PASSWORD,
+                GRANT_CLIENT_CREDENTIALS, GRANT_REFRESH_TOKEN, GRANT_ORGANIZATION_SWITCH);
 
         List<String> callBackUrls = new ArrayList<>();
         Collections.addAll(callBackUrls, OAuth2Constant.CALLBACK_URL);
@@ -261,23 +447,23 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
 
     private ClaimConfiguration setApplicationClaimConfig() {
 
-        ClaimMappings emailClaim = new ClaimMappings().applicationClaim(EMAIL_CLAIM_URI);
+        ClaimMappings emailClaim = new ClaimMappings().applicationClaim(CLAIM_EMAIL_URI);
         emailClaim.setLocalClaim(
                 new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(
-                        EMAIL_CLAIM_URI));
-        ClaimMappings countryClaim = new ClaimMappings().applicationClaim(COUNTRY_CLAIM_URI);
+                        CLAIM_EMAIL_URI));
+        ClaimMappings countryClaim = new ClaimMappings().applicationClaim(CLAIM_COUNTRY_URI);
         countryClaim.setLocalClaim(
                 new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(
-                        COUNTRY_CLAIM_URI));
+                        CLAIM_COUNTRY_URI));
 
         RequestedClaimConfiguration emailRequestedClaim = new RequestedClaimConfiguration();
         emailRequestedClaim.setClaim(
                 new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(
-                        EMAIL_CLAIM_URI));
+                        CLAIM_EMAIL_URI));
         RequestedClaimConfiguration countryRequestedClaim = new RequestedClaimConfiguration();
         countryRequestedClaim.setClaim(
                 new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(
-                        COUNTRY_CLAIM_URI));
+                        CLAIM_COUNTRY_URI));
 
         ClaimConfiguration claimConfiguration = new ClaimConfiguration().dialect(ClaimConfiguration.DialectEnum.CUSTOM);
         claimConfiguration.addClaimMappingsItem(emailClaim);
@@ -288,17 +474,32 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
         return claimConfiguration;
     }
 
-    protected void shareApplication(String applicationId) throws Exception {
+    private ClaimConfiguration getClaimConfigurationsWithRolesAndGroups() {
 
-        ApplicationSharePOSTRequest applicationSharePOSTRequest = new ApplicationSharePOSTRequest();
-        applicationSharePOSTRequest.setShareWithAllChildren(true);
-        oAuth2RestClient.shareApplication(applicationId, applicationSharePOSTRequest);
-
-        // Since application sharing is an async operation, wait for some time for it to finish.
-        Thread.sleep(5000);
+        ClaimConfiguration claimConfiguration = new ClaimConfiguration();
+        claimConfiguration.addRequestedClaimsItem(getRequestedClaim(CLAIM_ROLES_URI));
+        claimConfiguration.addRequestedClaimsItem(getRequestedClaim(CLAIM_GROUPS_URI));
+        return claimConfiguration;
     }
 
-    protected void switchApplicationAudience(String appId, AssociatedRolesConfig.AllowedAudienceEnum newAudience)
+    private RequestedClaimConfiguration getRequestedClaim(String claimUri) {
+
+        RequestedClaimConfiguration requestedClaim = new RequestedClaimConfiguration();
+        requestedClaim.setClaim(
+                new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(
+                        claimUri));
+        return requestedClaim;
+    }
+
+    private void updateRequestedClaimsOfApp(String applicationId, ClaimConfiguration claimConfigurationsForApp)
+            throws Exception {
+
+        ApplicationPatchModel applicationPatch = new ApplicationPatchModel();
+        applicationPatch.setClaimConfiguration(claimConfigurationsForApp);
+        oAuth2RestClient.updateApplication(applicationId, applicationPatch);
+    }
+
+    private void switchApplicationAudience(String appId, AssociatedRolesConfig.AllowedAudienceEnum newAudience)
             throws Exception {
 
         AssociatedRolesConfig associatedRolesConfigApp2 = new AssociatedRolesConfig();
@@ -310,54 +511,571 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
         oAuth2RestClient.updateApplication(appId, patchModelApp2);
     }
 
-    protected void updateRequestedClaimsOfApp(String applicationId, ClaimConfiguration claimConfigurationsForApp)
-            throws IOException {
+    private void shareApplication(String applicationId) throws Exception {
 
-        ApplicationPatchModel applicationPatch = new ApplicationPatchModel();
-        applicationPatch.setClaimConfiguration(claimConfigurationsForApp);
-        oAuth2RestClient.updateApplication(applicationId, applicationPatch);
+        ApplicationSharePOSTRequest applicationSharePOSTRequest = new ApplicationSharePOSTRequest();
+        applicationSharePOSTRequest.setShareWithAllChildren(true);
+        oAuth2RestClient.shareApplication(applicationId, applicationSharePOSTRequest);
+
+        // Since application sharing is an async operation, wait for some time for it to finish.
+        await().atMost(5, TimeUnit.SECONDS).until(() -> true);
     }
 
-    protected ClaimConfiguration getClaimConfigurationsWithRolesAndGroups() {
+    // Methods to add users in organizations and sub organizations for testing purposes.
 
-        ClaimConfiguration claimConfiguration = new ClaimConfiguration();
-        claimConfiguration.addRequestedClaimsItem(getRequestedClaim(ROLES_CLAIM_URI));
-        claimConfiguration.addRequestedClaimsItem(getRequestedClaim(GROUPS_CLAIM_URI));
-        return claimConfiguration;
-    }
+    protected UserObject createUserObject(String userDomain, String userName, String orgName) {
 
-    protected RequestedClaimConfiguration getRequestedClaim(String claimUri) {
-
-        RequestedClaimConfiguration requestedClaim = new RequestedClaimConfiguration();
-        requestedClaim.setClaim(
-                new org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim().uri(
-                        claimUri));
-        return requestedClaim;
-    }
-
-    protected static UserObject createUserObject(String userName, String orgName) {
-
+        String domainQualifiedUserName = userDomain + PATH_SEPARATOR + userName;
         UserObject user = new UserObject()
-                .userName("PRIMARY/" + userName)
-                .password("Admin123")
+                .userName(domainQualifiedUserName)
+                .password(ATTRIBUTE_USER_PASSWORD)
                 .name(new Name().givenName(userName).familyName(orgName))
                 .emails(new ArrayList<>());
 
         Email email = new Email();
-        email.setValue(userName + "@gmail.com");
+        email.setValue(userName + ATTRIBUTE_USER_EMAIL_DOMAIN);
         email.setPrimary(true);
         user.getEmails().add(email);
 
         List<String> schemas = new ArrayList<>();
-        schemas.add("urn:ietf:params:scim:schemas:core:2.0:User");
+        schemas.add(ATTRIBUTE_USER_SCHEMA_SCIM2_USER);
         user.setSchemas(schemas);
 
         return user;
     }
 
-    public String toJSONString(java.lang.Object object) {
+    protected String createUser(UserObject user) throws Exception {
+
+        String userId = scim2RestClient.createUser(user);
+        String domainQualifiedUserName = user.getUserName();
+        String domainQualifiedUserNameWithOrg = domainQualifiedUserName + PATH_SEPARATOR + ROOT_ORG_NAME;
+
+        Map<String, Object> userDetail = new HashMap<>();
+        userDetail.put(MAP_USER_DETAILS_KEY_DOMAIN_QUALIFIED_USER_NAME, domainQualifiedUserName);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_NAME,
+                getUserNameAndUserDomain(domainQualifiedUserName).get(MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_NAME));
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_DOMAIN,
+                getUserNameAndUserDomain(domainQualifiedUserName).get(MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_DOMAIN));
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ID, userId);
+        userDetail.put(MAP_USER_DETAILS_KEY_IS_ROOT_ORG_USER, true);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ORG_NAME, ROOT_ORG_NAME);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ORG_ID, ROOT_ORG_ID);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ORG_LEVEL, 0);
+
+        userDetails.put(domainQualifiedUserNameWithOrg, userDetail);
+        return userId;
+    }
+
+    protected String createSuborgUser(UserObject user, String suborg) throws Exception {
+
+        String userId = scim2RestClient.createSubOrgUser(user,
+                (String) orgDetails.get(suborg).get(MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN));
+        String domainQualifiedUserName = user.getUserName();
+        String domainQualifiedUserNameWithOrg = domainQualifiedUserName + PATH_SEPARATOR + suborg;
+
+        Map<String, Object> userDetail = new HashMap<>();
+        userDetail.put(MAP_USER_DETAILS_KEY_DOMAIN_QUALIFIED_USER_NAME, domainQualifiedUserName);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_NAME,
+                getUserNameAndUserDomain(domainQualifiedUserName).get(MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_NAME));
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_DOMAIN,
+                getUserNameAndUserDomain(domainQualifiedUserName).get(MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_DOMAIN));
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ID, userId);
+        userDetail.put(MAP_USER_DETAILS_KEY_IS_ROOT_ORG_USER, false);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ORG_NAME, suborg);
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ORG_ID, orgDetails.get(suborg).get(MAP_ORG_DETAILS_KEY_ORG_ID));
+        userDetail.put(MAP_USER_DETAILS_KEY_USER_ORG_LEVEL, orgDetails.get(suborg).get(MAP_ORG_DETAILS_KEY_ORG_LEVEL));
+
+        userDetails.put(domainQualifiedUserNameWithOrg, userDetail);
+        return userId;
+    }
+
+    protected String getUserId(String userName, String userDomain, String orgName) {
+
+        String domainQualifiedUserNameWithOrg = userDomain + PATH_SEPARATOR + userName + PATH_SEPARATOR + orgName;
+        return userDetails.get(domainQualifiedUserNameWithOrg).get(MAP_USER_DETAILS_KEY_USER_ID).toString();
+    }
+
+    private Map<String, String> getUserNameAndUserDomain(String domainQualifiedUserName) {
+
+        String[] parts = domainQualifiedUserName.split(PATH_SEPARATOR);
+        Map<String, String> userNameAndUserDomain = new HashMap<>();
+        userNameAndUserDomain.put(MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_NAME, parts[1]);
+        userNameAndUserDomain.put(MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_DOMAIN, parts[0]);
+        return userNameAndUserDomain;
+    }
+
+    // Method to validate user shared organizations and assigned roles.
+
+    /**
+     * Validates the user sharing results by checking if the users have been shared to the expected organizations
+     * with the expected roles.
+     * This method uses the Awaitility library to wait for up to 20 seconds, polling every 2 seconds, to ensure that
+     * the user sharing results are as expected. If the validation fails within this period, an exception is thrown.
+     *
+     * @param userIds         The list of user IDs to validate.
+     * @param expectedResults A map containing the expected results, including the expected organization count,
+     *                        expected organization IDs, expected organization names, and expected roles per organization.
+     * @throws Exception If an error occurs during validation.
+     */
+    protected void validateUserSharingResults(List<String> userIds, Map<String, Object> expectedResults)
+            throws Exception {
+
+        final Object[] lastException = {null};
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .until(() -> {
+                    try {
+                        for (String userId : userIds) {
+                            validateUserHasBeenSharedToExpectedOrgsWithExpectedRoles(userId, expectedResults);
+                        }
+                        lastException[0] = null;
+                        return true;
+                    } catch (AssertionError | Exception e) {
+                        lastException[0] = e;
+                        return false;
+                    }
+                });
+
+        if (lastException[0] != null) {
+            throw (Exception) lastException[0];
+        }
+    }
+
+    /**
+     * Validates user sharing results and retrieves the list of shared user IDs.
+     * This method uses the Awaitility library to wait for up to 20 seconds, polling every 2 seconds,
+     * to ensure that the user sharing results are as expected. If the validation fails within this period,
+     * an exception is thrown.
+     *
+     * @param userIds                The list of user IDs to validate.
+     * @param reSharingSubOrgDetails The details of the sub-organization for re-sharing.
+     * @param expectedSharedResults  A map containing the expected results, including the expected organization count,
+     *                               expected organization IDs, expected organization names, and expected roles per organization.
+     * @return A list of shared user IDs.
+     * @throws Exception If an error occurs during validation.
+     */
+    protected List<String> validateUserSharingResultsAndGetSharedUsersList(List<String> userIds,
+                                                                           Map<String, Object> reSharingSubOrgDetails,
+                                                                           Map<String, Object> expectedSharedResults)
+            throws Exception {
+
+        final Object[] lastException = {null};
+
+        List<String> sharedUserIds = new ArrayList<>();
+        await().atMost(20, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .until(() -> {
+                    try {
+                        for (String userId : userIds) {
+                            validateUserHasBeenSharedToExpectedOrgsWithExpectedRoles(userId, expectedSharedResults);
+                        }
+                        lastException[0] = null;
+                        return true;
+                    } catch (AssertionError | Exception e) {
+                        lastException[0] = e;
+                        return false;
+                    }
+                });
+
+        if (lastException[0] != null) {
+            throw (Exception) lastException[0];
+        }
+
+        // Once assertions pass, extract shared user IDs
+        for (String userId : userIds) {
+            Response sharedOrgsResponseOfUserId =
+                    getResponseOfGet(USER_SHARING_API_BASE_PATH + "/" + userId + SHARED_ORGANIZATIONS_PATH);
+            String sharedUserId = extractSharedUserId(sharedOrgsResponseOfUserId,
+                    reSharingSubOrgDetails.get(MAP_ORG_DETAILS_KEY_ORG_NAME).toString());
+            sharedUserIds.add(sharedUserId);
+        }
+        return sharedUserIds;
+    }
+
+    /**
+     * Validate that the user has been shared to the expected organizations with the expected roles.
+     *
+     * @param userId          The ID of the user to validate.
+     * @param expectedResults A map containing the expected results, including the expected organization count,
+     *                        expected organization IDs, expected organization names, and expected roles per
+     *                        organization.
+     *
+     * <p>
+     * The `@SuppressWarnings("unchecked")` annotation is used in this method because the values being cast are
+     * predefined in the test data providers.
+     * </p>
+     */
+    @SuppressWarnings("unchecked")
+    protected void validateUserHasBeenSharedToExpectedOrgsWithExpectedRoles(String userId,
+                                                                            Map<String, Object> expectedResults) {
+
+        testGetSharedOrganizations(userId, (int) expectedResults.get(MAP_KEY_EXPECTED_ORG_COUNT),
+                (List<String>) expectedResults.get(MAP_KEY_EXPECTED_ORG_IDS),
+                (List<String>) expectedResults.get(MAP_KEY_EXPECTED_ORG_NAMES));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg =
+                (Map<String, List<RoleWithAudience>>) expectedResults.get(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG);
+        for (Map.Entry<String, List<RoleWithAudience>> entry : expectedRolesPerExpectedOrg.entrySet()) {
+            testGetSharedRolesForOrg(userId, entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Test method for GET /user-sharing/{userId}/shared-organizations.
+     *
+     * @param userId           The ID of the user to get shared organizations for.
+     * @param expectedOrgCount The expected number of shared organizations.
+     * @param expectedOrgIds   The expected IDs of the shared organizations.
+     * @param expectedOrgNames The expected names of the shared organizations.
+     */
+    protected void testGetSharedOrganizations(String userId, int expectedOrgCount, List<String> expectedOrgIds,
+                                              List<String> expectedOrgNames) {
+
+        Response response =
+                getResponseOfGet(USER_SHARING_API_BASE_PATH + "/" + userId + SHARED_ORGANIZATIONS_PATH);
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(RESPONSE_LINKS_SIZE, equalTo(1))
+                .body(RESPONSE_LINKS_EMPTY, equalTo(true))
+                .body(RESPONSE_LINKS_SHARED_ORGS, notNullValue())
+                .body(RESPONSE_LINKS_SHARED_ORGS_SIZE, equalTo(expectedOrgCount))
+                .body(RESPONSE_LINKS_SHARED_ORGS_ID, hasItems(expectedOrgIds.toArray(new String[0])))
+                .body(RESPONSE_LINKS_SHARED_ORGS_NAME, hasItems(expectedOrgNames.toArray(new String[0])))
+                .body(RESPONSE_LINKS_SHARED_ORGS_SHARED_TYPE, everyItem(equalTo(SHARED_TYPE_SHARED)))
+                .body(RESPONSE_LINKS_SHARED_ORGS_ROLES_REF, hasItems(
+                        expectedOrgIds.stream()
+                                .map(orgId -> getSharedOrgsRolesRef(userId, orgId))
+                                .toArray(String[]::new)));
+    }
+
+    /**
+     * Test method for GET /user-sharing/{userId}/shared-roles?orgId={orgId}.
+     *
+     * @param userId        The ID of the user to get shared roles for.
+     * @param orgId         The ID of the organization to get shared roles for.
+     * @param expectedRoles The expected roles for the user in the specified organization.
+     */
+    protected void testGetSharedRolesForOrg(String userId, String orgId, List<RoleWithAudience> expectedRoles) {
+
+        Response response = getResponseOfGet(USER_SHARING_API_BASE_PATH + "/" + userId + SHARED_ROLES_PATH,
+                Collections.singletonMap(QUERY_PARAM_ORG_ID, orgId));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(RESPONSE_LINKS_SIZE, equalTo(1))
+                .body(RESPONSE_LINKS_EMPTY, equalTo(true))
+                .body(RESPONSE_LINKS_SHARED_ORGS_ROLES, notNullValue())
+                .body(RESPONSE_LINKS_SHARED_ORGS_ROLES_SIZE, equalTo(expectedRoles.size()));
+
+        if (!expectedRoles.isEmpty()) {
+            response.then()
+                    .body(RESPONSE_LINKS_SHARED_ORGS_ROLES_NAME, hasItems(
+                            expectedRoles.stream()
+                                    .map(RoleWithAudience::getDisplayName)
+                                    .toArray(String[]::new)))
+                    .body(RESPONSE_LINKS_SHARED_ORGS_ROLES_AUDIENCE_NAME, hasItems(
+                            expectedRoles.stream()
+                                    .map(role -> role.getAudience().getDisplay())
+                                    .toArray(String[]::new)))
+                    .body(RESPONSE_LINKS_SHARED_ORGS_ROLES_AUDIENCE_TYPE, hasItems(
+                            expectedRoles.stream()
+                                    .map(role -> role.getAudience().getType())
+                                    .toArray(String[]::new)));
+        }
+    }
+
+    // Methods to create request bodies for user sharing and unsharing.
+
+    /**
+     * Creates a `UserShareRequestBodyUserCriteria` object with the given user IDs.
+     *
+     * @param userIds The list of user IDs to be included in the criteria.
+     * @return A `UserShareRequestBodyUserCriteria` object containing the specified user IDs.
+     */
+    protected UserShareRequestBodyUserCriteria getUserCriteriaForBaseUserSharing(List<String> userIds) {
+
+        UserShareRequestBodyUserCriteria criteria = new UserShareRequestBodyUserCriteria();
+        criteria.setUserIds(userIds);
+        return criteria;
+    }
+
+    /**
+     * Creates a `UserUnshareRequestBodyUserCriteria` object with the given user IDs.
+     *
+     * @param userIds The list of user IDs to be included in the criteria.
+     * @return A `UserUnshareRequestBodyUserCriteria` object containing the specified user IDs.
+     */
+    protected UserUnshareRequestBodyUserCriteria getUserCriteriaForBaseUserUnsharing(List<String> userIds) {
+
+        UserUnshareRequestBodyUserCriteria criteria = new UserUnshareRequestBodyUserCriteria();
+        criteria.setUserIds(userIds);
+        return criteria;
+    }
+
+    /**
+     * Converts a map of organization details into a list of `UserShareRequestBodyOrganizations` objects.
+     *
+     * @param organizations A map where the key is the organization name and the value is a map of organization details.
+     * @return A list of `UserShareRequestBodyOrganizations` objects.
+     *
+     * <p>
+     * The `@SuppressWarnings("unchecked")` annotation is used in this method because the values being cast are
+     * predefined in the test data providers.
+     * </p>
+     */
+    @SuppressWarnings("unchecked")
+    protected List<UserShareRequestBodyOrganizations> getOrganizationsForSelectiveUserSharing(
+            Map<String, Map<String, Object>> organizations) {
+
+        List<UserShareRequestBodyOrganizations> orgs = new ArrayList<>();
+
+        for (Map.Entry<String, Map<String, Object>> entry : organizations.entrySet()) {
+
+            Map<String, Object> orgDetail = entry.getValue();
+
+            UserShareRequestBodyOrganizations org = new UserShareRequestBodyOrganizations();
+            org.setOrgId((String) orgDetail.get(MAP_KEY_SELECTIVE_ORG_ID));
+            org.setPolicy((UserShareRequestBodyOrganizations.PolicyEnum) orgDetail.get(MAP_KEY_SELECTIVE_POLICY));
+            org.setRoles((List<RoleWithAudience>) orgDetail.get(MAP_KEY_SELECTIVE_ROLES));
+
+            orgs.add(org);
+        }
+        return orgs;
+    }
+
+    /**
+     * Retrieves the policy enum for general user sharing from the provided map.
+     *
+     * @param policyWithRoles A map containing the policy and roles for general user sharing.
+     * @return The policy enum for general user sharing.
+     */
+    protected UserShareWithAllRequestBody.PolicyEnum getPolicyEnumForGeneralUserSharing(
+            Map<String, Object> policyWithRoles) {
+
+        return (UserShareWithAllRequestBody.PolicyEnum) policyWithRoles.get(MAP_KEY_GENERAL_POLICY);
+    }
+
+    /**
+     * Retrieves the roles for general user sharing from the provided map.
+     *
+     * @param policyWithRoles A map containing the policy and roles for general user sharing.
+     * @return A list of `RoleWithAudience` objects representing the roles for general user sharing.
+     *
+     * <p>
+     * The `@SuppressWarnings("unchecked")` annotation is used in this method because the values being cast are
+     * predefined in the test data providers.
+     * </p>
+     */
+    @SuppressWarnings("unchecked")
+    protected List<RoleWithAudience> getRolesForGeneralUserSharing(Map<String, Object> policyWithRoles) {
+
+        return (List<RoleWithAudience>) policyWithRoles.get(MAP_KEY_GENERAL_ROLES);
+    }
+
+    /**
+     * Retrieves the list of organization IDs from which the users are being selectively unshared.
+     *
+     * @param removingOrgIds The list of organization IDs to be removed.
+     * @return A list of organization IDs as strings.
+     */
+    protected List<String> getOrganizationsForSelectiveUserUnsharing(List<String> removingOrgIds) {
+
+        return removingOrgIds;
+    }
+
+    // Methods to clean up the resources created for testing purposes.
+
+    /**
+     * Clean up users by deleting them if they exist.
+     *
+     * @throws Exception If an error occurs while deleting the users.
+     */
+    protected void cleanUpUsers() throws Exception {
+
+        for (Map.Entry<String, Map<String, Object>> entry : userDetails.entrySet()) {
+            String userId = (String) entry.getValue().get(MAP_USER_DETAILS_KEY_USER_ID);
+            String orgName = (String) entry.getValue().get(MAP_USER_DETAILS_KEY_USER_ORG_NAME);
+            int orgLevel = (int) entry.getValue().get(MAP_USER_DETAILS_KEY_USER_ORG_LEVEL);
+
+            if (orgLevel == 0) {
+                deleteUserIfExists(userId);
+            } else {
+                deleteSubOrgUserIfExists(userId,
+                        (String) orgDetails.get(orgName).get(MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN));
+            }
+        }
+    }
+
+    /**
+     * Cleans up roles for the specified audiences if exists.
+     * Audiences will always be either ORGANIZATION_AUDIENCE or APPLICATION_AUDIENCE or both.
+     *
+     * @param audiences The audiences for which roles need to be cleaned up.
+     * @throws Exception If an error occurs during the cleanup process.
+     *
+     * <p>
+     * The `@SuppressWarnings("unchecked")` annotation is used in this method because the values being cast are
+     * predefined in the test data providers.
+     * </p>
+     */
+    @SuppressWarnings("unchecked")
+    protected void cleanUpRoles(String... audiences) throws Exception {
+
+        for (String audience : audiences) {
+            Map<String, Object> orgWiseRolesOfAudience = roleDetails.get(audience);
+            for (Map.Entry<String, Object> entry : orgWiseRolesOfAudience.entrySet()) {
+                String audienceName = entry.getKey();
+                Map<String, String> roles = (Map<String, String>) entry.getValue();
+                for (Map.Entry<String, String> role : roles.entrySet()) {
+                    String roleId = role.getValue();
+                    if (audienceName.contains(ROOT_ORG_NAME)) {
+                        deleteRoleIfExists(roleId);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Cleans up applications by deleting them if they exist.
+     *
+     * @throws Exception If an error occurs while deleting the applications.
+     */
+    protected void cleanUpApplications() throws Exception {
+
+        for (Map.Entry<String, Map<String, Object>> entry : appDetails.entrySet()) {
+            Map<String, Object> details = entry.getValue();
+            deleteApplicationIfExists(details.get(MAP_APP_DETAILS_KEY_APP_ID).toString());
+        }
+    }
+
+    /**
+     * Cleans up organizations by deleting them from the deepest level to the root level.
+     *
+     * @throws Exception If an error occurs while deleting the organizations.
+     */
+    protected void cleanUpOrganizations() throws Exception {
+
+        // Determine the deepest organization level in the hierarchy.
+        int maxDepth = orgDetails.values().stream()
+                .mapToInt(details -> (int) details.get(MAP_ORG_DETAILS_KEY_ORG_LEVEL))
+                .max()
+                .orElse(1);
+
+        // Delete organizations starting from the deepest level down to the root level.
+        for (int level = maxDepth; level >= 1; level--) {
+            for (Map.Entry<String, Map<String, Object>> entry : orgDetails.entrySet()) {
+                if ((int) entry.getValue().get(MAP_ORG_DETAILS_KEY_ORG_LEVEL) == level) {
+                    deleteOrganization(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * Cleans up the detail maps by clearing all entries.
+     */
+    protected void cleanUpDetailMaps() {
+
+        userDetails.clear();
+        orgDetails.clear();
+        appDetails.clear();
+        roleDetails.clear();
+    }
+
+    /**
+     * Close the HTTP clients for OAuth2, SCIM2, and Organization Management.
+     *
+     * @throws IOException If an error occurred while closing the HTTP clients.
+     */
+    protected void closeRestClients() throws IOException {
+
+        oAuth2RestClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        orgMgtRestClient.closeHttpClient();
+    }
+
+    private void deleteOrganization(String orgName, Map<String, Object> orgDetail) throws Exception {
+
+        String orgId = getOrgId(orgName);
+        String parentOrgId = (String) orgDetail.get(MAP_ORG_DETAILS_KEY_PARENT_ORG_ID);
+
+        if ((int) orgDetail.get(MAP_ORG_DETAILS_KEY_ORG_LEVEL) > 1) {
+            deleteSubOrganizationIfExists(orgId, parentOrgId);
+        } else {
+            deleteOrganizationIfExists(orgId);
+        }
+    }
+
+    private void deleteUserIfExists(String userId) throws Exception {
+
+        if (userId != null) {
+            scim2RestClient.deleteUser(userId);
+        }
+    }
+
+    private void deleteSubOrgUserIfExists(String userId, String organizationSwitchToken) throws Exception {
+
+        if (userId != null) {
+            scim2RestClient.deleteSubOrgUser(userId, organizationSwitchToken);
+        }
+    }
+
+    private void deleteRoleIfExists(String roleId) throws Exception {
+
+        if (roleId != null) {
+            scim2RestClient.deleteV2Role(roleId);
+        }
+    }
+
+    private void deleteApplicationIfExists(String appId) throws Exception {
+
+        if (appId != null) {
+            oAuth2RestClient.deleteApplication(appId);
+        }
+    }
+
+    private void deleteSubOrganizationIfExists(String orgId, String parentId) throws Exception {
+
+        if (orgId != null) {
+            orgMgtRestClient.deleteSubOrganization(orgId, parentId);
+        }
+    }
+
+    private void deleteOrganizationIfExists(String orgId) throws Exception {
+
+        if (orgId != null) {
+            orgMgtRestClient.deleteOrganization(orgId);
+        }
+    }
+
+    // Helper methods.
+
+    protected String extractSharedUserId(Response response, String orgName) {
+
+        JsonPath jsonPath = response.jsonPath();
+        return jsonPath.getString(String.format(SHARED_USER_ID_JSON_PATH, orgName));
+    }
+
+    protected String toJSONString(java.lang.Object object) {
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         return gson.toJson(object);
+    }
+
+    private Header[] getHeaders(String token) {
+
+        return new Header[]{
+                new BasicHeader(HEADER_AUTHORIZATION, HEADER_AUTHORIZATION_VALUE_BEARER + token),
+                new BasicHeader(HEADER_CONTENT_TYPE, String.valueOf(ContentType.JSON))
+        };
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingFailureTest.java
@@ -1,0 +1,1233 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1;
+
+import io.restassured.response.Response;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudience;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareWithAllRequestBody;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.API_VERSION;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APPLICATION_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_2_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_ROLE_1;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_ROLE_2;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_ROLE_3;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.AUTHORIZED_APIS_JSON;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_USER_1_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_USER_2_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_USER_3_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_2_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_3_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L2_ORG_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L2_ORG_2_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L2_ORG_3_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L3_ORG_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_COUNT;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_IDS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_NAMES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_GENERAL_POLICY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_GENERAL_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_POLICY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORGANIZATION_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORG_ROLE_1;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORG_ROLE_2;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORG_ROLE_3;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_DETAILS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_DETAIL_VALUE_SHARING;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_DETAIL_VALUE_UNSHARING;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_STATUS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_STATUS_VALUE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_1_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_2_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_3_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_DUPLICATED_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARE_WITH_ALL_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.UNSHARE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.UNSHARE_WITH_ALL_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.USER_DOMAIN_PRIMARY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.USER_SHARING_API_BASE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_CHILDREN_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.IMMEDIATE_EXISTING_ORGS_ONLY;
+
+/**
+ * Tests for failure cases of the User Sharing REST APIs.
+ */
+public class UserSharingFailureTest extends UserSharingBaseTest {
+
+    private static final String INVALID_ORG_1_NAME = "invalid-org-1-name";
+    private static final String INVALID_ORG_1_ID = "invalid-org-1-id";
+
+    private static final String INVALID_APP_1_NAME = "invalid-app-1";
+    private static final String INVALID_APP_2_NAME = "invalid-app-2";
+
+    private static final String INVALID_APP_ROLE_1 = "invalid-app-role-1";
+    private static final String INVALID_APP_ROLE_2 = "invalid-app-role-2";
+    private static final String INVALID_ORG_ROLE_1 = "invalid-org-role-1";
+    private static final String INVALID_ORG_ROLE_2 = "invalid-org-role-2";
+
+    private static final String INVALID_USER_1_ID = "invalid-user-id-1";
+    private static final String INVALID_USER_2_ID = "invalid-user-id-2";
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public UserSharingFailureTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @Override
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+        setupDetailMaps();
+        setupRestClients();
+        setupOrganizations();
+        setupApplicationsAndRoles();
+        setupUsers();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    public void testConclude() throws Exception {
+
+        cleanUpUsers();
+        cleanUpRoles(APPLICATION_AUDIENCE, ORGANIZATION_AUDIENCE);
+        cleanUpApplications();
+        cleanUpOrganizations();
+        cleanUpDetailMaps();
+        closeRestClients();
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    // Invalid Selective User Sharing.
+
+    @DataProvider(name = "selectiveUserSharingWithInvalidDetailsDataProvider")
+    public Object[][] selectiveUserSharingWithInvalidDetailsDataProvider() {
+
+        // Test case 1: User sharing with invalid roles.
+        List<String> userIdsForTestCase1 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase1 =
+                setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase1();
+        Map<String, Object> expectedResultsForTestCase1 =
+                setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase1();
+
+        // Test case 2: User sharing with invalid organizations.
+        List<String> userIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase2 =
+                setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase2();
+        Map<String, Object> expectedResultsForTestCase2 =
+                setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase2();
+
+        // Test case 3: User sharing with invalid users.
+        List<String> userIdsForTestCase3 = Arrays.asList(INVALID_USER_1_ID, INVALID_USER_2_ID);
+        Map<String, Map<String, Object>> organizationsForTestCase3 =
+                setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase3();
+        Map<String, Object> expectedResultsForTestCase3 =
+                setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase3();
+
+        // Test case 4: User sharing with conflicting users.
+        List<String> userIdsForTestCase4 = Collections.singletonList(
+                getUserId(ROOT_ORG_USER_DUPLICATED_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase4 =
+                setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase4();
+        Map<String, Object> expectedResultsForTestCase4 =
+                setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase4();
+
+        // Test case 5: User sharing with non-immediate child organizations.
+        List<String> userIdsForTestCase5 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase5 =
+                setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase5();
+        Map<String, Object> expectedResultsForTestCase5 =
+                setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase5();
+
+        return new Object[][]{
+                {userIdsForTestCase1, organizationsForTestCase1, expectedResultsForTestCase1},
+                {userIdsForTestCase2, organizationsForTestCase2, expectedResultsForTestCase2},
+                {userIdsForTestCase3, organizationsForTestCase3, expectedResultsForTestCase3},
+                {userIdsForTestCase4, organizationsForTestCase4, expectedResultsForTestCase4},
+                {userIdsForTestCase5, organizationsForTestCase5, expectedResultsForTestCase5}
+        };
+    }
+
+    @Test(dataProvider = "selectiveUserSharingWithInvalidDetailsDataProvider")
+    public void testSelectiveUserSharing(List<String> userIds, Map<String, Map<String, Object>> organizations,
+                                         Map<String, Object> expectedResults) throws Exception {
+
+        UserShareRequestBody requestBody = new UserShareRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .organizations(getOrganizationsForSelectiveUserSharing(organizations));
+
+        Response response = getResponseOfPost(USER_SHARING_API_BASE_PATH + SHARE_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_SHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
+    }
+
+    // Invalid General User Sharing.
+
+    @DataProvider(name = "generalUserSharingWithInvalidDetailsDataProvider")
+    public Object[][] generalUserSharingWithInvalidDetailsDataProvider() {
+
+        // Test case 1: User sharing with invalid roles.
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase1 =
+                setPolicyWithRolesForGeneralUserSharingWithInvalidDetailsTestCase1();
+        Map<String, Object> expectedResultsForTestCase1 =
+                setExpectedResultsForGeneralUserSharingWithInvalidDetailsTestCase1();
+
+        // Test case 2: User sharing with invalid users.
+        List<String> userIdsForTestCase2 = Arrays.asList(INVALID_USER_1_ID, INVALID_USER_2_ID);
+        Map<String, Object> policyWithRolesForTestCase2 =
+                setPolicyWithRolesForGeneralUserSharingWithInvalidDetailsTestCase2();
+        Map<String, Object> expectedResultsForTestCase2 =
+                setExpectedResultsForGeneralUserSharingWithInvalidDetailsTestCase2();
+
+        // Test case 3: User sharing with conflicting users.
+        List<String> userIdsForTestCase3 = Collections.singletonList(
+                getUserId(ROOT_ORG_USER_DUPLICATED_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase3 =
+                setPolicyWithRolesForGeneralUserSharingWithInvalidDetailsTestCase3();
+        Map<String, Object> expectedResultsForTestCase3 =
+                setExpectedResultsForGeneralUserSharingWithInvalidDetailsTestCase3();
+
+        return new Object[][]{
+                {userIdsForTestCase1, policyWithRolesForTestCase1, expectedResultsForTestCase1},
+                {userIdsForTestCase2, policyWithRolesForTestCase2, expectedResultsForTestCase2},
+                {userIdsForTestCase3, policyWithRolesForTestCase3, expectedResultsForTestCase3}
+        };
+    }
+
+    @Test(dataProvider = "generalUserSharingWithInvalidDetailsDataProvider")
+    public void testGeneralUserSharing(List<String> userIds, Map<String, Object> policyWithRoles,
+                                       Map<String, Object> expectedResults) throws Exception {
+
+        UserShareWithAllRequestBody requestBody = new UserShareWithAllRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .policy(getPolicyEnumForGeneralUserSharing(policyWithRoles))
+                .roles(getRolesForGeneralUserSharing(policyWithRoles));
+
+        Response response =
+                getResponseOfPost(USER_SHARING_API_BASE_PATH + SHARE_WITH_ALL_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_SHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
+    }
+
+    // Invalid General User Unsharing.
+
+    @DataProvider(name = "generalUserUnsharingWithInvalidDetailsDataProvider")
+    public Object[][] generalUserUnsharingWithInvalidDetailsDataProvider() {
+
+        List<String> sharingUserIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase1 =
+                setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase1();
+        Map<String, Object> expectedSharedResultsForTestCase1 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase1();
+        List<String> userIdsForTestCase1 = Collections.singletonList(INVALID_USER_1_ID);
+        Map<String, Object> expectedResultsForTestCase1 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase1();
+
+        List<String> sharingUserIdsForTestCase2 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase2 =
+                setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase2();
+        Map<String, Object> expectedSharedResultsForTestCase2 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase2();
+        List<String> userIdsForTestCase2 = Arrays.asList(INVALID_USER_1_ID, INVALID_USER_2_ID);
+        Map<String, Object> expectedResultsForTestCase2 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase2();
+
+        return new Object[][]{
+                {sharingUserIdsForTestCase1, policyWithRolesForTestCase1, expectedSharedResultsForTestCase1,
+                        userIdsForTestCase1, expectedResultsForTestCase1},
+                {sharingUserIdsForTestCase2, policyWithRolesForTestCase2, expectedSharedResultsForTestCase2,
+                        userIdsForTestCase2, expectedResultsForTestCase2},
+        };
+    }
+
+    @Test(dataProvider = "generalUserUnsharingWithInvalidDetailsDataProvider")
+    public void testGeneralUserUnsharing(List<String> userIds, Map<String, Object> policyWithRoles,
+                                         Map<String, Object> expectedSharedResults, List<String> removingUserIds,
+                                         Map<String, Object> expectedResults) throws Exception {
+
+        // Sharing valid users.
+        testGeneralUserSharing(userIds, policyWithRoles, expectedSharedResults);
+
+        // Unsharing invalid users.
+        UserUnshareWithAllRequestBody requestBody = new UserUnshareWithAllRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserUnsharing(removingUserIds));
+
+        Response response =
+                getResponseOfPost(USER_SHARING_API_BASE_PATH + UNSHARE_WITH_ALL_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_UNSHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
+    }
+
+    // Invalid Selective User Unsharing.
+
+    @DataProvider(name = "selectiveUserUnsharingDataProvider")
+    public Object[][] selectiveUserUnsharingDataProvider() {
+
+        // ALL EXISTING
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase1 =
+                setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase1();
+        Map<String, Object> expectedSharedResultsForTestCase1 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase1();
+        List<String> removingUserIdsForTestCase1 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        INVALID_USER_1_ID, INVALID_USER_2_ID);
+        List<String> removingOrgIdsForTestCase1 = Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L1_ORG_2_NAME));
+        Map<String, Object> expectedResultsForTestCase1 =
+                setExpectedResultsForSelectiveUserUnsharingWithInvalidDetailsTestCase1();
+
+        // IMMEDIATE EXISTING AND FUTURE
+        List<String> userIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase2 =
+                setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase2();
+        Map<String, Object> expectedSharedResultsForTestCase2 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase2();
+        List<String> removingUserIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME), INVALID_USER_1_ID);
+        List<String> removingOrgIdsForTestCase2 = Arrays.asList(getOrgId(L1_ORG_1_NAME), INVALID_ORG_1_ID);
+        Map<String, Object> expectedResultsForTestCase2 =
+                setExpectedResultsForSelectiveUserUnsharingWithInvalidDetailsTestCase2();
+
+        return new Object[][]{
+                {userIdsForTestCase1, policyWithRolesForTestCase1, expectedSharedResultsForTestCase1,
+                        removingUserIdsForTestCase1, removingOrgIdsForTestCase1, expectedResultsForTestCase1},
+                {userIdsForTestCase2, policyWithRolesForTestCase2, expectedSharedResultsForTestCase2,
+                        removingUserIdsForTestCase2, removingOrgIdsForTestCase2, expectedResultsForTestCase2}
+        };
+    }
+
+    @Test(dataProvider = "selectiveUserUnsharingDataProvider")
+    public void testSelectiveUserUnsharing(List<String> userIds, Map<String, Object> policyWithRoles,
+                                           Map<String, Object> expectedSharedResults, List<String> removingUserIds,
+                                           List<String> removingOrgIds, Map<String, Object> expectedResults)
+            throws Exception {
+
+        testGeneralUserSharing(userIds, policyWithRoles, expectedSharedResults);
+
+        UserUnshareRequestBody requestBody = new UserUnshareRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserUnsharing(removingUserIds))
+                .organizations(getOrganizationsForSelectiveUserUnsharing(removingOrgIds));
+
+        Response response = getResponseOfPost(USER_SHARING_API_BASE_PATH + UNSHARE_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_UNSHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
+    }
+
+    // Invalid Selective User Sharing for re-sharing.
+
+    @DataProvider(name = "selectiveUserSharingWithReSharingDataProvider")
+    public Object[][] selectiveUserSharingWithReSharingDataProvider() {
+
+        // Test case 1: User re-sharing.
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase1 =
+                setOrganizationsForSelectiveUserSharingWithValidDetailsTestCase1();
+        Map<String, Object> expectedSharedResultsForTestCase1 =
+                setExpectedResultsForSelectiveUserSharingWithValidDetailsTestCase1();
+        Map<String, Map<String, Object>> organizationsForReSharingTestCase1 =
+                setOrganizationsForSelectiveUserSharingWithReSharingTestCase1();
+        Map<String, Object> reSharingSubOrgDetailsForTestCase1 = orgDetails.get(L1_ORG_1_NAME);
+        Map<String, Object> expectedResultsForTestCase1 =
+                setExpectedResultsForSelectiveUserSharingWithReSharingTestCase1();
+
+        return new Object[][]{
+                {userIdsForTestCase1, organizationsForTestCase1, expectedSharedResultsForTestCase1,
+                        organizationsForReSharingTestCase1, reSharingSubOrgDetailsForTestCase1,
+                        expectedResultsForTestCase1}
+        };
+    }
+
+    @Test(dataProvider = "selectiveUserSharingWithReSharingDataProvider")
+    public void testSelectiveUserSharingWithReSharing(List<String> userIds,
+                                                      Map<String, Map<String, Object>> organizations,
+                                                      Map<String, Object> expectedSharedResults,
+                                                      Map<String, Map<String, Object>> organizationsForReSharing,
+                                                      Map<String, Object> reSharingSubOrgDetails,
+                                                      Map<String, Object> expectedResults) throws Exception {
+
+        UserShareRequestBody requestBody = new UserShareRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .organizations(getOrganizationsForSelectiveUserSharing(organizations));
+
+        Response response = getResponseOfPost(USER_SHARING_API_BASE_PATH + SHARE_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_SHARING));
+
+        List<String> sharedUserIds =
+                validateUserSharingResultsAndGetSharedUsersList(userIds, reSharingSubOrgDetails, expectedSharedResults);
+
+        UserShareRequestBody requestBodyForReSharing = new UserShareRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(sharedUserIds))
+                .organizations(getOrganizationsForSelectiveUserSharing(organizationsForReSharing));
+
+        HttpResponse responseOfReSharing = getResponseOfPostToSubOrg(USER_SHARING_API_BASE_PATH + SHARE_PATH,
+                toJSONString(requestBodyForReSharing),
+                reSharingSubOrgDetails.get(MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN).toString());
+
+        Assert.assertEquals(responseOfReSharing.getStatusLine().getStatusCode(), HttpStatus.SC_ACCEPTED);
+
+        validateUserSharingResults(sharedUserIds, expectedResults);
+    }
+
+    // Invalid General User Sharing for re-sharing.
+
+    @DataProvider(name = "generalUserSharingWithReSharingDataProvider")
+    public Object[][] generalUserSharingWithReSharingDataProvider() {
+
+        // Test case 1: User re-sharing.
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase1 =
+                setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase1();
+        Map<String, Object> expectedSharedResultsForTestCase1 =
+                setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase1();
+        Map<String, Object> reSharingSubOrgDetailsForTestCase1 = orgDetails.get(L1_ORG_1_NAME);
+        Map<String, Object> expectedResultsForTestCase1 =
+                setExpectedResultsForGeneralUserSharingWithReSharingTestCase1();
+
+        return new Object[][]{
+                {userIdsForTestCase1, policyWithRolesForTestCase1, expectedSharedResultsForTestCase1,
+                        reSharingSubOrgDetailsForTestCase1, expectedResultsForTestCase1}
+        };
+    }
+
+    @Test(dataProvider = "generalUserSharingWithReSharingDataProvider")
+    public void testGeneralUserSharingWithReSharing(List<String> userIds, Map<String, Object> policyWithRoles,
+                                                    Map<String, Object> expectedSharedResults,
+                                                    Map<String, Object> reSharingSubOrgDetails,
+                                                    Map<String, Object> expectedResults) throws Exception {
+
+        UserShareWithAllRequestBody requestBody = new UserShareWithAllRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .policy(getPolicyEnumForGeneralUserSharing(policyWithRoles))
+                .roles(getRolesForGeneralUserSharing(policyWithRoles));
+
+        Response response =
+                getResponseOfPost(USER_SHARING_API_BASE_PATH + SHARE_WITH_ALL_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_SHARING));
+
+        List<String> sharedUserIds =
+                validateUserSharingResultsAndGetSharedUsersList(userIds, reSharingSubOrgDetails, expectedSharedResults);
+
+        UserShareWithAllRequestBody requestBodyForReSharing = new UserShareWithAllRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .policy(getPolicyEnumForGeneralUserSharing(policyWithRoles))
+                .roles(getRolesForGeneralUserSharing(policyWithRoles));
+
+        HttpResponse responseOfReSharing = getResponseOfPostToSubOrg(USER_SHARING_API_BASE_PATH + SHARE_WITH_ALL_PATH,
+                toJSONString(requestBodyForReSharing),
+                reSharingSubOrgDetails.get(MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN).toString());
+
+        Assert.assertEquals(responseOfReSharing.getStatusLine().getStatusCode(), HttpStatus.SC_ACCEPTED);
+
+        validateUserSharingResults(sharedUserIds, expectedResults);
+    }
+
+    // Test cases builders.
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase1() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(INVALID_APP_ROLE_1, INVALID_APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(APP_ROLE_1, INVALID_APP_2_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        // Organization 3
+        Map<String, Object> org3 = new HashMap<>();
+        org3.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_3_NAME));
+        org3.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_3_NAME);
+        org3.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_ONLY);
+        org3.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(INVALID_APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(INVALID_ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE),
+                createRoleWithAudience(INVALID_ORG_ROLE_2, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_3_NAME, org3);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME), Collections.emptyList());
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase2() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, INVALID_ORG_1_ID);
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, INVALID_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES, Collections.singletonList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(INVALID_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase2() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 2);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L2_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase3() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES, Collections.singletonList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        // Organization 3
+        Map<String, Object> org3 = new HashMap<>();
+        org3.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_3_NAME));
+        org3.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_3_NAME);
+        org3.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_ONLY);
+        org3.put(MAP_KEY_SELECTIVE_ROLES, Collections.emptyList());
+
+        organizations.put(L1_ORG_3_NAME, org3);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase3() {
+
+        return setExpectedResultsForEmptySharedResult();
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase4() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_CHILDREN_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES, Collections.singletonList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_ONLY);
+        org2.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase4() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 3);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithInvalidDetailsTestCase5() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L3_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L3_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES, Collections.singletonList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(INVALID_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(ORG_ROLE_2, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithInvalidDetailsTestCase5() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 2);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L2_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_2, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_2, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingWithInvalidDetailsTestCase1() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, ALL_EXISTING_ORGS_ONLY);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES, Arrays.asList(
+                createRoleWithAudience(INVALID_APP_ROLE_1, INVALID_APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(APP_ROLE_1, INVALID_APP_2_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(INVALID_APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(INVALID_ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE),
+                createRoleWithAudience(INVALID_ORG_ROLE_2, INVALID_ORG_1_NAME, ORGANIZATION_AUDIENCE),
+                createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingWithInvalidDetailsTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingWithInvalidDetailsTestCase2() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, IMMEDIATE_EXISTING_AND_FUTURE_ORGS);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES,
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingWithInvalidDetailsTestCase2() {
+
+        return setExpectedResultsForEmptySharedResult();
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingWithInvalidDetailsTestCase3() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, IMMEDIATE_EXISTING_ORGS_ONLY);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES,
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingWithInvalidDetailsTestCase3() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 2);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithValidDetailsTestCase1() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN);
+        org1.put(MAP_KEY_SELECTIVE_ROLES,
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES,
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        // Organization 3
+        Map<String, Object> org3 = new HashMap<>();
+        org3.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_3_NAME));
+        org3.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_3_NAME);
+        org3.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_ONLY);
+        org3.put(MAP_KEY_SELECTIVE_ROLES,
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_3_NAME, org3);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithValidDetailsTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase1() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, ALL_EXISTING_ORGS_ONLY);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES, Collections.singletonList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingWithValidDetailsTestCase2() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, IMMEDIATE_EXISTING_ORGS_ONLY);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES,
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingWithValidDetailsTestCase2() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 3);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_1_NAME, L1_ORG_2_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_1_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserUnsharingWithInvalidDetailsTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 5);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME), getOrgId(L3_ORG_1_NAME),
+                        getOrgId(L2_ORG_3_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L2_ORG_3_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserUnsharingWithInvalidDetailsTestCase2() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 2);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingWithReSharingTestCase1() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L2_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L2_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES, Collections.singletonList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L2_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L2_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L2_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES, Arrays.asList(
+                createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L2_ORG_2_NAME, org2);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingWithReSharingTestCase1() {
+
+        return setExpectedResultsForEmptySharedResult();
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingWithReSharingTestCase1() {
+
+        return setExpectedResultsForEmptySharedResult();
+    }
+
+    private Map<String, Object> setExpectedResultsForEmptySharedResult() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 0);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Collections.emptyList());
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Collections.emptyList());
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    // Setup methods.
+
+    private void setupDetailMaps() {
+
+        userDetails = new HashMap<>();
+        orgDetails = new HashMap<>();
+        appDetails = new HashMap<>();
+        roleDetails = new HashMap<>();
+    }
+
+    private void setupRestClients() throws Exception {
+
+        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        orgMgtRestClient = new OrgMgtRestClient(context, tenantInfo, serverURL,
+                new JSONObject(readResource(AUTHORIZED_APIS_JSON)));
+        httpClient = HttpClientBuilder.create().build();
+    }
+
+    private void setupOrganizations() throws Exception {
+
+        // Create Level 1 Organizations
+        addOrganization(L1_ORG_1_NAME);
+        addOrganization(L1_ORG_2_NAME);
+        addOrganization(L1_ORG_3_NAME);
+
+        // Create Level 2 Organizations
+        addSubOrganization(L2_ORG_1_NAME, getOrgId(L1_ORG_1_NAME), 2);
+        addSubOrganization(L2_ORG_2_NAME, getOrgId(L1_ORG_1_NAME), 2);
+        addSubOrganization(L2_ORG_3_NAME, getOrgId(L1_ORG_2_NAME), 2);
+
+        // Create Level 3 Organization
+        addSubOrganization(L3_ORG_1_NAME, getOrgId(L2_ORG_1_NAME), 3);
+    }
+
+    protected void setupApplicationsAndRoles() throws Exception {
+
+        Map<String, String> rootOrgOrganizationRoles =
+                setUpOrganizationRoles(ROOT_ORG_NAME, Arrays.asList(ORG_ROLE_1, ORG_ROLE_2, ORG_ROLE_3));
+
+        createApplication(APP_1_NAME, APPLICATION_AUDIENCE, Arrays.asList(APP_ROLE_1, APP_ROLE_2, APP_ROLE_3));
+        createApplication(APP_2_NAME, ORGANIZATION_AUDIENCE, new ArrayList<>(rootOrgOrganizationRoles.keySet()));
+    }
+
+    private void setupUsers() throws Exception {
+
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_1_USERNAME, ROOT_ORG_NAME));
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_2_USERNAME, ROOT_ORG_NAME));
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_3_USERNAME, ROOT_ORG_NAME));
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_DUPLICATED_USERNAME, ROOT_ORG_NAME));
+
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, L1_ORG_1_USER_1_USERNAME, L1_ORG_1_NAME), L1_ORG_1_NAME);
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, L1_ORG_1_USER_2_USERNAME, L1_ORG_1_NAME), L1_ORG_1_NAME);
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, L1_ORG_1_USER_3_USERNAME, L1_ORG_1_NAME), L1_ORG_1_NAME);
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_DUPLICATED_USERNAME, ROOT_ORG_NAME),
+                L1_ORG_1_NAME);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingSuccessTest.java
@@ -20,6 +20,7 @@ package org.wso2.identity.integration.test.rest.api.server.user.sharing.manageme
 
 import io.restassured.response.Response;
 import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -27,67 +28,83 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
-import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AssociatedRolesConfig;
-import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
-import org.wso2.identity.integration.test.rest.api.server.roles.v2.model.Audience;
-import org.wso2.identity.integration.test.rest.api.server.roles.v2.model.RoleV2;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudience;
-import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudienceAudience;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBody;
-import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations;
-import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
-import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareWithAllRequestBody;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.everyItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.API_VERSION;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APPLICATION_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_2_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_ROLE_1;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_ROLE_2;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.APP_ROLE_3;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.AUTHORIZED_APIS_JSON;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_USER_1_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_USER_2_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_1_USER_3_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_2_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L1_ORG_3_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L2_ORG_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L2_ORG_2_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L2_ORG_3_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.L3_ORG_1_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_COUNT;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_IDS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ORG_NAMES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_GENERAL_POLICY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_GENERAL_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ORG_ID;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_POLICY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.MAP_KEY_SELECTIVE_ROLES;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORGANIZATION_AUDIENCE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORG_ROLE_1;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORG_ROLE_2;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ORG_ROLE_3;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_DETAILS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_DETAIL_VALUE_SHARING;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_DETAIL_VALUE_UNSHARING;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_STATUS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.RESPONSE_STATUS_VALUE;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_NAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_1_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_2_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.ROOT_ORG_USER_3_USERNAME;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.SHARE_WITH_ALL_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.UNSHARE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.UNSHARE_WITH_ALL_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.USER_DOMAIN_PRIMARY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant.UserSharingConstants.USER_SHARING_API_BASE_PATH;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_AND_FUTURE_ORGS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.IMMEDIATE_EXISTING_ORGS_ONLY;
 
 /**
  * Tests for successful cases of the User Sharing REST APIs.
  */
 public class UserSharingSuccessTest extends UserSharingBaseTest {
-
-    private String rootOrgUserId;
-    private String l1Org1UserId;
-
-    private String l1Org1Id;
-    private String l1Org2Id;
-    private String l2Org1Id;
-    private String l2Org2Id;
-    private String l2Org3Id;
-    private String l3Org1Id;
-
-    private String l1Org1SwitchToken;
-    private String l2Org1SwitchToken;
-
-    private String appId1;
-    private String appId2;
-    private String sharedApp1IdInLevel1Org;
-    private String sharedApp2IdInLevel1Org;
-
-    private ApplicationResponseModel application1WithAppAudienceRoles;
-    private ApplicationResponseModel application2WithOrgAudienceRoles;
-    private String clientIdApp1;
-    private String clientSecretApp1;
-    private String clientIdApp2;
-    private String clientSecretApp2;
-
-    private String appRole1Id;
-    private String appRole2Id;
-    private String appRole3Id;
-    private String orgRole1Id;
-    private String orgRole2Id;
-    private String orgRole3Id;
 
     @Factory(dataProvider = "restAPIUserConfigProvider")
     public UserSharingSuccessTest(TestUserMode userMode) throws Exception {
@@ -104,14 +121,9 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
     public void init() throws Exception {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
-
-        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
-        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
-        orgMgtRestClient = new OrgMgtRestClient(context, tenantInfo, serverURL,
-                new JSONObject(readResource(AUTHORIZED_APIS_JSON)));
-
+        setupDetailMaps();
+        setupRestClients();
         setupOrganizations();
-        setupTokens();
         setupApplicationsAndRoles();
         setupUsers();
     }
@@ -120,31 +132,11 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
     @AfterClass(alwaysRun = true)
     public void testConclude() throws Exception {
 
-        // Cleanup users
-        deleteUserIfExists(rootOrgUserId);
-        deleteSubOrgUserIfExists(l1Org1UserId, l1Org1SwitchToken);
-
-        // Cleanup roles
-        deleteRoleIfExists(appRole1Id);
-        deleteRoleIfExists(appRole2Id);
-        deleteRoleIfExists(appRole3Id);
-        deleteRoleIfExists(orgRole1Id);
-        deleteRoleIfExists(orgRole2Id);
-        deleteRoleIfExists(orgRole3Id);
-
-        // Cleanup applications
-        deleteApplicationIfExists(application1WithAppAudienceRoles.getId());
-        deleteApplicationIfExists(application2WithOrgAudienceRoles.getId());
-
-        // Cleanup organizations
-        deleteSubOrganizationIfExists(l3Org1Id, l2Org1Id);
-        deleteSubOrganizationIfExists(l2Org3Id, l1Org2Id);
-        deleteSubOrganizationIfExists(l2Org2Id, l1Org1Id);
-        deleteSubOrganizationIfExists(l2Org1Id, l1Org1Id);
-        deleteOrganizationIfExists(l1Org2Id);
-        deleteOrganizationIfExists(l1Org1Id);
-
-        // Close REST clients
+        cleanUpUsers();
+        cleanUpRoles(APPLICATION_AUDIENCE, ORGANIZATION_AUDIENCE);
+        cleanUpApplications();
+        cleanUpOrganizations();
+        cleanUpDetailMaps();
         closeRestClients();
     }
 
@@ -157,12 +149,36 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
         };
     }
 
-    @Test
-    public void testShareUsersWithOrganizations() {
+    // Selective User Sharing.
+
+    @DataProvider(name = "selectiveUserSharingDataProvider")
+    public Object[][] selectiveUserSharingDataProvider() {
+
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase1 = setOrganizationsForSelectiveUserSharingTestCase1();
+        Map<String, Object> expectedResultsForTestCase1 = setExpectedResultsForSelectiveUserSharingTestCase1();
+
+        List<String> userIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Map<String, Object>> organizationsForTestCase2 = setOrganizationsForSelectiveUserSharingTestCase2();
+        Map<String, Object> expectedResultsForTestCase2 = setExpectedResultsForSelectiveUserSharingTestCase2();
+
+        return new Object[][]{
+                {userIdsForTestCase1, organizationsForTestCase1, expectedResultsForTestCase1},
+                {userIdsForTestCase2, organizationsForTestCase2, expectedResultsForTestCase2}
+        };
+    }
+
+    @Test(dataProvider = "selectiveUserSharingDataProvider")
+    public void testSelectiveUserSharing(List<String> userIds, Map<String, Map<String, Object>> organizations,
+                                         Map<String, Object> expectedResults) throws Exception {
 
         UserShareRequestBody requestBody = new UserShareRequestBody()
-                .userCriteria(getUserCriteria())
-                .organizations(getOrganizations());
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .organizations(getOrganizationsForSelectiveUserSharing(organizations));
 
         Response response = getResponseOfPost(USER_SHARING_API_BASE_PATH + SHARE_PATH, toJSONString(requestBody));
 
@@ -170,194 +186,560 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_ACCEPTED)
-                .body("status", equalTo("Processing"))
-                .body("details", equalTo("User sharing process triggered successfully."));
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_SHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
     }
 
-    @Test(dependsOnMethods = "testShareUsersWithOrganizations")
-    public void testGetSharedOrganizationsWithoutPagination() throws Exception {
+    // General User Sharing.
+
+    @DataProvider(name = "generalUserSharingDataProvider")
+    public Object[][] generalUserSharingDataProvider() {
+
+        // ALL EXISTING
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase1 = setPolicyWithRolesForGeneralUserSharingTestCase1();
+        Map<String, Object> expectedResultsForTestCase1 = setExpectedResultsForGeneralUserSharingTestCase1();
+
+        // IMMEDIATE EXISTING AND FUTURE
+        List<String> userIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase2 = setPolicyWithRolesForGeneralUserSharingTestCase2();
+        Map<String, Object> expectedResultsForTestCase2 = setExpectedResultsForGeneralUserSharingTestCase2();
+
+        // IMMEDIATE EXISTING
+        List<String> userIdsForTestCase3 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase3 = setPolicyWithRolesForGeneralUserSharingTestCase3();
+        Map<String, Object> expectedResultsForTestCase3 = setExpectedResultsForGeneralUserSharingTestCase3();
+
+        // ALL EXISTING AND FUTURE
+        List<String> userIdsForTestCase4 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase4 = setPolicyWithRolesForGeneralUserSharingTestCase4();
+        Map<String, Object> expectedResultsForTestCase4 = setExpectedResultsForGeneralUserSharingTestCase4();
+
+        return new Object[][]{
+                {userIdsForTestCase1, policyWithRolesForTestCase1, expectedResultsForTestCase1},
+                {userIdsForTestCase2, policyWithRolesForTestCase2, expectedResultsForTestCase2},
+                {userIdsForTestCase3, policyWithRolesForTestCase3, expectedResultsForTestCase3},
+                {userIdsForTestCase4, policyWithRolesForTestCase4, expectedResultsForTestCase4}
+        };
+    }
+
+    @Test(dataProvider = "generalUserSharingDataProvider")
+    public void testGeneralUserSharing(List<String> userIds, Map<String, Object> policyWithRoles,
+                                       Map<String, Object> expectedResults) throws Exception {
+
+        UserShareWithAllRequestBody requestBody = new UserShareWithAllRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserSharing(userIds))
+                .policy(getPolicyEnumForGeneralUserSharing(policyWithRoles))
+                .roles(getRolesForGeneralUserSharing(policyWithRoles));
 
         Response response =
-                getResponseOfGet(USER_SHARING_API_BASE_PATH + "/" + rootOrgUserId + SHARED_ORGANIZATIONS_PATH);
+                getResponseOfPost(USER_SHARING_API_BASE_PATH + SHARE_WITH_ALL_PATH, toJSONString(requestBody));
 
         response.then()
                 .log().ifValidationFails()
                 .assertThat()
-                .statusCode(HttpStatus.SC_OK)
-                .body("links.size()", equalTo(1))
-                .body("links[0].isEmpty()", equalTo(true))
-                .body("sharedOrganizations", notNullValue())
-                .body("sharedOrganizations.size()", equalTo(4))
-                .body("sharedOrganizations.orgId", hasItems(l1Org1Id, l1Org2Id, l2Org1Id, l2Org2Id))
-                .body("sharedOrganizations.orgName",
-                        hasItems(L1_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_1_NAME, L1_ORG_2_NAME))
-                .body("sharedOrganizations.sharedType", everyItem(equalTo("SHARED")))
-                .body("sharedOrganizations.rolesRef", hasItems(
-                        getSharedOrgsRolesRef(rootOrgUserId, l1Org1Id),
-                        getSharedOrgsRolesRef(rootOrgUserId, l1Org2Id),
-                        getSharedOrgsRolesRef(rootOrgUserId, l2Org1Id),
-                        getSharedOrgsRolesRef(rootOrgUserId, l2Org2Id)));
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_SHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
     }
 
-    private UserShareRequestBodyUserCriteria getUserCriteria() {
+    // General User Unsharing.
 
-        UserShareRequestBodyUserCriteria criteria = new UserShareRequestBodyUserCriteria();
-        criteria.setUserIds(Collections.singletonList(rootOrgUserId));
-        return criteria;
+    @DataProvider(name = "generalUserUnsharingDataProvider")
+    public Object[][] generalUserUnsharingDataProvider() {
+
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        List<String> userIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        List<String> userIdsForTestCase3 = Collections.emptyList();
+        Map<String, Object> expectedResultsForTestCase = setExpectedResultsForGeneralUserUnsharingTestCase1();
+
+        return new Object[][]{
+                {userIdsForTestCase1, expectedResultsForTestCase},
+                {userIdsForTestCase2, expectedResultsForTestCase},
+                {userIdsForTestCase3, expectedResultsForTestCase}
+        };
     }
 
-    private List<UserShareRequestBodyOrganizations> getOrganizations() {
+    @Test(dataProvider = "generalUserUnsharingDataProvider")
+    public void testGeneralUserUnsharing(List<String> userIds, Map<String, Object> expectedResults) throws Exception {
 
-        UserShareRequestBodyOrganizations organizationWithRoles = new UserShareRequestBodyOrganizations();
-        organizationWithRoles.setOrgId(l1Org1Id);
-        organizationWithRoles.setPolicy(
-                UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
-        organizationWithRoles.setRoles(
+        UserUnshareWithAllRequestBody requestBody = new UserUnshareWithAllRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserUnsharing(userIds));
+
+        Response response =
+                getResponseOfPost(USER_SHARING_API_BASE_PATH + UNSHARE_WITH_ALL_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_UNSHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
+    }
+
+    // Selective User Unsharing.
+
+    @DataProvider(name = "selectiveUserUnsharingDataProvider")
+    public Object[][] selectiveUserUnsharingDataProvider() {
+
+        // ALL EXISTING
+        List<String> userIdsForTestCase1 =
+                Collections.singletonList(getUserId(ROOT_ORG_USER_1_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase1 = setPolicyWithRolesForGeneralUserSharingTestCase1();
+        Map<String, Object> expectedSharedResultsForTestCase1 = setExpectedResultsForGeneralUserSharingTestCase1();
+        List<String> removingOrgIdsForTestCase1 = Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L1_ORG_2_NAME));
+        Map<String, Object> expectedResultsForTestCase1 = setExpectedResultsForSelectiveUserUnsharingTestCase1();
+
+        // IMMEDIATE EXISTING AND FUTURE
+        List<String> userIdsForTestCase2 =
+                Arrays.asList(getUserId(ROOT_ORG_USER_3_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME),
+                        getUserId(ROOT_ORG_USER_2_USERNAME, USER_DOMAIN_PRIMARY, ROOT_ORG_NAME));
+        Map<String, Object> policyWithRolesForTestCase2 = setPolicyWithRolesForGeneralUserSharingTestCase2();
+        Map<String, Object> expectedSharedResultsForTestCase2 = setExpectedResultsForGeneralUserSharingTestCase2();
+        List<String> removingOrgIdsForTestCase2 = Collections.singletonList(getOrgId(L1_ORG_1_NAME));
+        Map<String, Object> expectedResultsForTestCase2 = setExpectedResultsForSelectiveUserUnsharingTestCase2();
+
+        return new Object[][]{
+                {userIdsForTestCase1, policyWithRolesForTestCase1, expectedSharedResultsForTestCase1,
+                        removingOrgIdsForTestCase1, expectedResultsForTestCase1},
+                {userIdsForTestCase2, policyWithRolesForTestCase2, expectedSharedResultsForTestCase2,
+                        removingOrgIdsForTestCase2, expectedResultsForTestCase2}
+        };
+    }
+
+    @Test(dataProvider = "selectiveUserUnsharingDataProvider")
+    public void testSelectiveUserUnsharing(List<String> userIds, Map<String, Object> policyWithRoles,
+                                           Map<String, Object> expectedSharedResults, List<String> removingOrgIds,
+                                           Map<String, Object> expectedResults) throws Exception {
+
+        testGeneralUserSharing(userIds, policyWithRoles, expectedSharedResults);
+
+        UserUnshareRequestBody requestBody = new UserUnshareRequestBody()
+                .userCriteria(getUserCriteriaForBaseUserUnsharing(userIds))
+                .organizations(getOrganizationsForSelectiveUserUnsharing(removingOrgIds));
+
+        Response response = getResponseOfPost(USER_SHARING_API_BASE_PATH + UNSHARE_PATH, toJSONString(requestBody));
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_ACCEPTED)
+                .body(RESPONSE_STATUS, equalTo(RESPONSE_STATUS_VALUE))
+                .body(RESPONSE_DETAILS, equalTo(RESPONSE_DETAIL_VALUE_UNSHARING));
+
+        validateUserSharingResults(userIds, expectedResults);
+    }
+
+    // Test cases builders.
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingTestCase1() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 1
+        Map<String, Object> org1 = new HashMap<>();
+        org1.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_1_NAME));
+        org1.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_1_NAME);
+        org1.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY);
+        org1.put(MAP_KEY_SELECTIVE_ROLES,
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_1_NAME, org1);
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES,
                 Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
-                        createRoleWithAudience(ORG_ROLE_1, SUPER_ORG, ORGANIZATION_AUDIENCE)));
+                        createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
 
-        UserShareRequestBodyOrganizations organizationWithoutRoles = new UserShareRequestBodyOrganizations();
-        organizationWithoutRoles.setOrgId(l1Org2Id);
-        organizationWithoutRoles.setPolicy(UserShareRequestBodyOrganizations.PolicyEnum.SELECTED_ORG_ONLY);
+        organizations.put(L1_ORG_2_NAME, org2);
 
-        return Arrays.asList(organizationWithRoles, organizationWithoutRoles);
+        // Organization 3
+        Map<String, Object> org3 = new HashMap<>();
+        org3.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_3_NAME));
+        org3.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_3_NAME);
+        org3.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_ONLY);
+        org3.put(MAP_KEY_SELECTIVE_ROLES, Collections.emptyList());
+
+        organizations.put(L1_ORG_3_NAME, org3);
+
+        return organizations;
     }
 
-    private RoleWithAudience createRoleWithAudience(String roleName, String display, String type) {
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingTestCase1() {
 
-        RoleWithAudienceAudience audience = new RoleWithAudienceAudience();
-        audience.setDisplay(display);
-        audience.setType(type);
+        Map<String, Object> expectedResults = new HashMap<>();
 
-        RoleWithAudience roleWithAudience = new RoleWithAudience();
-        roleWithAudience.setDisplayName(roleName);
-        roleWithAudience.setAudience(audience);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
 
-        return roleWithAudience;
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_1, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME), Collections.emptyList());
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Map<String, Object>> setOrganizationsForSelectiveUserSharingTestCase2() {
+
+        Map<String, Map<String, Object>> organizations = new HashMap<>();
+
+        // Organization 2
+        Map<String, Object> org2 = new HashMap<>();
+        org2.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_2_NAME));
+        org2.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_2_NAME);
+        org2.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN);
+        org2.put(MAP_KEY_SELECTIVE_ROLES,
+                Arrays.asList(createRoleWithAudience(ORG_ROLE_1, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_2, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_2_NAME, org2);
+
+        // Organization 3
+        Map<String, Object> org3 = new HashMap<>();
+        org3.put(MAP_KEY_SELECTIVE_ORG_ID, getOrgId(L1_ORG_3_NAME));
+        org3.put(MAP_KEY_SELECTIVE_ORG_NAME, L1_ORG_3_NAME);
+        org3.put(MAP_KEY_SELECTIVE_POLICY, SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN);
+        org3.put(MAP_KEY_SELECTIVE_ROLES,
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        organizations.put(L1_ORG_3_NAME, org3);
+
+        return organizations;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserSharingTestCase2() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 3);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L2_ORG_3_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(ORG_ROLE_1, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_2, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(ORG_ROLE_1, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_2, L2_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_2, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingTestCase1() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, ALL_EXISTING_ORGS_ONLY);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES,
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingTestCase2() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, IMMEDIATE_EXISTING_AND_FUTURE_ORGS);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES,
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingTestCase2() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 3);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_1_NAME, L1_ORG_2_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_1_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingTestCase3() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, IMMEDIATE_EXISTING_ORGS_ONLY);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES,
+                Collections.singletonList(createRoleWithAudience(ORG_ROLE_3, ROOT_ORG_NAME, ORGANIZATION_AUDIENCE)));
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingTestCase3() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 3);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_1_NAME, L1_ORG_2_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(ORG_ROLE_3, L1_ORG_1_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(ORG_ROLE_3, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(ORG_ROLE_3, L1_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setPolicyWithRolesForGeneralUserSharingTestCase4() {
+
+        Map<String, Object> policyWithRoles = new HashMap<>();
+
+        policyWithRoles.put(MAP_KEY_GENERAL_POLICY, ALL_EXISTING_AND_FUTURE_ORGS);
+        policyWithRoles.put(MAP_KEY_GENERAL_ROLES, Collections.emptyList());
+
+        return policyWithRoles;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserSharingTestCase4() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 7);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L1_ORG_1_NAME), getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME),
+                        getOrgId(L3_ORG_1_NAME), getOrgId(L1_ORG_2_NAME), getOrgId(L2_ORG_3_NAME),
+                        getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L1_ORG_1_NAME, L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L1_ORG_2_NAME, L2_ORG_3_NAME,
+                        L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_1_NAME), Collections.emptyList());
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME), Collections.emptyList());
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME), Collections.emptyList());
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME), Collections.emptyList());
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME), Collections.emptyList());
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME), Collections.emptyList());
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME), Collections.emptyList());
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setExpectedResultsForGeneralUserUnsharingTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 0);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Collections.emptyList());
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Collections.emptyList());
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserUnsharingTestCase1() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 5);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS,
+                Arrays.asList(getOrgId(L2_ORG_1_NAME), getOrgId(L2_ORG_2_NAME), getOrgId(L3_ORG_1_NAME),
+                        getOrgId(L2_ORG_3_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES,
+                Arrays.asList(L2_ORG_1_NAME, L2_ORG_2_NAME, L3_ORG_1_NAME, L2_ORG_3_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_2_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L3_ORG_1_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L2_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Collections.singletonList(createRoleWithAudience(APP_ROLE_1, APP_1_NAME, APPLICATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    private Map<String, Object> setExpectedResultsForSelectiveUserUnsharingTestCase2() {
+
+        Map<String, Object> expectedResults = new HashMap<>();
+
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_COUNT, 2);
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_IDS, Arrays.asList(getOrgId(L1_ORG_2_NAME), getOrgId(L1_ORG_3_NAME)));
+        expectedResults.put(MAP_KEY_EXPECTED_ORG_NAMES, Arrays.asList(L1_ORG_2_NAME, L1_ORG_3_NAME));
+
+        Map<String, List<RoleWithAudience>> expectedRolesPerExpectedOrg = new HashMap<>();
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_2_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_2_NAME, ORGANIZATION_AUDIENCE)));
+        expectedRolesPerExpectedOrg.put(getOrgId(L1_ORG_3_NAME),
+                Arrays.asList(createRoleWithAudience(APP_ROLE_3, APP_1_NAME, APPLICATION_AUDIENCE),
+                        createRoleWithAudience(ORG_ROLE_3, L1_ORG_3_NAME, ORGANIZATION_AUDIENCE)));
+
+        expectedResults.put(MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG, expectedRolesPerExpectedOrg);
+
+        return expectedResults;
+    }
+
+    // Setup methods.
+
+    private void setupDetailMaps() {
+
+        userDetails = new HashMap<>();
+        orgDetails = new HashMap<>();
+        appDetails = new HashMap<>();
+        roleDetails = new HashMap<>();
+    }
+
+    private void setupRestClients() throws Exception {
+
+        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        orgMgtRestClient = new OrgMgtRestClient(context, tenantInfo, serverURL,
+                new JSONObject(readResource(AUTHORIZED_APIS_JSON)));
+        httpClient = HttpClientBuilder.create().build();
     }
 
     private void setupOrganizations() throws Exception {
 
-        l1Org1Id = orgMgtRestClient.addOrganization(L1_ORG_1_NAME);
-        l1Org2Id = orgMgtRestClient.addOrganization(L1_ORG_2_NAME);
-        l2Org1Id = orgMgtRestClient.addSubOrganization(L2_ORG_1_NAME, l1Org1Id);
-        l2Org2Id = orgMgtRestClient.addSubOrganization(L2_ORG_2_NAME, l1Org1Id);
-        l2Org3Id = orgMgtRestClient.addSubOrganization(L2_ORG_3_NAME, l1Org2Id);
-        l3Org1Id = orgMgtRestClient.addSubOrganization(L3_ORG_1_NAME, l2Org1Id);
-    }
+        // Create Level 1 Organizations
+        addOrganization(L1_ORG_1_NAME);
+        addOrganization(L1_ORG_2_NAME);
+        addOrganization(L1_ORG_3_NAME);
 
-    private void setupTokens() throws Exception {
+        // Create Level 2 Organizations
+        addSubOrganization(L2_ORG_1_NAME, getOrgId(L1_ORG_1_NAME), 2);
+        addSubOrganization(L2_ORG_2_NAME, getOrgId(L1_ORG_1_NAME), 2);
+        addSubOrganization(L2_ORG_3_NAME, getOrgId(L1_ORG_2_NAME), 2);
 
-        l1Org1SwitchToken = orgMgtRestClient.switchM2MToken(l1Org1Id);
-        l2Org1SwitchToken = orgMgtRestClient.switchM2MToken(l2Org1Id);
+        // Create Level 3 Organization
+        addSubOrganization(L3_ORG_1_NAME, getOrgId(L2_ORG_1_NAME), 3);
     }
 
     protected void setupApplicationsAndRoles() throws Exception {
 
-        // Create a new application which consume application audience roles and share with all children.
-        application1WithAppAudienceRoles = addApplication(APP_1_NAME);
-        String app1Id = application1WithAppAudienceRoles.getId();
-        OpenIDConnectConfiguration oidcConfigOfApp1 = oAuth2RestClient.getOIDCInboundDetails(app1Id);
-        clientIdApp1 = oidcConfigOfApp1.getClientId();
-        clientSecretApp1 = oidcConfigOfApp1.getClientSecret();
-        createApp1RolesWithAppAudience(app1Id);
-        // Mark roles and groups as requested claims for the app 1.
-        updateRequestedClaimsOfApp(app1Id, getClaimConfigurationsWithRolesAndGroups());
-        shareApplication(app1Id);
-        sharedApp1IdInLevel1Org =
-                oAuth2RestClient.getAppIdUsingAppNameInOrganization(APP_1_NAME, l1Org1SwitchToken);
+        Map<String, String> rootOrgOrganizationRoles =
+                setUpOrganizationRoles(ROOT_ORG_NAME, Arrays.asList(ORG_ROLE_1, ORG_ROLE_2, ORG_ROLE_3));
 
-        // Create a new application which consume organization audience roles and share with all children.
-        application2WithOrgAudienceRoles = addApplication(APP_2_NAME);
-        String app2Id = application2WithOrgAudienceRoles.getId();
-        OpenIDConnectConfiguration oidcConfigOfApp2 = oAuth2RestClient.getOIDCInboundDetails(app2Id);
-        clientIdApp2 = oidcConfigOfApp2.getClientId();
-        clientSecretApp2 = oidcConfigOfApp2.getClientSecret();
-        createOrganizationRoles();
-        switchApplicationAudience(app2Id, AssociatedRolesConfig.AllowedAudienceEnum.ORGANIZATION);
-    }
-
-    private void createOrganizationRoles() throws IOException {
-
-        RoleV2 orgRole1 = new RoleV2(null, ORG_ROLE_1, Collections.emptyList(), Collections.emptyList());
-        orgRole1Id = scim2RestClient.addV2Role(orgRole1);
-        RoleV2 orgRole2 = new RoleV2(null, ORG_ROLE_2, Collections.emptyList(), Collections.emptyList());
-        orgRole2Id = scim2RestClient.addV2Role(orgRole2);
-        RoleV2 orgRole3 = new RoleV2(null, ORG_ROLE_3, Collections.emptyList(), Collections.emptyList());
-        orgRole3Id = scim2RestClient.addV2Role(orgRole3);
-    }
-
-    private void createApp1RolesWithAppAudience(String app1Id) throws IOException {
-
-        Audience app1RoleAudience = new Audience(APPLICATION_AUDIENCE, app1Id);
-        RoleV2 appRole1 = new RoleV2(app1RoleAudience, APP_ROLE_1, Collections.emptyList(), Collections.emptyList());
-        appRole1Id = scim2RestClient.addV2Role(appRole1);
-        RoleV2 appRole2 = new RoleV2(app1RoleAudience, APP_ROLE_2, Collections.emptyList(), Collections.emptyList());
-        appRole2Id = scim2RestClient.addV2Role(appRole2);
-        RoleV2 appRole3 = new RoleV2(app1RoleAudience, APP_ROLE_3, Collections.emptyList(), Collections.emptyList());
-        appRole3Id = scim2RestClient.addV2Role(appRole3);
+        createApplication(APP_1_NAME, APPLICATION_AUDIENCE, Arrays.asList(APP_ROLE_1, APP_ROLE_2, APP_ROLE_3));
+        createApplication(APP_2_NAME, ORGANIZATION_AUDIENCE, new ArrayList<>(rootOrgOrganizationRoles.keySet()));
     }
 
     private void setupUsers() throws Exception {
 
-        UserObject rootOrgUser = createUserObject(ROOT_ORG_USERNAME, ROOT_ORG_NAME);
-        rootOrgUserId = scim2RestClient.createUser(rootOrgUser);
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_1_USERNAME, ROOT_ORG_NAME));
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_2_USERNAME, ROOT_ORG_NAME));
+        createUser(createUserObject(USER_DOMAIN_PRIMARY, ROOT_ORG_USER_3_USERNAME, ROOT_ORG_NAME));
 
-        UserObject l1Org1User = createUserObject(L1_ORG_1_USERNAME, L1_ORG_1_NAME);
-        l1Org1UserId = scim2RestClient.createSubOrgUser(l1Org1User, l1Org1SwitchToken);
-    }
-
-    private String getSharedOrgsRolesRef(String userId, String orgId) {
-
-        return "/api/server/v1" + USER_SHARING_API_BASE_PATH + "/" + userId + SHARED_ROLES_PATH + "?orgId=" + orgId;
-    }
-
-    private void deleteUserIfExists(String userId) throws Exception {
-
-        if (userId != null) {
-            scim2RestClient.deleteUser(userId);
-        }
-    }
-
-    private void deleteSubOrgUserIfExists(String userId, String organizationSwitchToken) throws Exception {
-
-        if (userId != null) {
-            scim2RestClient.deleteSubOrgUser(userId, organizationSwitchToken);
-        }
-    }
-
-    private void deleteRoleIfExists(String roleId) throws Exception {
-
-        if (roleId != null) {
-            scim2RestClient.deleteV2Role(roleId);
-        }
-    }
-
-    private void deleteApplicationIfExists(String appId) throws Exception {
-
-        if (appId != null) {
-            oAuth2RestClient.deleteApplication(appId);
-        }
-    }
-
-    private void deleteSubOrganizationIfExists(String orgId, String parentId) throws Exception {
-
-        if (orgId != null) {
-            orgMgtRestClient.deleteSubOrganization(orgId, parentId);
-        }
-    }
-
-    private void deleteOrganizationIfExists(String orgId) throws Exception {
-
-        if (orgId != null) {
-            orgMgtRestClient.deleteOrganization(orgId);
-        }
-    }
-
-    private void closeRestClients() throws IOException {
-
-        oAuth2RestClient.closeHttpClient();
-        scim2RestClient.closeHttpClient();
-        orgMgtRestClient.closeHttpClient();
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, L1_ORG_1_USER_1_USERNAME, L1_ORG_1_NAME), L1_ORG_1_NAME);
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, L1_ORG_1_USER_2_USERNAME, L1_ORG_1_NAME), L1_ORG_1_NAME);
+        createSuborgUser(createUserObject(USER_DOMAIN_PRIMARY, L1_ORG_1_USER_3_USERNAME, L1_ORG_1_NAME), L1_ORG_1_NAME);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/constant/UserSharingConstants.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/constant/UserSharingConstants.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.constant;
+
+/**
+ * Constants for organization user sharing.
+ */
+public class UserSharingConstants {
+
+    public static final String API_DEFINITION_NAME = "organization-user-share.yaml";
+    public static final String AUTHORIZED_APIS_JSON = "user-sharing-apis.json";
+    public static final String API_VERSION = "v1";
+    public static final String API_PACKAGE_NAME =
+            "org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1";
+
+    public static final String API_SERVER_V1_BASE_PATH = "/api/server/v1";
+    public static final String ORGANIZATION_API_PATH = "/o";
+    public static final String USER_SHARING_API_BASE_PATH = "/users";
+    public static final String SHARE_PATH = "/share";
+    public static final String SHARE_WITH_ALL_PATH = "/share-with-all";
+    public static final String UNSHARE_PATH = "/unshare";
+    public static final String UNSHARE_WITH_ALL_PATH = "/unshare-with-all";
+    public static final String SHARED_ORGANIZATIONS_PATH = "/shared-organizations";
+    public static final String SHARED_ROLES_PATH = "/shared-roles";
+
+    public static final String PATH_SEPARATOR = "/";
+    public static final String QUERY_PARAM_SEPARATOR = "?";
+    public static final String QUERY_PARAM_VALUE_SEPARATOR = "=";
+    public static final String UNDERSCORE = "_";
+
+    public static final String HEADER_AUTHORIZATION = "Authorization";
+    public static final String HEADER_AUTHORIZATION_VALUE_BEARER = "Bearer ";
+    public static final String HEADER_CONTENT_TYPE = "Content-Type";
+
+    public static final String SHARED_TYPE_SHARED = "SHARED";
+    public static final String SHARED_TYPE_OWNER = "OWNER";
+    public static final String SHARED_TYPE_INVITED = "INVITED";
+
+    public static final String PATH_PARAM_USER_ID = "userId";
+    public static final String QUERY_PARAM_ORG_ID = "orgId";
+    public static final String QUERY_PARAM_LIMIT = "limit";
+    public static final String QUERY_PARAM_AFTER = "after";
+    public static final String QUERY_PARAM_BEFORE = "before";
+    public static final String QUERY_PARAM_FILTER = "filter";
+    public static final String QUERY_PARAM_RECURSIVE = "recursive";
+
+    public static final String ERROR_CODE_BAD_REQUEST = "UE-10000";
+    public static final String ERROR_CODE_INVALID_PAGINATION_CURSOR = "ORG-60026";
+    public static final String ERROR_CODE_SERVER_ERROR = "SE-50000";
+
+    public static final String ROOT_ORG_NAME = "Super";
+    public static final String L1_ORG_1_NAME = "L1 - Organization 1";
+    public static final String L1_ORG_2_NAME = "L1 - Organization 2";
+    public static final String L1_ORG_3_NAME = "L1 - Organization 3";
+    public static final String L2_ORG_1_NAME = "L2 - Organization 1";
+    public static final String L2_ORG_2_NAME = "L2 - Organization 2";
+    public static final String L2_ORG_3_NAME = "L2 - Organization 3";
+    public static final String L3_ORG_1_NAME = "L3 - Organization 1";
+
+    public static final String ROOT_ORG_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
+
+    public static final String APP_1_NAME = "App 1";
+    public static final String APP_2_NAME = "App 2";
+
+    public static final String APPLICATION_AUDIENCE = "application";
+    public static final String ORGANIZATION_AUDIENCE = "organization";
+
+    public static final String APP_ROLE_1 = "app-role-1";
+    public static final String APP_ROLE_2 = "app-role-2";
+    public static final String APP_ROLE_3 = "app-role-3";
+    public static final String ORG_ROLE_1 = "org-role-1";
+    public static final String ORG_ROLE_2 = "org-role-2";
+    public static final String ORG_ROLE_3 = "org-role-3";
+
+    public static final String USER_DOMAIN_PRIMARY = "PRIMARY";
+
+    public static final String ROOT_ORG_USER_1_USERNAME = "rootUser1";
+    public static final String ROOT_ORG_USER_2_USERNAME = "rootUser2";
+    public static final String ROOT_ORG_USER_3_USERNAME = "rootUser3";
+    public static final String L1_ORG_1_USER_1_USERNAME = "l1Org1User1";
+    public static final String L1_ORG_1_USER_2_USERNAME = "l1Org1User2";
+    public static final String L1_ORG_1_USER_3_USERNAME = "l1Org1User3";
+    public static final String ROOT_ORG_USER_DUPLICATED_USERNAME = "rootUserDuplicated";
+
+    public static final String MAP_KEY_SELECTIVE_ORG_ID = "orgId";
+    public static final String MAP_KEY_SELECTIVE_ORG_NAME = "orgName";
+    public static final String MAP_KEY_SELECTIVE_POLICY = "selectivePolicy";
+    public static final String MAP_KEY_SELECTIVE_ROLES = "selectiveRoles";
+
+    public static final String MAP_KEY_GENERAL_POLICY = "generalPolicy";
+    public static final String MAP_KEY_GENERAL_ROLES = "generalRoles";
+
+    public static final String MAP_KEY_EXPECTED_ORG_COUNT = "expectedOrgCount";
+    public static final String MAP_KEY_EXPECTED_ORG_IDS = "expectedOrgIds";
+    public static final String MAP_KEY_EXPECTED_ORG_NAMES = "expectedOrgNames";
+    public static final String MAP_KEY_EXPECTED_ROLES_PER_EXPECTED_ORG = "expectedRolesPerExpectedOrg";
+
+    public static final String MAP_ORG_DETAILS_KEY_ORG_NAME = "orgName";
+    public static final String MAP_ORG_DETAILS_KEY_ORG_ID = "orgId";
+    public static final String MAP_ORG_DETAILS_KEY_PARENT_ORG_ID = "parentOrgId";
+    public static final String MAP_ORG_DETAILS_KEY_ORG_SWITCH_TOKEN = "orgSwitchToken";
+    public static final String MAP_ORG_DETAILS_KEY_ORG_LEVEL = "orgLevel";
+
+    public static final String MAP_APP_DETAILS_KEY_APP_NAME = "appName";
+    public static final String MAP_APP_DETAILS_KEY_APP_ID = "appId";
+    public static final String MAP_APP_DETAILS_KEY_APP_AUDIENCE = "appAudience";
+    public static final String MAP_APP_DETAILS_KEY_CLIENT_ID = "clientId";
+    public static final String MAP_APP_DETAILS_KEY_CLIENT_SECRET = "clientSecret";
+    public static final String MAP_APP_DETAILS_KEY_ROLE_NAMES = "roleNames";
+    public static final String MAP_APP_DETAILS_KEY_ROLE_IDS_BY_NAME = "roleIdsByName";
+    public static final String MAP_APP_DETAILS_KEY_APP_DETAILS_OF_SUB_ORGS = "appDetailsOfSubOrgs";
+    public static final String MAP_APP_DETAILS_KEY_APP_SUB_ORG_NAME = "subOrgName";
+
+    public static final String MAP_USER_DETAILS_KEY_DOMAIN_QUALIFIED_USER_NAME = "domainQualifiedUserName";
+    public static final String MAP_USER_DETAILS_KEY_USER_NAME = "userName";
+    public static final String MAP_USER_DETAILS_KEY_USER_ID = "userId";
+    public static final String MAP_USER_DETAILS_KEY_USER_DOMAIN = "userDomain";
+    public static final String MAP_USER_DETAILS_KEY_USER_ORG_NAME = "userOrgName";
+    public static final String MAP_USER_DETAILS_KEY_USER_ORG_ID = "userOrgId";
+    public static final String MAP_USER_DETAILS_KEY_USER_ORG_LEVEL = "userOrgLevel";
+    public static final String MAP_USER_DETAILS_KEY_IS_ROOT_ORG_USER = "isRootOrgUser";
+
+    public static final String MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_NAME = "userName";
+    public static final String MAP_USER_DOMAIN_QUALIFIED_USER_NAME_USER_DOMAIN = "userDomain";
+
+    public static final String SCOPE_INTERNAL_USER_SHARE = "internal_user_share";
+    public static final String SCOPE_INTERNAL_USER_UNSHARE = "internal_user_unshare";
+    public static final String SCOPE_INTERNAL_USER_SHARED_ACCESS_VIEW = "internal_user_shared_access_view";
+    public static final String SCOPE_INTERNAL_ORG_USER_SHARE = "internal_org_user_share";
+    public static final String SCOPE_INTERNAL_ORG_USER_UNSHARE = "internal_org_user_unshare";
+    public static final String SCOPE_INTERNAL_ORG_USER_SHARED_ACCESS_VIEW = "internal_org_user_shared_access_view";
+
+    public static final String GRANT_AUTHORIZATION_CODE = "authorization_code";
+    public static final String GRANT_IMPLICIT = "implicit";
+    public static final String GRANT_PASSWORD = "password";
+    public static final String GRANT_CLIENT_CREDENTIALS = "client_credentials";
+    public static final String GRANT_REFRESH_TOKEN = "refresh_token";
+    public static final String GRANT_ORGANIZATION_SWITCH = "organization_switch";
+
+    public static final String CLAIM_EMAIL_URI = "http://wso2.org/claims/emailaddress";
+    public static final String CLAIM_COUNTRY_URI = "http://wso2.org/claims/country";
+    public static final String CLAIM_ROLES_URI = "http://wso2.org/claims/roles";
+    public static final String CLAIM_GROUPS_URI = "http://wso2.org/claims/groups";
+
+    public static final String ATTRIBUTE_USER_PASSWORD = "Admin123";
+    public static final String ATTRIBUTE_USER_EMAIL_DOMAIN = "@gmail.com";
+    public static final String ATTRIBUTE_USER_SCHEMA_SCIM2_USER = "urn:ietf:params:scim:schemas:core:2.0:User";
+
+    public static final String RESPONSE_STATUS = "status";
+    public static final String RESPONSE_DETAILS = "details";
+    public static final String RESPONSE_STATUS_VALUE = "Processing";
+    public static final String RESPONSE_DETAIL_VALUE_SHARING = "User sharing process triggered successfully.";
+    public static final String RESPONSE_DETAIL_VALUE_UNSHARING = "User unsharing process triggered successfully.";
+
+    public static final String RESPONSE_LINKS_SIZE = "links.size()";
+    public static final String RESPONSE_LINKS_EMPTY = "links[0].isEmpty()";
+    public static final String RESPONSE_LINKS_SHARED_ORGS = "sharedOrganizations";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_SIZE = "sharedOrganizations.size()";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ID = "sharedOrganizations.orgId";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_NAME = "sharedOrganizations.orgName";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_SHARED_USER_ID = "sharedOrganizations.sharedUserId";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_SHARED_TYPE = "sharedOrganizations.sharedType";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ROLES_REF = "sharedOrganizations.rolesRef";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ROLES = "roles";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ROLES_SIZE = "roles.size()";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ROLES_NAME = "roles.displayName";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ROLES_AUDIENCE_NAME = "roles.audience.display";
+    public static final String RESPONSE_LINKS_SHARED_ORGS_ROLES_AUDIENCE_TYPE = "roles.audience.type";
+
+    public static final String ERROR_SETUP_SWAGGER_DEFINITION = "Unable to read the swagger definition %s from %s";
+    public static final String SHARED_USER_ID_JSON_PATH =
+            "sharedOrganizations.find { it.orgName == '%s' }.sharedUserId";
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UserSharingRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/UserSharingRestClient.java
@@ -24,10 +24,12 @@ import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
 import org.testng.Assert;
-import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBody;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareRequestBody;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserUnshareWithAllRequestBody;
 
 import java.io.IOException;
 
@@ -39,13 +41,25 @@ import javax.servlet.http.HttpServletResponse;
 public class UserSharingRestClient extends RestBaseClient {
 
     private static final String API_SERVER_BASE_PATH = "/api/server/v1";
-    public static final String USER_SHARE_WITH_ALL_ENDPOINT_URI = "/users/share-with-all";
+    static final String USER_SHARING_API_BASE_PATH = "/users";
+    static final String SHARE_PATH = "/share";
+    static final String SHARE_WITH_ALL_PATH = "/share-with-all";
+    static final String UNSHARE_PATH = "/unshare";
+    static final String UNSHARE_WITH_ALL_PATH = "/unshare-with-all";
+    static final String SHARED_ORGANIZATIONS_PATH = "/shared-organizations";
+    static final String SHARED_ROLES_PATH = "/shared-roles";
+
     public static final String PATH_SEPARATOR = "/";
+
     private final String serverUrl;
     private final String tenantDomain;
     private final String username;
     private final String password;
-    private final String userShareWithAllBasePath;
+
+    private final String selectiveUserShareEndpoint;
+    private final String generalUserShareEndpoint;
+    private final String selectiveUserUnshareEndpoint;
+    private final String generalUserUnshareEndpoint;
 
     public UserSharingRestClient(String serverUrl, Tenant tenantInfo) {
 
@@ -54,24 +68,77 @@ public class UserSharingRestClient extends RestBaseClient {
         this.username = tenantInfo.getContextUser().getUserName();
         this.password = tenantInfo.getContextUser().getPassword();
 
-        userShareWithAllBasePath = serverUrl +
-                ISIntegrationTest.getTenantedRelativePath(API_SERVER_BASE_PATH + USER_SHARE_WITH_ALL_ENDPOINT_URI,
-                        tenantDomain);
+        selectiveUserShareEndpoint = serverUrl + ISIntegrationTest.getTenantedRelativePath(
+                API_SERVER_BASE_PATH + USER_SHARING_API_BASE_PATH + SHARE_PATH, tenantDomain);
+        generalUserShareEndpoint = serverUrl + ISIntegrationTest.getTenantedRelativePath(
+                API_SERVER_BASE_PATH + USER_SHARING_API_BASE_PATH + SHARE_WITH_ALL_PATH, tenantDomain);
+        selectiveUserUnshareEndpoint = serverUrl + ISIntegrationTest.getTenantedRelativePath(
+                API_SERVER_BASE_PATH + USER_SHARING_API_BASE_PATH + UNSHARE_PATH, tenantDomain);
+        generalUserUnshareEndpoint = serverUrl + ISIntegrationTest.getTenantedRelativePath(
+                API_SERVER_BASE_PATH + USER_SHARING_API_BASE_PATH + UNSHARE_WITH_ALL_PATH, tenantDomain);
+    }
+
+    /**
+     * Share users selectively.
+     *
+     * @param userShareRequestBody Selective User Share request body.
+     * @throws Exception If an error occurs while sharing users selectively.
+     */
+    public void shareUsers(UserShareRequestBody userShareRequestBody) throws Exception {
+
+        String jsonRequest = toJSONString(userShareRequestBody);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(selectiveUserShareEndpoint, jsonRequest,
+                getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_ACCEPTED,
+                    "Selective User Sharing request accepted.");
+        }
     }
 
     /**
      * Share users with all.
      *
-     * @param userShareWithAllRequestBody User share with all request body.
+     * @param userShareWithAllRequestBody General User Share request body.
      * @throws Exception If an error occurs while sharing users with all.
      */
     public void shareUsersWithAll(UserShareWithAllRequestBody userShareWithAllRequestBody) throws Exception {
 
         String jsonRequest = toJSONString(userShareWithAllRequestBody);
-        try (CloseableHttpResponse response = getResponseOfHttpPost(userShareWithAllBasePath, jsonRequest,
+        try (CloseableHttpResponse response = getResponseOfHttpPost(generalUserShareEndpoint, jsonRequest,
                 getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_ACCEPTED,
-                    "User sharing request accepted.");
+                    "General User Sharing request accepted.");
+        }
+    }
+
+    /**
+     * Unshare users selectively.
+     *
+     * @param userUnshareRequestBody Selective User Unshare request body.
+     * @throws Exception If an error occurs while unsharing users selectively.
+     */
+    public void unshareUsers(UserUnshareRequestBody userUnshareRequestBody) throws Exception {
+
+        String jsonRequest = toJSONString(userUnshareRequestBody);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(selectiveUserUnshareEndpoint, jsonRequest,
+                getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_ACCEPTED,
+                    "Selective User Unsharing request accepted.");
+        }
+    }
+
+    /**
+     * Unshare users with all.
+     *
+     * @param userUnshareWithAllRequestBody General User Unshare request body.
+     * @throws Exception If an error occurs while unsharing users with all.
+     */
+    public void unshareUsersWithAll(UserUnshareWithAllRequestBody userUnshareWithAllRequestBody) throws Exception {
+
+        String jsonRequest = toJSONString(userUnshareWithAllRequestBody);
+        try (CloseableHttpResponse response = getResponseOfHttpPost(generalUserUnshareEndpoint, jsonRequest,
+                getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_ACCEPTED,
+                    "General User Unsharing request accepted.");
         }
     }
 


### PR DESCRIPTION
This PR introduces comprehensive integration tests for the User Sharing API, ensuring correctness in user sharing, unsharing, and verification through a successful GET request for a user's shared organizations and assigned shared roles to a shared user in a given organization. These tests validate request handling, response accuracy, and expected behavior across various valid and invalid scenarios, ensuring API reliability in standard usage.

**Test Coverage:**

**✅ Successful Scenarios**
1. Selective User Sharing:
    - Covers single and multiple users across multiple organizations.
    - Validates all selective resource-sharing policies:
        - `SELECTED_ORG_ONLY`
        - `SELECTED_ORG_WITH_ALL_EXISTING_CHILDREN_ONLY`
        - `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`
        - `SELECTED_ORG_WITH_EXISTING_IMMEDIATE_CHILDREN_ONLY`
        - `SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN`
2. General User Sharing:
    - Covers single and multiple users.
    - Validates all general resource-sharing policies:
        - `ALL_EXISTING_ORGS_ONLY`
        - `ALL_EXISTING_AND_FUTURE_ORGS`
        - `IMMEDIATE_EXISTING_ORGS_ONLY`
        - `IMMEDIATE_EXISTING_AND_FUTURE_ORGS`
3. General User Unsharing:
    - Covers single and multiple users.
4. Selective User Unsharing:
    - Covers single and multiple users.
    - Covers single and multiple organizations.


❌ **Failure Scenarios**

1. Selective User Sharing:
    - Selective User Sharing with invalid roles (single and multiple invalid roles).
    - Selective User Sharing with invalid organizations (single and multiple invalid organizations).
    - Selective User Sharing with invalid users (single and multiple invalid users).
    - Selective User Sharing with conflicting users (user exists in a child organization under the same username).
    - Selective User Sharing with non-immediate child organizations.
2. General User Sharing:
    - General User Sharing with invalid roles.
    - General User Sharing with invalid users.
    - General User Sharing with conflicting users.
3. General User Unsharing:
    - General User Unsharing with invalid users (single and multiple invalid users).
4. Selective User Unsharing:
    - Selective User Unsharing with invalid users and invalid organizations (single and multiple cases).
5. Selective User Re-Sharing:
    - Invalid Selective User Re-sharing (a shared user from a parent org cannot be re-shared from a child org).
6. General User Re-Sharing:
    - Invalid General User Re-sharing (a shared user from a parent org cannot be re-shared from a child org).

---

## Related Issue

[Add Integration Tests for User Sharing API #23328](https://github.com/wso2/product-is/issues/23328)