### PR TITLE
Update the integration tests for admin forced password reset configs & bump governance version.

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -337,9 +337,6 @@ else
   fi
 
   cd product-is
-  git checkout update-integration-tests-for-admin-force-password-reset
-  current_branch=$(git branch --show-current)
-  echo "You are on branch: $current_branch"
 
   echo "Updating dependency version in product-is..."
   echo "=========================================================="

--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -337,6 +337,9 @@ else
   fi
 
   cd product-is
+  git checkout update-integration-tests-for-admin-force-password-reset
+  current_branch=$(git branch --show-current)
+  echo "You are on branch: $current_branch"
 
   echo "Updating dependency version in product-is..."
   echo "=========================================================="

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/governance/AdminForcedPasswordResetTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/identity/governance/AdminForcedPasswordResetTestCase.java
@@ -75,16 +75,18 @@ public class AdminForcedPasswordResetTestCase extends ISIntegrationTest {
     private RemoteUserStoreManagerServiceClient remoteUSMServiceClient;
     private static final String PROFILE_NAME = "default";
     private static final String TEST_USER_USERNAME = "testUser";
-    private static final String TEST_USER_PASSWORD = "Ab@123";
+    private static final String TEST_USER_PASSWORD = "Abcd@123";
     private static final String TEST_USER_NEW_PASSWORD = "AbNew@123";
     private static final String TEST_USER_EMAIL = "test@test.com";
     private static final String TEST_ROLE = "testRole";
 
     private static final String TRUE_STRING = "true";
+    private static final String FALSE_STRING = "false";
 
     private static final String ENABLE_ADMIN_PASSWORD_RESET_OFFLINE = "Recovery.AdminPasswordReset.Offline";
-    private static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP = "Recovery.AdminPasswordReset.OTP";
-    private static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK = "Recovery.AdminPasswordReset.RecoveryLink";
+    private static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_OTP = "Recovery.AdminPasswordReset.OTP";
+    private static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_LINK = "Recovery.AdminPasswordReset.RecoveryLink";
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_SMS_OTP = "Recovery.AdminPasswordReset.SMSOTP";
     private static final String ENABLE_NOTIFICATION_BASED_PASSWORD_RECOVERY = "Recovery.Notification.Password.Enable";
     private static final String ADMIN_FORCED_PASSWORD_RESET_CLAIM = "http://wso2.org/claims/identity/adminForcedPasswordReset";
     private static final String OTP_CLAIM = "http://wso2.org/claims/oneTimePassword";
@@ -254,24 +256,27 @@ public class AdminForcedPasswordResetTestCase extends ISIntegrationTest {
                 isServer.getSuperTenant().getTenantAdmin().getPassword(),
                 isServer.getInstance().getHosts().get(DEFAULT));
 
-        Property[] newProperties = new Property[3];
-
-        Property prop = new Property();
-        prop.setName(option);
-        prop.setValue(TRUE_STRING);
-
         Property prop1 = new Property();
-        prop1.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK);
-        prop1.setValue("false");
+        prop1.setName(option);
+        prop1.setValue(TRUE_STRING);
 
         Property prop2 = new Property();
-        prop2.setName(ENABLE_NOTIFICATION_BASED_PASSWORD_RECOVERY);
-        prop2.setValue(TRUE_STRING);
+        prop2.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_LINK);
+        prop2.setValue(FALSE_STRING);
 
-        newProperties[0] = prop;
-        newProperties[1] = prop1;
-        newProperties[2] = prop2;
-        identityGovernanceServiceClient.updateConfigurations(newProperties);
+        Property prop3 = new Property();
+        prop3.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_OTP);
+        prop3.setValue(FALSE_STRING);
+
+        Property prop4 = new Property();
+        prop4.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_SMS_OTP);
+        prop4.setValue(FALSE_STRING);
+
+        Property prop5 = new Property();
+        prop5.setName(ENABLE_NOTIFICATION_BASED_PASSWORD_RECOVERY);
+        prop5.setValue(TRUE_STRING);
+
+        identityGovernanceServiceClient.updateConfigurations(new Property[]{prop1, prop2, prop3, prop4, prop5});
     }
 
     protected void setUpUser() throws UserStoreException, RemoteException, RemoteUserStoreManagerServiceUserStoreExceptionException, UserAdminUserAdminException, UserProfileMgtServiceUserProfileExceptionException, LogoutAuthenticationExceptionException {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -68,6 +68,12 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     private static final String SCIM2_USERS_API = "/scim2/Users";
     private static final String INTERNAL_USER_MANAGEMENT_UPDATE = "internal_user_mgt_update";
     private static final String APP_CALLBACK_URL = "http://localhost:8490/playground2/oauth2client";
+    private static final String ENABLE_ADMIN_PASSWORD_RESET_OFFLINE = "Recovery.AdminPasswordReset.Offline";
+    private static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_OTP = "Recovery.AdminPasswordReset.OTP";
+    private static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_LINK = "Recovery.AdminPasswordReset.RecoveryLink";
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_SMS_OTP = "Recovery.AdminPasswordReset.SMSOTP";
+    private static final String TRUE_STRING = "true";
+    private static final String FALSE_STRING = "false";
 
     protected static final String TEST_USER1_USERNAME = "testUsername";
     protected static final String TEST_USER2_USERNAME = "testUsername2";
@@ -86,6 +92,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String ACTION_DESCRIPTION = "This is a test for pre update password action type";
     protected static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+
 
     protected CloseableHttpClient client;
     protected IdentityGovernanceRestClient identityGovernanceRestClient;
@@ -129,14 +136,31 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
                 "YWNjb3VudC1yZWNvdmVyeQ", connectorsPatchReq);
     }
 
-    protected void updateAdminPasswordResetRecoveryEmailFeatureStatus(boolean enable) throws IOException {
+    protected void enableAdminPasswordResetRecoveryEmailLink() throws IOException {
 
         ConnectorsPatchReq connectorsPatchReq = new ConnectorsPatchReq();
         connectorsPatchReq.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
-        PropertyReq propertyReq = new PropertyReq();
-        propertyReq.setName("Recovery.AdminPasswordReset.RecoveryLink");
-        propertyReq.setValue(enable ? "true" : "false");
-        connectorsPatchReq.addProperties(propertyReq);
+
+        PropertyReq emailLinkProperty = new PropertyReq();
+        emailLinkProperty.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_LINK);
+        emailLinkProperty.setValue(TRUE_STRING);
+        connectorsPatchReq.addProperties(emailLinkProperty);
+
+        PropertyReq emailOtpProperty = new PropertyReq();
+        emailOtpProperty.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_EMAIL_OTP);
+        emailOtpProperty.setValue(FALSE_STRING);
+        connectorsPatchReq.addProperties(emailOtpProperty);
+
+        PropertyReq offlineProperty = new PropertyReq();
+        offlineProperty.setName(ENABLE_ADMIN_PASSWORD_RESET_OFFLINE);
+        offlineProperty.setValue(FALSE_STRING);
+        connectorsPatchReq.addProperties(offlineProperty);
+
+        PropertyReq smsOtpProperty = new PropertyReq();
+        smsOtpProperty.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_SMS_OTP);
+        smsOtpProperty.setValue(FALSE_STRING);
+        connectorsPatchReq.addProperties(smsOtpProperty);
+
         identityGovernanceRestClient.updateConnectors("QWNjb3VudCBNYW5hZ2VtZW50",
                 "YWRtaW4tZm9yY2VkLXBhc3N3b3JkLXJlc2V0", connectorsPatchReq);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -134,7 +134,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         userId = scim2RestClient.createUser(userInfo);
 
         updatePasswordRecoveryFeatureStatus(true);
-        updateAdminPasswordResetRecoveryEmailFeatureStatus(true);
+        enableAdminPasswordResetRecoveryEmailLink();
         updateAdminInitiatedPasswordResetEmailFeatureStatus(true);
 
         actionId = createPreUpdatePasswordAction(ACTION_NAME, ACTION_DESCRIPTION);
@@ -158,7 +158,6 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
     public void atEnd() throws Exception {
 
         updatePasswordRecoveryFeatureStatus(false);
-        updateAdminPasswordResetRecoveryEmailFeatureStatus(false);
         updateAdminInitiatedPasswordResetEmailFeatureStatus(false);
 
         deleteAction(PRE_UPDATE_PASSWORD_API_PATH, actionId);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -101,7 +101,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         userId = scim2RestClient.createUser(userInfo);
 
         updatePasswordRecoveryFeatureStatus(true);
-        updateAdminPasswordResetRecoveryEmailFeatureStatus(true);
+        enableAdminPasswordResetRecoveryEmailLink();
         updateAdminInitiatedPasswordResetEmailFeatureStatus(true);
 
         actionId = createPreUpdatePasswordAction(ACTION_NAME, ACTION_DESCRIPTION);
@@ -125,7 +125,6 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
     public void atEnd() throws Exception {
 
         updatePasswordRecoveryFeatureStatus(false);
-        updateAdminPasswordResetRecoveryEmailFeatureStatus(false);
         updateAdminInitiatedPasswordResetEmailFeatureStatus(false);
 
         deleteAction(PRE_UPDATE_PASSWORD_API_PATH, actionId);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/identity/governance/v1/get-category-QWNjb3VudCBNYW5hZ2VtZW50-response.json
@@ -283,8 +283,14 @@
         {
           "name": "Recovery.AdminPasswordReset.OTP",
           "value": "false",
-          "displayName": "Enable password reset via OTP",
-          "description": "User gets notified with a one time password to try with SSO login"
+          "displayName": "Enable password reset via Email OTP",
+          "description": "User gets notified with a one-time password to Email try with SSO login"
+        },
+        {
+          "name": "Recovery.AdminPasswordReset.SMSOTP",
+          "value": "false",
+          "displayName": "Enable password reset via SMS OTP",
+          "description": "User gets notified with a one-time password to Mobile try with SSO login"
         },
         {
           "name": "Recovery.AdminPasswordReset.Offline",

--- a/pom.xml
+++ b/pom.xml
@@ -2473,7 +2473,7 @@
         <carbon.consent.mgt.version>2.6.8</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.11.64</identity.governance.version>
+        <identity.governance.version>1.11.65</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.9.9</identity.carbon.auth.saml2.version>


### PR DESCRIPTION
### Purpose
- With the introduction new sms OTP config the previous display name and the description has been changed in email OTP and addition to that SMS OTP has been added.
- This PR will update the latest descriptions.

### Related issues
- https://github.com/wso2/product-is/issues/23660

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/943