### PR TITLE
Integration tests for SMS OTP-based password reset failures triggered by pre-password update action via the V2 Recovery API

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/ConfirmModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/ConfirmModel.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.recovery.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+public class ConfirmModel {
+
+    private String confirmationCode;
+    private String otp;
+
+    public ConfirmModel confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+
+    @ApiModelProperty(example = "afb09659-ab01-4913-b2dc-0ad7fda8a194", required = true)
+    @JsonProperty("confirmationCode")
+    @NotNull(message = "Confirmation code cannot be blank.")
+    public String getConfirmationCode() {
+
+        return confirmationCode;
+    }
+
+    public void setConfirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+    }
+
+    public ConfirmModel otp(String otp) {
+
+        this.otp = otp;
+        return this;
+    }
+
+    @ApiModelProperty(example = "yb3YRU", required = true)
+    @JsonProperty("otp")
+    @NotNull(message = "OTP cannot be blank.")
+    public String getOtp() {
+
+        return otp;
+    }
+
+    public void setOtp(String otp) {
+
+        this.otp = otp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfirmModel that = (ConfirmModel) o;
+        return Objects.equals(confirmationCode, that.confirmationCode) &&
+                Objects.equals(otp, that.otp);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(confirmationCode, otp);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConfirmModel {\n");
+        sb.append("    confirmationCode: ").append(toIndentedString(confirmationCode)).append("\n");
+        sb.append("    otp: ").append(toIndentedString(otp)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/InitModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/InitModel.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.recovery.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+public class InitModel {
+
+    private List<UserClaim> claims;
+
+    public InitModel claims(List<UserClaim> claims) {
+
+        this.claims = claims;
+        return this;
+    }
+
+    @ApiModelProperty(required = true, value = "User claims to identify the user")
+    @JsonProperty("claims")
+    @Valid
+    @NotNull(message = "Property claims cannot be null.")
+    public List<UserClaim> getClaims() {
+
+        return claims;
+    }
+
+    public void setClaims(List<UserClaim> claims) {
+
+        this.claims = claims;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InitModel that = (InitModel) o;
+        return Objects.equals(claims, that.claims);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(claims);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InitModel {\n");
+        sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/InitModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/InitModel.java
@@ -81,6 +81,6 @@ public class InitModel {
         if (o == null) {
             return "null";
         }
-        return o.toString().replace("\n", "\n");
+        return o.toString().replace("\n", "\n    ");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/RecoverModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/RecoverModel.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.recovery.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+public class RecoverModel {
+
+    private String recoveryCode;
+    private String channelId;
+
+    public RecoverModel recoveryCode(String recoveryCode) {
+
+        this.recoveryCode = recoveryCode;
+        return this;
+    }
+
+    @ApiModelProperty(example = "9588245c-5d51-4cfa-b8d9-f031f03294af", required = true)
+    @JsonProperty("recoveryCode")
+    @NotNull(message = "Recovery code cannot be blank.")
+    public String getRecoveryCode() {
+
+        return recoveryCode;
+    }
+
+    public void setRecoveryCode(String recoveryCode) {
+
+        this.recoveryCode = recoveryCode;
+    }
+
+    public RecoverModel channelId(String channelId) {
+
+        this.channelId = channelId;
+        return this;
+    }
+
+    @ApiModelProperty(example = "2", required = true)
+    @JsonProperty("channelId")
+    @NotNull(message = "Channel ID cannot be blank.")
+    public String getChannelId() {
+
+        return channelId;
+    }
+
+    public void setChannelId(String channelId) {
+
+        this.channelId = channelId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RecoverModel that = (RecoverModel) o;
+        return Objects.equals(recoveryCode, that.recoveryCode) &&
+                Objects.equals(channelId, that.channelId);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(recoveryCode, channelId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RecoverModel {\n");
+        sb.append("    recoveryCode: ").append(toIndentedString(recoveryCode)).append("\n");
+        sb.append("    channelId: ").append(toIndentedString(channelId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/ResetModel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/ResetModel.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.identity.integration.test.recovery.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+public class ResetModel {
+
+    private String resetCode;
+    private String password;
+    private String flowConfirmationCode;
+
+    public ResetModel resetCode(String resetCode) {
+
+        this.resetCode = resetCode;
+        return this;
+    }
+
+    @ApiModelProperty(example = "yb3YRU", required = true)
+    @JsonProperty("resetCode")
+    @NotNull(message = "Reset code cannot be blank.")
+    public String getResetCode() {
+
+        return resetCode;
+    }
+
+    public void setResetCode(String resetCode) {
+
+        this.resetCode = resetCode;
+    }
+
+    public ResetModel password(String password) {
+
+        this.password = password;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Userpass@123", required = true)
+    @JsonProperty("password")
+    @NotNull(message = "Password cannot be blank.")
+    public String getPassword() {
+
+        return password;
+    }
+
+    public void setPassword(String password) {
+
+        this.password = password;
+    }
+
+    public ResetModel flowConfirmationCode(String flowConfirmationCode) {
+
+        this.flowConfirmationCode = flowConfirmationCode;
+        return this;
+    }
+
+    @ApiModelProperty(example = "afb09659-ab01-4913-b2dc-0ad7fda8a194", required = true)
+    @JsonProperty("flowConfirmationCode")
+    @NotNull(message = "Flow confirmation code cannot be blank.")
+    public String getFlowConfirmationCode() {
+
+        return flowConfirmationCode;
+    }
+
+    public void setFlowConfirmationCode(String flowConfirmationCode) {
+
+        this.flowConfirmationCode = flowConfirmationCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResetModel that = (ResetModel) o;
+        return Objects.equals(resetCode, that.resetCode) &&
+                Objects.equals(password, that.password) &&
+                Objects.equals(flowConfirmationCode, that.flowConfirmationCode);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(resetCode, password, flowConfirmationCode);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ResetModel {\n");
+        sb.append("    resetCode: ").append(toIndentedString(resetCode)).append("\n");
+        sb.append("    password: ").append(toIndentedString(password)).append("\n");
+        sb.append("    flowConfirmationCode: ").append(toIndentedString(flowConfirmationCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/UserClaim.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/UserClaim.java
@@ -99,6 +99,6 @@ public class UserClaim {
         if (o == null) {
             return "null";
         }
-        return o.toString().replace("\n", "\n");
+        return o.toString().replace("\n", "\n    ");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/UserClaim.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/recovery/model/v2/UserClaim.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.recovery.model.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+public class UserClaim {
+
+    private String uri;
+    private String value;
+
+    public UserClaim uri(String uri) {
+
+        this.uri = uri;
+        return this;
+    }
+
+    @ApiModelProperty(example = "http://wso2.org/claims/username", required = true)
+    @JsonProperty("uri")
+    @NotNull(message = "Claim URI cannot be blank.")
+    public String getUri() {
+
+        return uri;
+    }
+
+    public void setUri(String uri) {
+
+        this.uri = uri;
+    }
+
+    public UserClaim value(String value) {
+
+        this.value = value;
+        return this;
+    }
+
+    @ApiModelProperty(example = "user@wso2.com", required = true)
+    @JsonProperty("value")
+    @NotNull(message = "Claim value cannot be blank.")
+    public String getValue() {
+
+        return value;
+    }
+
+    public void setValue(String value) {
+
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserClaim that = (UserClaim) o;
+        return Objects.equals(uri, that.uri) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(uri, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserClaim {\n");
+        sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/PasswordRecoveryV2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/PasswordRecoveryV2RestClient.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.restclients;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.identity.integration.test.recovery.model.v2.ConfirmModel;
+import org.wso2.identity.integration.test.recovery.model.v2.InitModel;
+import org.wso2.identity.integration.test.recovery.model.v2.RecoverModel;
+import org.wso2.identity.integration.test.recovery.model.v2.ResetModel;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.Error;
+
+import java.io.IOException;
+
+/**
+ * Client class for interacting with the WSO2 Identity Server's
+ * Password Recovery V2 REST API endpoints.
+ * This client is responsible for initiating, handling, and confirming
+ * password recovery flows using the API exposed under `/api/users/v2/recovery/password`.
+ */
+public class PasswordRecoveryV2RestClient extends RestBaseClient {
+
+    private static final String V2_PASSWORD_RECOVERY_PATH = "api/users/v2/recovery/password";
+    private static final String CHANNEL_INFO = "channelInfo";
+    private static final String FLOW_CONFIRMATION_CODE = "flowConfirmationCode";
+
+    private final String username;
+    private final String password;
+    private final String v2PasswordRecoveryBasePath;
+
+    private final ObjectMapper mapper;
+
+    public PasswordRecoveryV2RestClient(String serverUrl, Tenant tenantInfo) {
+
+        String tenantDomain = tenantInfo.getContextUser().getUserDomain();
+        this.username = tenantInfo.getContextUser().getUserName();
+        this.password = tenantInfo.getContextUser().getPassword();
+        v2PasswordRecoveryBasePath = generateV2PasswordRecoveryBasePath(serverUrl, tenantDomain);
+        mapper = new ObjectMapper();
+    }
+
+    /**
+     * Initiates the password recovery flow by posting the given user claims.
+     *
+     * @param initModel   The initialization request body containing user claims.
+     * @param channelType The preferred channel type (e.g., "SMS").
+     * @return RecoverModel containing recoveryCode and matching channelId.
+     * @throws IOException If an error occurs during HTTP communication or JSON parsing.
+     */
+    public RecoverModel init(InitModel initModel, String channelType) throws IOException {
+
+        String endPointUrl = v2PasswordRecoveryBasePath + "/init";
+        String jsonRequestBody = toJSONString(initModel);
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequestBody, getHeaders())) {
+
+            int status = response.getStatusLine().getStatusCode();
+            if (status != HttpStatus.SC_OK) {
+                throw new IOException("Unexpected response status for password recovery initialization: " + status);
+            }
+
+            JsonNode root = mapper.readTree(response.getEntity().getContent());
+            if (root == null || !root.isArray() || root.isEmpty()) {
+                throw new IllegalStateException("Recovery API returned an empty response.");
+            }
+
+            JsonNode firstMode = root.get(0);
+            JsonNode channelInfo = firstMode.get(CHANNEL_INFO);
+            if (channelInfo == null || !channelInfo.has("recoveryCode") || !channelInfo.has("channels")) {
+                throw new IllegalStateException("Response missing expected channel information.");
+            }
+
+            String recoveryCode = channelInfo.get("recoveryCode").asText();
+            for (JsonNode channel : channelInfo.get("channels")) {
+                if (channelType.equalsIgnoreCase(channel.get("type").asText())) {
+                    String channelId = channel.get("id").asText();
+                    return new RecoverModel()
+                            .channelId(channelId)
+                            .recoveryCode(recoveryCode);
+                }
+            }
+
+            throw new IllegalStateException("No channel of type " + channelType + " found in the response.");
+        }
+    }
+
+    /**
+     * Calls the password recovery endpoint using the provided recovery code and channel ID,
+     * and returns the flowConfirmationCode if available.
+     *
+     * @param recoverModel Model containing recoveryCode and channelId.
+     * @return The flowConfirmationCode returned by the server, or null if not present.
+     * @throws IOException If the request fails or response parsing fails.
+     */
+    public String recover(RecoverModel recoverModel) throws IOException {
+
+        String jsonRequestBody = toJSONString(recoverModel);
+        String endPointUrl = v2PasswordRecoveryBasePath + "/recover";
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequestBody, getHeaders())) {
+
+            int status = response.getStatusLine().getStatusCode();
+            if (status != HttpStatus.SC_OK && status != HttpStatus.SC_ACCEPTED) {
+                throw new IOException("Unexpected response status for password recover call: " + status);
+            }
+
+            JsonNode root = mapper.readTree(response.getEntity().getContent());
+            if (root != null && root.has(FLOW_CONFIRMATION_CODE)) {
+                return root.get(FLOW_CONFIRMATION_CODE).asText();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Confirms the password recovery using the confirmation code or OTP,
+     * and returns the resetCode if the confirmation is successful.
+     *
+     * @param confirmModel Model containing confirmationCode and optional OTP.
+     * @return The resetCode returned by the server, or null if not present.
+     * @throws IOException If the request fails or the response is invalid.
+     */
+    public String confirm(ConfirmModel confirmModel) throws IOException {
+
+        String jsonRequestBody = toJSONString(confirmModel);
+        String endPointUrl = v2PasswordRecoveryBasePath + "/confirm";
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequestBody, getHeaders())) {
+
+            int status = response.getStatusLine().getStatusCode();
+            if (status != HttpStatus.SC_OK) {
+                throw new IOException("Unexpected response status for password confirm: " + status);
+            }
+
+            JsonNode root = mapper.readTree(response.getEntity().getContent());
+            if (root != null && root.has("resetCode")) {
+                return root.get("resetCode").asText();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Executes the password reset operation using the provided reset code and new password.
+     *
+     * @param resetModel The reset request containing resetCode, password, and flowConfirmationCode.
+     * @return An ErrorResponse if the reset fails, or null if successful.
+     * @throws IOException If the request fails or response can't be parsed.
+     */
+    public Error reset(ResetModel resetModel) throws IOException {
+
+        String jsonRequestBody = toJSONString(resetModel);
+        String endPointUrl = v2PasswordRecoveryBasePath + "/reset";
+
+        try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequestBody, getHeaders())) {
+
+            int status = response.getStatusLine().getStatusCode();
+            if (status == HttpStatus.SC_OK) {
+                return null;
+            } else {
+                return mapper.readValue(response.getEntity().getContent(), Error.class);
+            }
+        }
+    }
+
+    private String generateV2PasswordRecoveryBasePath(String serverUrl, String tenantDomain) {
+
+        if (tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return serverUrl + V2_PASSWORD_RECOVERY_PATH;
+        } else {
+            return serverUrl + TENANT_PATH + tenantDomain + PATH_SEPARATOR + V2_PASSWORD_RECOVERY_PATH;
+        }
+    }
+
+    private Header[] getHeaders() {
+
+        Header[] headerList = new Header[3];
+        headerList[0] = new BasicHeader(USER_AGENT_ATTRIBUTE, OAuth2Constant.USER_AGENT);
+        headerList[1] = new BasicHeader(AUTHORIZATION_ATTRIBUTE, BASIC_AUTHORIZATION_ATTRIBUTE +
+                Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
+        headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
+
+        return headerList;
+    }
+
+    public void closeHttpClient() throws IOException {
+
+        client.close();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/PasswordRecoveryV2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/PasswordRecoveryV2RestClient.java
@@ -89,8 +89,8 @@ public class PasswordRecoveryV2RestClient extends RestBaseClient {
                 throw new IllegalStateException("Recovery API returned an empty response.");
             }
 
-            JsonNode firstMode = root.get(0);
-            JsonNode channelInfo = firstMode.get(CHANNEL_INFO);
+            JsonNode firstNode = root.get(0);
+            JsonNode channelInfo = firstNode.get(CHANNEL_INFO);
             if (channelInfo == null || !channelInfo.has("recoveryCode") || !channelInfo.has("channels")) {
                 throw new IllegalStateException("Response missing expected channel information.");
             }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 import org.testng.Assert;
 import org.testng.annotations.*;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
@@ -351,7 +354,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         String htmlContent = EntityUtils.toString(postResponse.getEntity());
         switch (expectedPasswordUpdateResponse.getStatusCode()) {
             case HttpServletResponse.SC_BAD_REQUEST:
-                assertTrue(htmlContent.contains(expectedPasswordUpdateResponse.getErrorDetail()));
+                assertHtmlErrorDescription(htmlContent);
                 break;
             case HttpServletResponse.SC_INTERNAL_SERVER_ERROR:
                 assertTrue(htmlContent.contains(PASSWORD_RESET_ERROR));
@@ -359,5 +362,16 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             default:
                 Assert.fail("Unexpected response status code: " + postResponse.getStatusLine().getStatusCode());
         }
+        EntityUtils.consume(postResponse.getEntity());
+    }
+
+    private void assertHtmlErrorDescription(String htmlResponse) {
+
+        Document doc = Jsoup.parse(htmlResponse);
+        Elements header = doc.select("[data-testid=error-page-header]");
+        String actualText = header.text().trim();
+
+        assertEquals(actualText, expectedPasswordUpdateResponse.getErrorDetail(),
+                "Error description text does not match");
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSmsOtpFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSmsOtpFailureTestCase.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preupdatepassword;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.testng.annotations.*;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.base.MockSMSProvider;
+import org.wso2.identity.integration.test.recovery.model.v2.ConfirmModel;
+import org.wso2.identity.integration.test.recovery.model.v2.InitModel;
+import org.wso2.identity.integration.test.recovery.model.v2.RecoverModel;
+import org.wso2.identity.integration.test.recovery.model.v2.ResetModel;
+import org.wso2.identity.integration.test.recovery.model.v2.UserClaim;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.Properties;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.SMSSender;
+import org.wso2.identity.integration.test.restclients.NotificationSenderRestClient;
+import org.wso2.identity.integration.test.restclients.PasswordRecoveryV2RestClient;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ActionResponse;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ExpectedPasswordUpdateResponse;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.serviceextensions.model.*;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.Error;
+import org.wso2.identity.integration.test.rest.api.user.common.model.*;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.utils.FileUtils;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Integration test class for testing the pre update password action failure.
+ * This test case extends {@link PreUpdatePasswordActionBaseTestCase} and focuses on failed scenario
+ * on SMS OTP based password recovery/reset via V2 recovery API.
+ */
+public class PreUpdatePasswordActionSmsOtpFailureTestCase extends PreUpdatePasswordActionBaseTestCase {
+
+    private static final String MOBILE = "+941111111111";
+    private static final String SMS_SENDER_REQUEST_FORMAT = "{\"content\": {{body}}, \"to\": {{mobile}} }";
+
+    private final String tenantId;
+    private final TestUserMode userMode;
+
+    private SCIM2RestClient scim2RestClient;
+    private NotificationSenderRestClient notificationSenderRestClient;
+    private PasswordRecoveryV2RestClient passwordRecoveryV2RestClient;
+
+    private String actionId;
+    private String userId;
+    private UserObject userInfo;
+
+    private ServiceExtensionMockServer serviceExtensionMockServer;
+    private MockSMSProvider mockSMSProvider;
+
+    private final ActionResponse actionResponse;
+    private final ExpectedPasswordUpdateResponse expectedPasswordUpdateResponse;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public PreUpdatePasswordActionSmsOtpFailureTestCase(TestUserMode testUserMode, ActionResponse actionResponse,
+                                                        ExpectedPasswordUpdateResponse expectedPasswordUpdateResponse) {
+
+        this.userMode = testUserMode;
+        this.tenantId = testUserMode == TestUserMode.SUPER_TENANT_USER ? "-1234" : "1";
+        this.actionResponse = actionResponse;
+        this.expectedPasswordUpdateResponse = expectedPasswordUpdateResponse;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() throws IOException, URISyntaxException {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(HttpServletResponse.SC_OK,
+                        FileUtils.readFileInClassPathAsString("actions/response/failure-response.json")),
+                        new ExpectedPasswordUpdateResponse(HttpServletResponse.SC_BAD_REQUEST,
+                                "Some failure reason",
+                                "Some description")},
+                {TestUserMode.TENANT_USER, new ActionResponse(HttpServletResponse.SC_OK,
+                        FileUtils.readFileInClassPathAsString("actions/response/failure-response.json")),
+                        new ExpectedPasswordUpdateResponse(HttpServletResponse.SC_BAD_REQUEST,
+                                "Some failure reason",
+                                "Some description")}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        passwordRecoveryV2RestClient = new PasswordRecoveryV2RestClient(serverURL, tenantInfo);
+
+        userInfo = new UserObject()
+                .userName(TEST_USER1_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .addPhoneNumbers(new PhoneNumbers().type("mobile").value(MOBILE))
+                .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
+                .addEmail(new Email().value(TEST_USER_EMAIL));
+        userId = scim2RestClient.createUser(userInfo);
+
+        updatePasswordBasedRecoveryFeatureStatus(true);
+
+        actionId = createPreUpdatePasswordAction(ACTION_NAME, ACTION_DESCRIPTION);
+
+        mockSMSProvider = new MockSMSProvider();
+        mockSMSProvider.start();
+        String backendServicesUrl = backendURL.replace("services/", "");
+        notificationSenderRestClient = new NotificationSenderRestClient(backendServicesUrl, tenantInfo);
+        SMSSender smsSender = initSMSSender();
+        notificationSenderRestClient.createSMSProvider(smsSender);
+
+        serviceExtensionMockServer = new ServiceExtensionMockServer();
+        serviceExtensionMockServer.startServer();
+        serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
+                        MOCK_SERVER_AUTH_BASIC_PASSWORD),
+                actionResponse.getResponseBody(), actionResponse.getStatusCode());
+    }
+
+    @BeforeMethod
+    public void setUp() {
+
+        serviceExtensionMockServer.resetRequests();
+    }
+
+    @Test
+    public void testPasswordResetFailsForSmsOtpWhenPrePasswordUpdateActionFails() throws Exception {
+
+        // Step 1: Build user claim.
+        UserClaim usernameClaim = new UserClaim()
+                .uri("http://wso2.org/claims/username")
+                .value(userInfo.getUserName());
+
+        InitModel initModel = new InitModel().claims(List.of(usernameClaim));
+
+        // Step 2: Initiate password recovery via SMS.
+        RecoverModel recoverModel = passwordRecoveryV2RestClient.init(initModel, "SMS");
+        assertNotNull(recoverModel, "Recovery model should not be null");
+        assertTrue(StringUtils.isNotBlank(recoverModel.getChannelId()), "Channel ID should not be blank");
+        assertTrue(StringUtils.isNotBlank(recoverModel.getRecoveryCode()), "Recovery code should not be blank");
+
+        // Step 3: Trigger recovery to get flow confirmation code.
+        String flowConfirmationCode = passwordRecoveryV2RestClient.recover(recoverModel);
+        assertTrue(StringUtils.isNotBlank(flowConfirmationCode), "Flow confirmation code should not be blank");
+
+        // Step 4: Extract OTP and confirm.
+        String otp = extractOtp(mockSMSProvider.getSmsContent());
+        assertTrue(StringUtils.isNotBlank(otp), "OTP should not be blank");
+
+        ConfirmModel confirmModel = new ConfirmModel()
+                .confirmationCode(flowConfirmationCode)
+                .otp(otp);
+
+        String resetCode = passwordRecoveryV2RestClient.confirm(confirmModel);
+        assertTrue(StringUtils.isNotBlank(resetCode), "Reset code should not be blank");
+
+        // Step 5: Attempt password reset.
+        ResetModel resetModel = new ResetModel()
+                .resetCode(resetCode)
+                .flowConfirmationCode(flowConfirmationCode)
+                .password(TEST_USER_UPDATED_PASSWORD);
+
+        Error errorResponse = passwordRecoveryV2RestClient.reset(resetModel);
+
+        // Step 6: Validate error response (e.g. due to password policy violation).
+        assertNotNull(errorResponse, "Expected error response on reset attempt");
+        assertEquals(errorResponse.getCode(), "PWR-20067");
+        assertEquals(errorResponse.getMessage(), expectedPasswordUpdateResponse.getErrorMessage());
+        assertEquals(errorResponse.getDescription(), expectedPasswordUpdateResponse.getErrorDetail());
+        assertTrue(StringUtils.isNotBlank(errorResponse.getTraceId()), "Trace ID should not be blank");
+
+        // Step 7: Assert the pre password update action.
+        assertActionRequestPayload(
+                userId,
+                TEST_USER_UPDATED_PASSWORD,
+                PreUpdatePasswordEvent.FlowInitiatorType.USER,
+                PreUpdatePasswordEvent.Action.RESET
+                                  );
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        updatePasswordBasedRecoveryFeatureStatus(false);
+        deleteAction(PRE_UPDATE_PASSWORD_API_PATH, actionId);
+        scim2RestClient.deleteUser(userId);
+        notificationSenderRestClient.deleteSMSProvider();
+        identityGovernanceRestClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        passwordRecoveryV2RestClient.closeHttpClient();
+        client.close();
+        serviceExtensionMockServer.stopServer();
+        serviceExtensionMockServer = null;
+        mockSMSProvider.stop();
+    }
+
+    private void assertActionRequestPayload(String userId, String updatedPassword,
+                                            PreUpdatePasswordEvent.FlowInitiatorType initiatorType,
+                                            PreUpdatePasswordEvent.Action action) throws JsonProcessingException {
+
+        String actualRequestPayload =
+                serviceExtensionMockServer.getReceivedRequestPayload(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
+        PreUpdatePasswordActionRequest actionRequest = new ObjectMapper()
+                .readValue(actualRequestPayload, PreUpdatePasswordActionRequest.class);
+
+        assertEquals(actionRequest.getActionType(), ActionType.PRE_UPDATE_PASSWORD);
+        assertEquals(actionRequest.getEvent().getTenant().getName(), tenantInfo.getDomain());
+        assertEquals(actionRequest.getEvent().getTenant().getId(), tenantId);
+        assertEquals(actionRequest.getEvent().getUserStore().getName(), PRIMARY_USER_STORE_NAME);
+        assertEquals(actionRequest.getEvent().getUserStore().getId(), PRIMARY_USER_STORE_ID);
+
+        PasswordUpdatingUser user = actionRequest.getEvent().getPasswordUpdatingUser();
+
+        assertEquals(user.getId(), userId);
+        assertEquals(user.getUpdatingCredential().getType(), Credential.Type.PASSWORD);
+        assertEquals(user.getUpdatingCredential().getFormat(), Credential.Format.PLAIN_TEXT);
+        assertEquals(user.getUpdatingCredential().getValue(), updatedPassword.toCharArray());
+        assertEquals(actionRequest.getEvent().getInitiatorType(), initiatorType);
+        assertEquals(actionRequest.getEvent().getAction(), action);
+    }
+
+    private SMSSender initSMSSender() {
+
+        SMSSender smsSender = new SMSSender();
+        smsSender.setProvider(MockSMSProvider.SMS_SENDER_PROVIDER_TYPE);
+        smsSender.setProviderURL(MockSMSProvider.SMS_SENDER_URL);
+        smsSender.contentType(SMSSender.ContentTypeEnum.JSON);
+        ArrayList<Properties> properties = new ArrayList<>();
+        properties.add(new Properties().key("body").value(SMS_SENDER_REQUEST_FORMAT));
+        smsSender.setProperties(properties);
+        return smsSender;
+    }
+
+    private void updatePasswordBasedRecoveryFeatureStatus(boolean enable) throws IOException {
+
+        ConnectorsPatchReq connectorsPatchReq = new ConnectorsPatchReq();
+        connectorsPatchReq.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
+
+        PropertyReq enableSMSOtpRecovery = new PropertyReq()
+                .name("Recovery.Notification.Password.smsOtp.Enable")
+                .value(enable ? "true" : "false");
+
+        PropertyReq enablePasswordRecovery = new PropertyReq()
+                .name("Recovery.Notification.Password.Enable")
+                .value(enable ? "true" : "false");
+
+        connectorsPatchReq.addProperties(enablePasswordRecovery);
+        connectorsPatchReq.addProperties(enableSMSOtpRecovery);
+
+        identityGovernanceRestClient.updateConnectors("QWNjb3VudCBNYW5hZ2VtZW50",
+                "YWNjb3VudC1yZWNvdmVyeQ", connectorsPatchReq);
+    }
+
+    private String extractOtp(String message) {
+
+        String prefix = "Your One-Time Password : ";
+        if (message != null && message.contains(prefix)) {
+            return message.substring(message.indexOf(prefix) + prefix.length()).trim();
+        }
+        return null;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -142,6 +142,7 @@
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionWithRulesAtAuthorizationCodeGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionSuccessTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionFailureTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionSmsOtpFailureTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCHybridFlowIntegrationTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsGrantTypesTestCase"/>


### PR DESCRIPTION
This integration tests includes
1. Pre password update failure on SMS OTP via V2 recovery API.
2. Error response format assertion for pre password update failure on "Bad Request".

Product-is issue
- https://github.com/wso2/product-is/issues/23788

