### PR TITLE
Update integration tests with password recovery email otp support.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/PreferenceAPIIntegrationUITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/PreferenceAPIIntegrationUITestCase.java
@@ -58,6 +58,8 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
     private static final String ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY = "Recovery.Question.Password.Enable";
     private static final String ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY =
             "Recovery.Notification.Password.Enable";
+    private static final String ENABLE_PASSWORD_EMAIL_OTP_RECOVERY_PROP_KEY =
+            "Recovery.Notification.Password.OTP.SendOTPInEmail";
     private static final String ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY =
             "Recovery.Notification.Password.emailLink.Enable";
     private static final String ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY =
@@ -66,7 +68,7 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
     private static final String RECOVERY_USERNAME_CONTENT = "id=\"usernameRecoverLink\"";
     private static final String RECOVERY_PASSWORD_CONTENT = "id=\"passwordRecoverLink\"";
     private static final String RECOVERY_ENDPOINT_QS_CONTENT = "name=\"recoveryOption\" value=\"SECURITY_QUESTIONS\"";
-    private static final String RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
+    private static final String RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_CONTENT = "name=\"recoveryOption\" value=\"EMAIL\"";
     private static final String RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT = "name=\"recoveryOption\" value=\"SMSOTP\"";
     private static final String CREATE_ACCOUNT_CONTENT = "id=\"registerLink\"";
     private static final String RECOVERY_ENDPOINT_URL = "/accountrecoveryendpoint/recoveraccountrouter.do";
@@ -136,6 +138,7 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
                 ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "false",
                 ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "false",
                 ENABLE_PASSWORD_EMAIL_LINK_RECOVERY_PROP_KEY, "false",
+                ENABLE_PASSWORD_EMAIL_OTP_RECOVERY_PROP_KEY, "false",
                 ENABLE_PASSWORD_SMS_OTP_RECOVERY_PROP_KEY, "false"));
     }
 
@@ -201,7 +204,7 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
         updateResidentIDPProperty(superTenantResidentIDP, ENABLE_PASSWORD_QS_RECOVERY_PROP_KEY, "true");
         String content = sendRecoveryRequest();
         Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
-        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_CONTENT));
         Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
     }
 
@@ -214,7 +217,19 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
         String content = sendRecoveryRequest();
         Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
         Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
-        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_CONTENT));
+    }
+
+    @Test(groups = "wso2.is", description = "Check Notification recovery option recovery Page")
+    public void testRecoveryNotificationEmailOTPOnly() throws Exception {
+
+        updateResidentIDPProperties(superTenantResidentIDP, Map.of(
+                ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true",
+                ENABLE_PASSWORD_EMAIL_OTP_RECOVERY_PROP_KEY, "true"));
+        String content = sendRecoveryRequest();
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
+        Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_CONTENT));
     }
 
     @Test(groups = "wso2.is", description = "Check Notification recovery option recovery Page")
@@ -226,7 +241,7 @@ public class PreferenceAPIIntegrationUITestCase extends OAuth2ServiceAbstractInt
                 ENABLE_PASSWORD_NOTIFICATION_RECOVERY_PROP_KEY, "true"));
         String content = sendRecoveryRequest();
         Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_QS_CONTENT));
-        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_LINK_CONTENT));
+        Assert.assertFalse(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_EMAIL_CONTENT));
         Assert.assertTrue(content.contains(RECOVERY_ENDPOINT_NOTIFICATION_SMS_OTP_CONTENT));
     }
 


### PR DESCRIPTION
### Purpose
- $subject

### Description
- These tests will only checks the configurations are working for the email otp option.

### Related issues
- https://github.com/wso2/product-is/issues/23444