### PR TITLE
Fix OAuth2ServiceResourceOwnerTestCase failures

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/EmailOTPTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/EmailOTPTestCase.java
@@ -161,6 +161,7 @@ public class EmailOTPTestCase extends ISIntegrationTest {
 
         deleteUser();
         deleteApplication();
+        deleteIdP();
 
         applicationManagementServiceClient = null;
         ssoConfigServiceClient = null;
@@ -289,6 +290,11 @@ public class EmailOTPTestCase extends ISIntegrationTest {
     private void deleteApplication() throws Exception {
 
         applicationManagementServiceClient.deleteApplication(APPLICATION_NAME);
+    }
+
+    private void deleteIdP() throws Exception {
+
+        identityProviderMgtServiceClient.deleteIdP(IDENTITY_PROVIDER_NAME);
     }
 
     private SAMLSSOServiceProviderDTO getSsoServiceProviderDTO() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/apiAuthorization/APIResourceInheritanceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/apiAuthorization/APIResourceInheritanceTestCase.java
@@ -18,6 +18,8 @@
 
 package org.wso2.identity.integration.test.apiAuthorization;
 
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -26,6 +28,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.APIResourceCreationModel;
 import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.APIResourceListItem;
@@ -71,6 +74,7 @@ public class APIResourceInheritanceTestCase extends OAuth2ServiceAbstractIntegra
     private final TestUserMode userMode;
     private APIResourceManagementClient apiResourceManagementClient;
     private OrgMgtRestClient orgMgtRestClient;
+    private IdentityProviderMgtServiceClient idpMgtServiceClient;
     private String level1OrgId;
     private String level2OrgId;
     private String switchedM2MTokenForLevel1Org;
@@ -100,6 +104,10 @@ public class APIResourceInheritanceTestCase extends OAuth2ServiceAbstractIntegra
         orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
                 new JSONObject(readResource(AUTHORIZED_APIS_JSON, this.getClass())));
 
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
+
         level1OrgId = orgMgtRestClient.addOrganization(L1_SUB_ORG_NAME);
         level2OrgId = orgMgtRestClient.addSubOrganization(L2_SUB_ORG_NAME, level1OrgId);
         switchedM2MTokenForLevel1Org = orgMgtRestClient.switchM2MToken(level1OrgId);
@@ -112,6 +120,7 @@ public class APIResourceInheritanceTestCase extends OAuth2ServiceAbstractIntegra
         // Delete sub organizations.
         orgMgtRestClient.deleteSubOrganization(level2OrgId, level1OrgId);
         orgMgtRestClient.deleteOrganization(level1OrgId);
+        idpMgtServiceClient.deleteIdP("SSO");
         orgMgtRestClient.closeHttpClient();
         apiResourceManagementClient.closeHttpClient();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/idp/mgt/IdentityProviderMgtServiceTestCase.java
@@ -495,6 +495,10 @@ public class IdentityProviderMgtServiceTestCase extends ISIntegrationTest {
     public void testGetAllIdPsCount() throws Exception {
 
         int idpCount = idpMgtServiceClient.getAllIdpCount();
+        List<IdentityProvider> identityProviders = idpMgtServiceClient.getIdPs();
+        for (IdentityProvider identityProvider : identityProviders) {
+            log.info("Identity Provider Name : " + identityProvider.getIdentityProviderName());
+        }
         Assert.assertEquals(idpCount, 2, "Total idp count did not match with the expected.");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceResourceOwnerTestCase.java
@@ -38,45 +38,56 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.wso2.identity.integration.test.rest.api.user.common.model.ScimSchemaExtensionSystem;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.DataExtractUtil;
 import org.wso2.identity.integration.test.utils.OAuth2Constant;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.xpath.XPathExpressionException;
+
 import static org.wso2.identity.integration.test.utils.CommonConstants.USER_IS_LOCKED;
 import static org.wso2.identity.integration.test.utils.DataExtractUtil.KeyValue;
 
 public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
+	public static final String OAUTH_2_SERVICE_RESOURCE_OWNER_TOML = "oauth2_service_resource_owner.toml";
+
+	private ServerConfigurationManager serverConfigurationManager;
 	private String accessToken;
 	private String consumerKey;
 	private String consumerSecret;
 
 	private CloseableHttpClient client;
-	private final AutomationContext context;
+	private AutomationContext context;
 	private Tenant tenantInfo;
 	private SCIM2RestClient scim2RestClient;
 
 	private static final String lockedUser = "test_locked_user";
 	private static final String lockedUserPassword = "Test_locked_user_pass@123";
-	private final String username;
-	private final String tenantAwareUsername;
-	private final String userPassword;
-	private final String activeTenant;
+	private String username;
+	private String tenantAwareUsername;
+	private String userPassword;
+	private String activeTenant;
 	private static final String TENANT_DOMAIN = "wso2.com";
 	private String applicationId;
 	private String userId;
+	private TestUserMode userMode;
 
 	@DataProvider(name = "configProvider")
 	public static Object[][] configProvider() {
@@ -87,16 +98,20 @@ public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractInt
 	@Factory(dataProvider = "configProvider")
 	public OAuth2ServiceResourceOwnerTestCase(TestUserMode userMode) throws Exception {
 
+		this.userMode = userMode;
+	}
+
+	@BeforeClass(alwaysRun = true)
+	public void testInit() throws Exception {
+
+		super.init();
+		changeISConfiguration();
 		super.init(userMode);
 		context = new AutomationContext("IDENTITY", userMode);
 		this.username = context.getContextTenant().getTenantAdmin().getUserNameWithoutDomain();
 		this.userPassword = context.getContextTenant().getTenantAdmin().getPassword();
 		this.activeTenant = context.getContextTenant().getDomain();
 		this.tenantAwareUsername = context.getContextTenant().getTenantAdmin().getUserName();
-	}
-
-	@BeforeClass(alwaysRun = true)
-	public void testInit() throws Exception {
 
 		tenantInfo = context.getContextTenant();
 
@@ -120,6 +135,21 @@ public class OAuth2ServiceResourceOwnerTestCase extends OAuth2ServiceAbstractInt
 		scim2RestClient.closeHttpClient();
 		consumerKey = null;
 		accessToken = null;
+		serverConfigurationManager.restoreToLastConfiguration(false);
+	}
+
+	private void changeISConfiguration() throws IOException,
+			XPathExpressionException, AutomationUtilException {
+
+		log.info("Replacing the deployment.toml file to enabling showing auth failure reason for password grant");
+		String carbonHome = Utils.getResidentCarbonHome();
+		File defaultTomlFile = getDeploymentTomlFile(carbonHome);
+		File configuredTomlFile = new File
+					(getISResourceLocation() + File.separator + "oauth" +
+							File.separator + OAUTH_2_SERVICE_RESOURCE_OWNER_TOML);
+		serverConfigurationManager = new ServerConfigurationManager(isServer);
+		serverConfigurationManager.applyConfigurationWithoutRestart(configuredTomlFile, defaultTomlFile, true);
+		serverConfigurationManager.restartForcefully();
 	}
 
 	@Test(groups = "wso2.is", description = "Check Oauth2 application registration")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/organizationDiscovery/OrganizationDiscoveryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/organizationDiscovery/OrganizationDiscoveryTestCase.java
@@ -18,6 +18,8 @@
 
 package org.wso2.identity.integration.test.organizationDiscovery;
 
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -43,6 +45,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
 import org.wso2.identity.integration.test.oauth2.dataprovider.model.ApplicationConfig;
 import org.wso2.identity.integration.test.oauth2.dataprovider.model.UserClaimConfig;
@@ -103,6 +106,7 @@ public class OrganizationDiscoveryTestCase extends OAuth2ServiceAbstractIntegrat
     private ServerConfigurationManager serverConfigurationManager;
     private CloseableHttpClient client;
     private ClaimManagementRestClient claimManagementRestClient;
+    private IdentityProviderMgtServiceClient idpMgtServiceClient;
     private OrgDiscoveryConfigRestClient organizationDiscoveryConfigRestClient;
     private OAuth2RestClient oAuth2RestClient;
     private OrgMgtRestClient orgMgtRestClient;
@@ -169,6 +173,10 @@ public class OrganizationDiscoveryTestCase extends OAuth2ServiceAbstractIntegrat
         // Map an email domain to the created sub-organization
         String mapEmailDomainRequestBody = RESTTestBase.readResource(EMAIL_DOMAIN_SUB_ORG_JSON, this.getClass());
         organizationDiscoveryConfigRestClient.mapDiscoveryAttributes(subOrgId, mapEmailDomainRequestBody);
+
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
     }
 
     @Test(dependsOnGroups = "wso2.is", description = "Test email domain based organization discovery not initiated " +
@@ -270,6 +278,7 @@ public class OrganizationDiscoveryTestCase extends OAuth2ServiceAbstractIntegrat
         organizationDiscoveryConfigRestClient.deleteOrganizationDiscoveryConfig();
         deleteApp(application.getId());
         orgMgtRestClient.deleteOrganization(subOrgId);
+        idpMgtServiceClient.deleteIdP(SSO);
         String revertEmailAsUsernameClaimRequestBody =
                 RESTTestBase.readResource(REVERT_EMAIL_AS_USERNAME_CLAIM_JSON, this.getClass());
         claimManagementRestClient.updateClaim(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/AppBrandingPreferenceManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/branding/preference/management/v1/AppBrandingPreferenceManagementSuccessTest.java
@@ -20,6 +20,8 @@ package org.wso2.identity.integration.test.rest.api.server.branding.preference.m
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
@@ -33,6 +35,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
 
@@ -49,6 +52,7 @@ import static org.wso2.identity.integration.test.util.Utils.areJSONObjectsEqual;
 public class AppBrandingPreferenceManagementSuccessTest extends AppBrandingPreferenceManagementTestBase {
 
     private OrgMgtRestClient orgMgtRestClient;
+    protected IdentityProviderMgtServiceClient identityProviderMgtServiceClient;
     private String rootAppId;
     private String level1AppId;
     private String level2AppId;
@@ -94,6 +98,10 @@ public class AppBrandingPreferenceManagementSuccessTest extends AppBrandingPrefe
                 orgMgtRestClient.switchM2MToken(level1OrgId));
         level2AppId = oAuth2RestClient.getAppIdUsingAppNameInOrganization(TEST_APP_NAME,
                 orgMgtRestClient.switchM2MToken(level2OrgId));
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        identityProviderMgtServiceClient =
+                new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
     }
 
     @AfterClass(alwaysRun = true)
@@ -102,6 +110,7 @@ public class AppBrandingPreferenceManagementSuccessTest extends AppBrandingPrefe
         super.conclude();
         deleteTestApp(rootAppId);
         deleteOrganizations();
+        identityProviderMgtServiceClient.deleteIdP("SSO");
         oAuth2RestClient.closeHttpClient();
         orgMgtRestClient.closeHttpClient();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/IdentityGovernanceSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/IdentityGovernanceSuccessTest.java
@@ -93,7 +93,7 @@ public class IdentityGovernanceSuccessTest extends IdentityGovernanceTestBase {
     }
 
     @AfterClass(alwaysRun = true)
-    public void testConclude() {
+    public void testConclude() throws IOException {
 
         super.conclude();
     }
@@ -290,6 +290,7 @@ public class IdentityGovernanceSuccessTest extends IdentityGovernanceTestBase {
                 .statusCode(HttpStatus.SC_OK)
                 .body("properties.find{it.name == 'passwordHistory.enable' }.value",
                         equalTo("true"));
+        disablePasswordExpiry();
     }
 
     @Test
@@ -330,5 +331,19 @@ public class IdentityGovernanceSuccessTest extends IdentityGovernanceTestBase {
                 i++;
             }
         }
+    }
+
+    private void disablePasswordExpiry() throws IOException {
+
+        String body = readResource("disable-password-expiry.json");
+        Response response =
+                getResponseOfPatch(IDENTITY_GOVERNANCE_ENDPOINT_URI +
+                                "/" + CATEGORY_PASSWORD_POLICIES + "/connectors/" +
+                                CONNECTOR_PASSWORD_EXPIRY,
+                        body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementBaseTest.java
@@ -30,6 +30,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationSharePOSTRequest;
@@ -137,6 +138,8 @@ public class OrganizationManagementBaseTest extends RESTAPIServerTestBase {
     protected static String swaggerDefinition;
     protected OAuth2RestClient oAuth2RestClient;
     protected SCIM2RestClient scim2RestClient;
+    protected IdentityProviderMgtServiceClient idpMgtServiceClient;
+
 
     static {
         String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.organization.management.v1";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementFailureTest.java
@@ -19,6 +19,8 @@
 package org.wso2.identity.integration.test.rest.api.server.organization.management.v1;
 
 import io.restassured.response.Response;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
@@ -45,6 +47,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
@@ -121,6 +124,10 @@ public class OrganizationManagementFailureTest extends OrganizationManagementBas
                 .setDefaultCookieSpecRegistry(cookieSpecRegistry)
                 .disableRedirectHandling()
                 .setDefaultCookieStore(cookieStore).build();
+
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
     }
 
     @AfterClass(alwaysRun = true)
@@ -129,6 +136,7 @@ public class OrganizationManagementFailureTest extends OrganizationManagementBas
         super.conclude();
         OAuth2Util.deleteApplication(oAuth2RestClient, applicationID);
         OAuth2Util.deleteApplication(oAuth2RestClient, b2bApplicationID);
+        idpMgtServiceClient.deleteIdP(ORGANIZATION_SSO);
         oAuth2RestClient.closeHttpClient();
         orgMgtRestClient.closeHttpClient();
         scim2RestClient.closeHttpClient();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementSuccessTest.java
@@ -34,6 +34,8 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
@@ -71,6 +73,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationListItem;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationSharePOSTRequest;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
@@ -164,6 +167,10 @@ public class OrganizationManagementSuccessTest extends OrganizationManagementBas
                 .setDefaultCookieSpecRegistry(cookieSpecRegistry)
                 .disableRedirectHandling()
                 .setDefaultCookieStore(cookieStore).build();
+
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
     }
 
     @AfterClass(alwaysRun = true)
@@ -172,6 +179,7 @@ public class OrganizationManagementSuccessTest extends OrganizationManagementBas
         super.conclude();
         deleteApplication(selfServiceAppId);
         deleteApplication(b2bApplicationID);
+        idpMgtServiceClient.deleteIdP(ORGANIZATION_SSO);
         oAuth2RestClient.closeHttpClient();
         scim2RestClient.closeHttpClient();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingBaseTest.java
@@ -39,6 +39,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
@@ -173,6 +174,8 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
     protected OAuth2RestClient oAuth2RestClient;
     protected SCIM2RestClient scim2RestClient;
     protected OrgMgtRestClient orgMgtRestClient;
+    protected IdentityProviderMgtServiceClient idpMgtServiceClient;
+
     protected HttpClient httpClient;
 
     protected Map<String, Map<String, Object>> userDetails;
@@ -989,6 +992,11 @@ public class UserSharingBaseTest extends RESTAPIServerTestBase {
         orgDetails.clear();
         appDetails.clear();
         roleDetails.clear();
+    }
+
+    protected void cleanUpSSOIdP() throws Exception {
+
+            idpMgtServiceClient.deleteIdP("SSO");
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingFailureTest.java
@@ -19,6 +19,8 @@
 package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1;
 
 import io.restassured.response.Response;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -30,6 +32,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudience;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBody;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
@@ -154,6 +157,7 @@ public class UserSharingFailureTest extends UserSharingBaseTest {
         cleanUpRoles(APPLICATION_AUDIENCE, ORGANIZATION_AUDIENCE);
         cleanUpApplications();
         cleanUpOrganizations();
+        cleanUpSSOIdP();
         cleanUpDetailMaps();
         closeRestClients();
     }
@@ -1190,6 +1194,9 @@ public class UserSharingFailureTest extends UserSharingBaseTest {
         orgMgtRestClient = new OrgMgtRestClient(context, tenantInfo, serverURL,
                 new JSONObject(readResource(AUTHORIZED_APIS_JSON)));
         httpClient = HttpClientBuilder.create().build();
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
     }
 
     private void setupOrganizations() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v1/UserSharingSuccessTest.java
@@ -19,6 +19,8 @@
 package org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1;
 
 import io.restassured.response.Response;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.http.HttpStatus;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.JSONObject;
@@ -28,6 +30,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.RoleWithAudience;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBody;
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
@@ -136,6 +139,7 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
         cleanUpRoles(APPLICATION_AUDIENCE, ORGANIZATION_AUDIENCE);
         cleanUpApplications();
         cleanUpOrganizations();
+        cleanUpSSOIdP();
         cleanUpDetailMaps();
         closeRestClients();
     }
@@ -705,6 +709,10 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
         orgMgtRestClient = new OrgMgtRestClient(context, tenantInfo, serverURL,
                 new JSONObject(readResource(AUTHORIZED_APIS_JSON)));
         httpClient = HttpClientBuilder.create().build();
+
+        ConfigurationContext configContext =
+                ConfigurationContextFactory.createConfigurationContextFromFileSystem(null, null);
+        idpMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL, configContext);
     }
 
     private void setupOrganizations() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/UserProfileAdminTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/UserProfileAdminTestCase.java
@@ -41,6 +41,7 @@ import java.nio.file.Paths;
 
 public class UserProfileAdminTestCase extends ISIntegrationTest {
 
+    public static final String IDP_NAME = "idp1";
     private UserProfileMgtServiceClient userProfileMgtClient;
     private UserManagementClient userMgtClient;
     private AuthenticatorClient logManger;
@@ -78,6 +79,7 @@ public class UserProfileAdminTestCase extends ISIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
         userMgtClient.deleteUser(userId1);
+        idpMgtClient.deleteIdP(IDP_NAME);
         logManger = null;
         log.info("Replacing identity.xml with default configurations");
 
@@ -180,7 +182,6 @@ public class UserProfileAdminTestCase extends ISIntegrationTest {
 
         String username = "testUser2";
         String password = "passWord1@";
-        String idpName = "idp1";
 
         // create a user
         userMgtClient.addUser(username, password, new String[]{"admin"}, "default");
@@ -190,13 +191,14 @@ public class UserProfileAdminTestCase extends ISIntegrationTest {
         userProfileMgtClient = new UserProfileMgtServiceClient(backendURL, username, password);
 
         IdentityProvider idp = new IdentityProvider();
-        idp.setIdentityProviderName(idpName);
+
+        idp.setIdentityProviderName(IDP_NAME);
         idpMgtClient.addIdP(idp);
-        Assert.assertNotNull(idpMgtClient.getIdPByName(idpName));
+        Assert.assertNotNull(idpMgtClient.getIdPByName(IDP_NAME));
 
         // create a federated user account association
-        userProfileMgtClient.addFedIdpAccountAssociation(idpName, "dummy_idp_account_1");
-        userProfileMgtClient.addFedIdpAccountAssociation(idpName, "dummy_idp_account_2");
+        userProfileMgtClient.addFedIdpAccountAssociation(IDP_NAME, "dummy_idp_account_1");
+        userProfileMgtClient.addFedIdpAccountAssociation(IDP_NAME, "dummy_idp_account_2");
 
         AssociatedAccountDTO[] associatedFedUserAccountIds = userProfileMgtClient.getAssociatedFedUserAccountIds();
         Assert.assertNotNull(associatedFedUserAccountIds);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/oauth2_service_resource_owner.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/oauth2_service_resource_owner.toml
@@ -1,0 +1,39 @@
+[server]
+hostname = "localhost"
+node_ip = "127.0.0.1"
+base_path = "https://$ref{server.hostname}:${carbon.management.port}"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[user_store]
+type = "database_unique_id"
+
+[database.identity_db]
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
+
+[database.shared_db]
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
+
+[keystore.primary]
+file_name = "wso2carbon.p12"
+password = "wso2carbon"
+
+[truststore]
+file_name = "client-truststore.p12"
+password = "wso2carbon"
+type = "PKCS12"
+
+[authentication.authenticator.basic.parameters]
+showAuthFailureReason = true
+
+[oauth.grant_type.password]
+show_auth_failure_reason = true

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/disable-password-expiry.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/disable-password-expiry.json
@@ -1,0 +1,9 @@
+{
+  "operation": "UPDATE",
+  "properties": [
+    {
+      "name":"passwordExpiry.enablePasswordExpiry",
+      "value":"false"
+    }
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -96,7 +96,6 @@
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ApplicationAccessTokenIntrospectionTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.SystemScopePermissionValidationTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>
-            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCSubAttributeTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCSSOConsentTestCase"/>
@@ -432,6 +431,7 @@
     </test>
     <test name="is-tests-with-individual-configuration-changes" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>
             <class name="org.wso2.identity.integration.test.application.mgt.ServiceProviderUserRoleValidationTestCase"/>
             <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCFileBasedSkipLoginConsentTestCase"/>


### PR DESCRIPTION
### Purpose
- As part of [1], we have made changes to use the below configuration to show the authentication failure reason for password grant.
```
[authentication.authenticator.basic.parameters]
showAuthFailureReason = true
```
- As of now the integration tests depends on this config being enabled to pass.
- This PR fixes this issue by moving `OAuth2ServiceResourceOwnerTestCase` to tests with individual configuration changes and apply `showAuthFailureReason = true` config only for that test.

### Related Issue
- https://github.com/wso2/product-is/issues/23476

[1] https://github.com/wso2/product-is/issues/20464