### PR TITLE
Refactor UserMe Integration Tests to Use REST APIs

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
@@ -41,7 +41,6 @@ import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServi
 import org.wso2.identity.integration.common.clients.UserProfileMgtServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
-import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.util.Utils;
 
 import java.io.BufferedInputStream;
@@ -94,7 +93,6 @@ public class RESTTestBase extends ISIntegrationTest {
     protected AutomationContext context;
 
     protected RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
-    protected SCIM2RestClient scim2RestClient;
     protected UserProfileMgtServiceClient userProfileMgtServiceClient;
     protected IdentityProviderMgtServiceClient identityProviderMgtServiceClient;
     protected String swaggerDefinition;
@@ -126,7 +124,6 @@ public class RESTTestBase extends ISIntegrationTest {
                 .build();
         validationFilter = new OpenApiValidationFilter(openAPIValidator);
         remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
-        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
         userProfileMgtServiceClient = new UserProfileMgtServiceClient(backendURL, sessionCookie);
         identityProviderMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/common/RESTTestBase.java
@@ -41,6 +41,7 @@ import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServi
 import org.wso2.identity.integration.common.clients.UserProfileMgtServiceClient;
 import org.wso2.identity.integration.common.clients.usermgt.remote.RemoteUserStoreManagerServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.util.Utils;
 
 import java.io.BufferedInputStream;
@@ -93,6 +94,7 @@ public class RESTTestBase extends ISIntegrationTest {
     protected AutomationContext context;
 
     protected RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
+    protected SCIM2RestClient scim2RestClient;
     protected UserProfileMgtServiceClient userProfileMgtServiceClient;
     protected IdentityProviderMgtServiceClient identityProviderMgtServiceClient;
     protected String swaggerDefinition;
@@ -124,6 +126,7 @@ public class RESTTestBase extends ISIntegrationTest {
                 .build();
         validationFilter = new OpenApiValidationFilter(openAPIValidator);
         remoteUSMServiceClient = new RemoteUserStoreManagerServiceClient(backendURL, sessionCookie);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
         userProfileMgtServiceClient = new UserProfileMgtServiceClient(backendURL, sessionCookie);
         identityProviderMgtServiceClient = new IdentityProviderMgtServiceClient(sessionCookie, backendURL);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeNegativeTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeNegativeTestBase.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
-import org.wso2.identity.integration.test.utils.UserUtil;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
 import java.io.IOException;
 import java.rmi.RemoteException;
@@ -48,6 +48,8 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
     private static final String TEST_USER_1 = "TestUser01";
     private static final String TEST_USER_PW = "Test@123";
     private TestUserMode userMode;
+    private SCIM2RestClient scim2RestClient;
+    private String testUserId;
 
     @Factory(dataProvider = "restAPIUserConfigProvider")
     public UserMeNegativeTestBase(TestUserMode userMode) throws Exception {
@@ -62,11 +64,12 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException, RemoteException {
 
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");
 
         try {
-            createUser(TEST_USER_1, TEST_USER_PW);
+            testUserId = createUser(TEST_USER_1, TEST_USER_PW);
         } catch (Exception e) {
             log.error("Error while creating the user :" + TEST_USER_1, e);
         }
@@ -78,8 +81,9 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
         super.conclude();
 
         try {
-            deleteUser(TEST_USER_1);
+            deleteUser(TEST_USER_1, testUserId);
             remoteUSMServiceClient = null;
+            scim2RestClient.closeHttpClient();
         } catch (Exception e) {
             log.error("Error while deleting the user :" + TEST_USER_1, e);
         }
@@ -144,19 +148,18 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
                 .log().ifValidationFails();
     }
 
-    protected void createUser(String username, String password) throws Exception {
+    protected String createUser(String username, String password) throws Exception {
 
         log.info("Creating User " + username);
         UserObject userObject = new UserObject();
         userObject.setUserName(username);
         userObject.setPassword(password);
-        scim2RestClient.createUser(userObject);
+        return scim2RestClient.createUser(userObject);
     }
 
-    protected void deleteUser(String username) throws Exception {
+    protected void deleteUser(String username, String testUserId) throws Exception {
 
         log.info("Deleting User " + username);
-        String userId = UserUtil.getUserId(username, tenantInfo);
-        scim2RestClient.deleteUser(userId);
+        scim2RestClient.deleteUser(testUserId);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeNegativeTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeNegativeTestBase.java
@@ -29,6 +29,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.utils.UserUtil;
 
 import java.io.IOException;
 import java.rmi.RemoteException;
@@ -64,7 +66,7 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
         initUrls("me");
 
         try {
-            createUser(TEST_USER_1, TEST_USER_PW, null);
+            createUser(TEST_USER_1, TEST_USER_PW);
         } catch (Exception e) {
             log.error("Error while creating the user :" + TEST_USER_1, e);
         }
@@ -142,15 +144,19 @@ public class UserMeNegativeTestBase extends UserAssociationTestBase {
                 .log().ifValidationFails();
     }
 
-    protected void createUser(String username, String password, String[] roles) throws Exception {
+    protected void createUser(String username, String password) throws Exception {
 
         log.info("Creating User " + username);
-        remoteUSMServiceClient.addUser(username, password, roles, null, null, true);
+        UserObject userObject = new UserObject();
+        userObject.setUserName(username);
+        userObject.setPassword(password);
+        scim2RestClient.createUser(userObject);
     }
 
     protected void deleteUser(String username) throws Exception {
 
         log.info("Deleting User " + username);
-        remoteUSMServiceClient.deleteUser(username);
+        String userId = UserUtil.getUserId(username, tenantInfo);
+        scim2RestClient.deleteUser(userId);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeSuccessTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/association/v1/UserMeSuccessTestBase.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpStatus;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -35,7 +34,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.IdentityProviderPOSTRequest;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.IdpMgtRestClient;
-import org.wso2.identity.integration.test.utils.UserUtil;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -61,6 +60,11 @@ public class UserMeSuccessTestBase extends UserAssociationTestBase {
     private String federatedAssociationIdHolder;
     private String associatedUserIdHolder;
     private TestUserMode userMode;
+    private SCIM2RestClient scim2RestClient;
+    private IdpMgtRestClient idpMgtRestClient;
+    private String testUserId1;
+    private String testUserId2;
+    private String idpId;
 
     @Factory(dataProvider = "restAPIUserConfigProvider")
     public UserMeSuccessTestBase(TestUserMode userMode) throws Exception {
@@ -75,14 +79,16 @@ public class UserMeSuccessTestBase extends UserAssociationTestBase {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException, RemoteException {
 
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        idpMgtRestClient = new IdpMgtRestClient(serverURL, tenantInfo);
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         initUrls("me");
 
         try {
-            createUser(TEST_USER_1, TEST_USER_PW);
-            createUser(TEST_USER_2, TEST_USER_PW);
+            testUserId1 = createUser(TEST_USER_1, TEST_USER_PW);
+            testUserId2 = createUser(TEST_USER_2, TEST_USER_PW);
 
-            createIdP(EXTERNAL_IDP_NAME);
+            idpId = createIdP(EXTERNAL_IDP_NAME);
             createMyFederatedAssociation(EXTERNAL_IDP_NAME, EXTERNAL_USER_ID_1);
             createMyFederatedAssociation(EXTERNAL_IDP_NAME, EXTERNAL_USER_ID_2);
         } catch (Exception e) {
@@ -96,15 +102,17 @@ public class UserMeSuccessTestBase extends UserAssociationTestBase {
         super.conclude();
 
         try {
-            deleteUser(TEST_USER_1);
-            deleteUser(TEST_USER_2);
+            deleteUser(TEST_USER_1, testUserId1);
+            deleteUser(TEST_USER_2, testUserId2);
 
-            deleteIdP(EXTERNAL_IDP_NAME);
+            deleteIdP(idpId);
 
             // Clear up any possible associations that may have created while running tests. The following delete
             // operations are expected to silently ignore any non-existing federated associations.
             deleteFederatedAssociation(EXTERNAL_IDP_NAME, EXTERNAL_USER_ID_1);
             deleteFederatedAssociation(EXTERNAL_IDP_NAME, EXTERNAL_USER_ID_2);
+            scim2RestClient.closeHttpClient();
+            idpMgtRestClient.closeHttpClient();
         } catch (Exception e) {
             log.error("Error while deleting the users :" + TEST_USER_1 + ", and " + TEST_USER_2, e);
         }
@@ -220,13 +228,13 @@ public class UserMeSuccessTestBase extends UserAssociationTestBase {
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 
-    protected void createUser(String username, String password) throws Exception {
+    protected String createUser(String username, String password) throws Exception {
 
         log.info("Creating User " + username);
         UserObject userObject = new UserObject();
         userObject.setUserName(username);
         userObject.setPassword(password);
-        scim2RestClient.createUser(userObject);
+        return scim2RestClient.createUser(userObject);
     }
 
     protected void createMyFederatedAssociation(String idpName, String associatedUserId) throws Exception {
@@ -236,11 +244,10 @@ public class UserMeSuccessTestBase extends UserAssociationTestBase {
         userProfileMgtServiceClient.addFedIdpAccountAssociation(idpName, associatedUserId);
     }
 
-    protected void deleteUser(String username) throws Exception {
+    protected void deleteUser(String username, String testUserId) throws Exception {
 
         log.info("Deleting User " + username);
-        String userId = UserUtil.getUserId(username, tenantInfo);
-        scim2RestClient.deleteUser(userId);
+        scim2RestClient.deleteUser(testUserId);
     }
 
     protected void deleteFederatedAssociation(String idpName, String associatedUserId) throws Exception {
@@ -264,25 +271,15 @@ public class UserMeSuccessTestBase extends UserAssociationTestBase {
         return Base64.getUrlEncoder().encodeToString(username.getBytes(StandardCharsets.UTF_8));
     }
 
-    private void createIdP(String idpName) {
+    private String createIdP(String idpName) throws Exception {
 
-        try {
-            IdpMgtRestClient idpMgtRestClient = new IdpMgtRestClient(serverURL, tenantInfo);
-            IdentityProviderPOSTRequest idpPostRequest = new IdentityProviderPOSTRequest()
-                    .name(idpName);
-            idpMgtRestClient.createIdentityProvider(idpPostRequest);
-        } catch (Exception e) {
-            Assert.fail("Error while trying to create Identity Provider", e);
-        }
+        IdentityProviderPOSTRequest idpPostRequest = new IdentityProviderPOSTRequest()
+                .name(idpName);
+        return idpMgtRestClient.createIdentityProvider(idpPostRequest);
     }
 
-    private void deleteIdP(String idpName) {
+    private void deleteIdP(String idpId) throws Exception {
 
-        try {
-            IdpMgtRestClient idpMgtRestClient = new IdpMgtRestClient(serverURL, tenantInfo);
-            idpMgtRestClient.deleteIdp(idpName);
-        } catch (Exception e) {
-            Assert.fail("Error while trying to delete Identity Provider", e);
-        }
+        idpMgtRestClient.deleteIdp(idpId);
     }
 }


### PR DESCRIPTION
## Purpose
This PR refactors the integration tests to standardize the usage of REST clients for user and identity provider management. It replaces the legacy SOAP-based clients with REST-based counterparts to enhance consistency, reliability, and maintainability across the tests.

## Implementation
This PR includes changes to the integration tests to replace the usage of `RemoteUserStoreManagerServiceClient` with `SCIM2RestClient` for user management operations, and to replace the usage of `IdentityProviderMgtServiceClient` with `IdpMgtRestClient` for identity provider management operations. These changes aim to standardize the REST client usage across the tests.

- Refactored `createUser` and `deleteUser` methods to use `SCIM2RestClient` instead of `RemoteUserStoreManagerServiceClient` in multiple test files for better user management.
- Updated `createIdP` and `deleteIdP` methods to use `IdpMgtRestClient` instead of `IdentityProviderMgtServiceClient` for improved Identity Provider management.

