### PR TITLE
Add integration test for efficient filtering multi valued attributes

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/LocalClaimRes.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/LocalClaimRes.java
@@ -40,6 +40,7 @@ public class LocalClaimRes {
     private String regEx = null;
     private Boolean required = null;
     private Boolean supportedByDefault = null;
+    private Boolean multiValued = null;
 
     public enum UniquenessScopeEnum {
         NONE, WITHIN_USERSTORE, ACROSS_USERSTORES,
@@ -207,6 +208,18 @@ public class LocalClaimRes {
     public void setSupportedByDefault(Boolean supportedByDefault) {
 
         this.supportedByDefault = supportedByDefault;
+    }
+
+    /**
+     * Specifies if the claim can hold multiple values.
+     **/
+    @ApiModelProperty(value = "Specifies if the claim can hold multiple values.")
+    @JsonProperty("multiValued")
+    public Boolean getMultiValued() {
+        return multiValued;
+    }
+    public void setMultiValued(Boolean multiValued) {
+        this.multiValued = multiValued;
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/LocalClaimRes.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/LocalClaimRes.java
@@ -218,6 +218,7 @@ public class LocalClaimRes {
     public Boolean getMultiValued() {
         return multiValued;
     }
+
     public void setMultiValued(Boolean multiValued) {
         this.multiValued = multiValued;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2BaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2BaseTestCase.java
@@ -42,6 +42,7 @@ public class SCIM2BaseTestCase extends ISIntegrationTest {
     public static final String GIVEN_NAME_ATTRIBUTE = "givenName";
     public static final String EMAIL_TYPE_WORK_ATTRIBUTE = "work";
     public static final String EMAIL_TYPE_HOME_ATTRIBUTE = "home";
+    public static final String EMAIL_ADDRESSES_ATTRIBUTE = "emailAddresses";
     public static final String ID_ATTRIBUTE = "id";
     public static final String PASSWORD_ATTRIBUTE = "password";
     public static final String EMAILS_ATTRIBUTE = "emails";
@@ -59,6 +60,7 @@ public class SCIM2BaseTestCase extends ISIntegrationTest {
     public static final String LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
     public static final String RESOURCE_TYPE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ResourceType";
     public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+    public static final String USER_SYSTEM_SCHEMA_ATTRIBUTE ="urn:scim:wso2:schema";
 
     private ServerConfigurationManager serverConfigurationManager;
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2BaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2BaseTestCase.java
@@ -60,7 +60,7 @@ public class SCIM2BaseTestCase extends ISIntegrationTest {
     public static final String LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
     public static final String RESOURCE_TYPE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ResourceType";
     public static final String ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
-    public static final String USER_SYSTEM_SCHEMA_ATTRIBUTE ="urn:scim:wso2:schema";
+    public static final String USER_SYSTEM_SCHEMA = "urn:scim:wso2:schema";
 
     private ServerConfigurationManager serverConfigurationManager;
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2UserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2UserTestCase.java
@@ -25,7 +25,6 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -41,7 +40,6 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.identity.integration.common.clients.claim.metadata.mgt.ClaimMetadataManagementServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
@@ -71,7 +69,7 @@ import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.SCIM_RE
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.SERVER_URL;
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.TYPE_PARAM;
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.USER_NAME_ATTRIBUTE;
-import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.USER_SYSTEM_SCHEMA_ATTRIBUTE;
+import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.USER_SYSTEM_SCHEMA;
 import static org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase.VALUE_PARAM;
 
 public class SCIM2UserTestCase extends ISIntegrationTest {
@@ -168,7 +166,7 @@ public class SCIM2UserTestCase extends ISIntegrationTest {
         emailAddresses.add(EMAIL_TYPE_HOME_CLAIM_VALUE);
         JSONObject emailAddressesObject = new JSONObject();
         emailAddressesObject.put(EMAIL_ADDRESSES_ATTRIBUTE, emailAddresses);
-        rootObject.put(USER_SYSTEM_SCHEMA_ATTRIBUTE, emailAddressesObject);
+        rootObject.put(USER_SYSTEM_SCHEMA, emailAddressesObject);
 
         StringEntity entity = new StringEntity(rootObject.toString());
         request.setEntity(entity);
@@ -339,7 +337,7 @@ public class SCIM2UserTestCase extends ISIntegrationTest {
     private void validateFilteredUserByEmailAddresses(String attributeName, String operator, String attributeValue)
             throws IOException {
 
-        String userResourcePath = getPath() + "?filter=" + USER_SYSTEM_SCHEMA_ATTRIBUTE + ":" + attributeName + operator
+        String userResourcePath = getPath() + "?filter=" + USER_SYSTEM_SCHEMA + ":" + attributeName + operator
                 + attributeValue;
         HttpGet request = new HttpGet(userResourcePath);
         request.addHeader(HttpHeaders.AUTHORIZATION, getAuthzHeader());
@@ -352,8 +350,9 @@ public class SCIM2UserTestCase extends ISIntegrationTest {
         Object responseObj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
         EntityUtils.consume(response.getEntity());
 
-        JSONArray emailsArray = ((JSONArray)((JSONObject)((JSONObject) ((JSONArray) ((JSONObject) responseObj)
-                .get("Resources")).get(0)).get(USER_SYSTEM_SCHEMA_ATTRIBUTE)).get(attributeName));
+        JSONObject userResources = ((JSONObject) ((JSONArray) ((JSONObject) responseObj)
+                .get("Resources")).get(0));
+        JSONArray emailsArray = (JSONArray) ((JSONObject) userResources.get(USER_SYSTEM_SCHEMA)).get(attributeName);
 
         for (Object email : emailsArray) {
             if (email.equals(attributeValue)) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2UserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2UserTestCase.java
@@ -354,7 +354,7 @@ public class SCIM2UserTestCase extends ISIntegrationTest {
                 .get("Resources")).get(0));
         JSONArray emailsArray = (JSONArray) ((JSONObject) userResources.get(USER_SYSTEM_SCHEMA)).get(attributeName);
 
-        for (Object email : emailsArray) {
+        for (Object email: emailsArray) {
             if (email.equals(attributeValue)) {
                 return;
             }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2UserTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/SCIM2UserTestCase.java
@@ -309,7 +309,7 @@ public class SCIM2UserTestCase extends ISIntegrationTest {
         validateFilteredUser(USER_NAME_ATTRIBUTE, CONTAINS, USERNAME.substring(2, 4));
         validateFilteredUser(USER_NAME_ATTRIBUTE, STARTWITH, USERNAME.substring(0, 3));
         validateFilteredUser(USER_NAME_ATTRIBUTE, ENDWITH, USERNAME.substring(4, USERNAME.length()));
-        validateFilteredUserByEmailAddresses(EMAIL_ADDRESSES_ATTRIBUTE, CONTAINS, EMAIL_TYPE_WORK_CLAIM_VALUE);
+        validateFilteredUserByEmailAddresses(EMAIL_ADDRESSES_ATTRIBUTE, CONTAINS, EMAIL_TYPE_HOME_CLAIM_VALUE);
     }
 
     private void validateFilteredUser(String attributeName, String operator, String attributeValue) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -2574,7 +2574,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.95-SNAPSHOT</identity.server.api.version>
+        <identity.server.api.version>1.3.94</identity.server.api.version>
         <identity.user.api.version>1.3.61</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2574,7 +2574,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.94</identity.server.api.version>
+        <identity.server.api.version>1.3.95-SNAPSHOT</identity.server.api.version>
         <identity.user.api.version>1.3.61</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
This PR should be updated once the required backend changes are merged.
The test case should be update to a `eq` operator instead of `co` operator once all the backend PRs are merged.


### Related Issues
- https://github.com/wso2/product-is/issues/23547