### PR TITLE
[Integration tests] Failure scenarios for refresh token expiry time update in the pre-issue access token action flow.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase.java
@@ -249,7 +249,7 @@ public class PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase extends A
     }
 
     @Test(groups = "wso2.is", description =
-            "Verify that the refresh token expiry time is correctly updated by the action in the authorization code grant flow.",
+            "Verify that the refresh token expiry time is not updated by the action in the refresh grant flow.",
             dependsOnMethods = "testGetAccessTokenWithCodeGrant")
     public void tesRefreshTokenExpiryTimeFailureInIntrospectForCodeGrant() throws Exception {
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,8 +18,10 @@
 
 package org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -28,6 +30,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -65,12 +68,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.xpath.XPathExpressionException;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
 import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
 import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.INTRO_SPEC_ENDPOINT;
 import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
 
 /**
@@ -83,6 +89,7 @@ public class PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase extends A
     private static final String PRE_ISSUE_ACCESS_TOKEN_API_PATH = "preIssueAccessToken";
     private static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
     private static final int APP_CONFIGURED_EXPIRY_TIME = 3600;
+    private static final int UPDATED_REFRESH_TOKEN_EXPIRY_TIME_BY_ACTION_AT_CODE_GRANT = 47400;
     private CloseableHttpClient client;
     private SCIM2RestClient scim2RestClient;
     private List<String> requestedScopes;
@@ -179,7 +186,8 @@ public class PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase extends A
             serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
                     "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME, MOCK_SERVER_AUTH_BASIC_PASSWORD),
                     FileUtils.readFileInClassPathAsString(
-                            "actions/response/pre-issue-access-token-response-code-before-refresh.json"), 200);
+                            "actions/response/pre-issue-access-token-response-code-before-refresh-with-refresh-token-expiry.json"),
+                    200);
         } else if (method.getName().equals("testPreIssueAccessTokenActionFailureForRefreshGrant")) {
             serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
                     "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME, MOCK_SERVER_AUTH_BASIC_PASSWORD),
@@ -217,6 +225,15 @@ public class PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase extends A
     }
 
     @Test(groups = "wso2.is", description =
+            "Verify that the refresh token expiry time is correctly updated by the action in the authorization code grant flow.",
+            dependsOnMethods = "testGetAccessTokenWithCodeGrant")
+    public void tesRefreshTokenExpiryTimeInIntrospectForCodeGrant() throws Exception {
+
+        JSONObject jsonResponse = invokeIntrospectEndpoint(refreshToken);
+        assertIntrospectResponse(jsonResponse, UPDATED_REFRESH_TOKEN_EXPIRY_TIME_BY_ACTION_AT_CODE_GRANT);
+    }
+
+    @Test(groups = "wso2.is", description =
             "Get access token from refresh token when pre-issue access token action is successful",
             dependsOnMethods = "testGetAccessTokenWithCodeGrant")
     public void testPreIssueAccessTokenActionFailureForRefreshGrant() throws Exception {
@@ -229,6 +246,15 @@ public class PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase extends A
         JSONObject jsonResponse = new JSONObject(responseString);
         assertEquals(jsonResponse.getString("error"), expectedResponse.getErrorMessage());
         assertEquals(jsonResponse.getString("error_description"), expectedResponse.getErrorDescription());
+    }
+
+    @Test(groups = "wso2.is", description =
+            "Verify that the refresh token expiry time is correctly updated by the action in the authorization code grant flow.",
+            dependsOnMethods = "testGetAccessTokenWithCodeGrant")
+    public void tesRefreshTokenExpiryTimeFailureInIntrospectForCodeGrant() throws Exception {
+
+        JSONObject jsonResponse = invokeIntrospectEndpoint(refreshToken);
+        assertIntrospectResponse(jsonResponse, UPDATED_REFRESH_TOKEN_EXPIRY_TIME_BY_ACTION_AT_CODE_GRANT);
     }
 
     private HttpResponse sendTokenRequestForRefreshGrant() throws IOException {
@@ -313,6 +339,60 @@ public class PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase extends A
 
         return sendPostRequest(client, headers, urlParameters,
                 getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+    }
+
+    private JSONObject invokeIntrospectEndpoint(String refreshToken)
+            throws XPathExpressionException, IOException, JSONException {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("token", refreshToken));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER, OAuth2Constant.BASIC_HEADER + " " +
+                getBase64EncodedString(isServer.getContextTenant().getTenantAdmin().getUserName(),
+                        isServer.getContextTenant().getTenantAdmin().getPassword())));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(client, headers, urlParameters,
+                getTenantQualifiedURL(INTRO_SPEC_ENDPOINT, tenantInfo.getDomain()));
+
+        assertNotNull(response, "Failed to receive a response for introspection request.");
+        assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK,
+                response.getStatusLine().getReasonPhrase());
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        EntityUtils.consume(response.getEntity());
+        assertTrue(StringUtils.isNotBlank(responseString));
+
+        return new JSONObject(responseString);
+    }
+
+    private void assertIntrospectResponse(JSONObject jsonResponse, long expectedRefreshTokenExpiryInSeconds)
+            throws JSONException {
+
+        assertTrue(jsonResponse.has("nbf"), "Not Before value not found in the refresh token introspection response");
+        assertTrue(jsonResponse.has("exp"), "Expiry timestamp not found in the refresh token introspection response");
+        long exp = jsonResponse.getLong("exp");
+        assertTrue(jsonResponse.has("iat"),
+                "Issued at timestamp not found in the refresh token introspection response");
+        long iat = jsonResponse.getLong("iat");
+
+        assertEquals((exp - iat), expectedRefreshTokenExpiryInSeconds,
+                "Invalid expiry time for the refresh token.");
+
+        assertTrue(jsonResponse.has("scope"), "Scopes not found in the refresh token introspection response");
+        List<String> authorizedScopes = Arrays.asList(jsonResponse.getString("scope").split(" "));
+        List<String> expectedScopes = requestedScopes;
+        for (String expectedScope : expectedScopes) {
+            assertTrue(authorizedScopes.contains(expectedScope),
+                    "Scope " + expectedScope + " not found in the refresh token introspection.");
+        }
+
+        assertTrue((Boolean) jsonResponse.get("active"), "Refresh token is inactive");
+        assertEquals(jsonResponse.get("token_type"), "Refresh", "Invalid token type");
+        assertEquals(jsonResponse.get("client_id"), clientId,
+                "Invalid client id in the refresh token introspection response");
     }
 
     private String getAuthorizationCodeFromURL(String location) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase.java
@@ -240,7 +240,8 @@ public class PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase extends 
     }
 
     @Test(groups = "wso2.is", description =
-            "Test obtaining a refresh token using authorization code grant when the pre-issue access token action completes successfully.",
+            "Test obtaining a refresh token using authorization code grant when the pre-issue access token " +
+                    "action completes successfully for re-login.",
             dependsOnMethods = "tesRefreshTokenExpiryTimeInIntrospectForRefreshGrant")
     public void testGetRefreshTokenWithCodeGrantForReLogin() throws Exception {
 
@@ -257,7 +258,8 @@ public class PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase extends 
     }
 
     @Test(groups = "wso2.is", description =
-            "Verify that the refresh token expiry time is correctly updated by the action in the authorization code grant flow.",
+            "Verify that the refresh token expiry time is correctly updated by the action in the " +
+                    "authorization code grant on re-login.",
             dependsOnMethods = "testGetRefreshTokenWithCodeGrantForReLogin")
     public void tesRefreshTokenExpiryTimeInIntrospectForCodeGrantForReLogin() throws Exception {
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase.java
@@ -180,6 +180,11 @@ public class PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase extends 
                     FileUtils.readFileInClassPathAsString(
                             "actions/response/refresh-token-expiry-response-refresh-grant.json"),
                     200);
+        } else if (method.getName().equals("testGetRefreshTokenWithCodeGrantForReLogin")) {
+            serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                    "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME, MOCK_SERVER_AUTH_BASIC_PASSWORD),
+                    FileUtils.readFileInClassPathAsString(
+                            "actions/response/refresh-token-expiry-response-code-grant.json"), 200);
         }
     }
 
@@ -211,7 +216,7 @@ public class PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase extends 
 
     @Test(groups = "wso2.is", description =
             "Test obtaining a refresh token using refresh token grant when the pre-issue access token action completes successfully.",
-            dependsOnMethods = "testGetRefreshTokenWithCodeGrant")
+            dependsOnMethods = "tesRefreshTokenExpiryTimeInIntrospectForCodeGrant")
     public void testGetRefreshTokenFromRefreshGrant() throws Exception {
 
         HttpResponse response = sendTokenRequestForRefreshGrant();
@@ -232,6 +237,32 @@ public class PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase extends 
 
         JSONObject jsonResponse = invokeIntrospectEndpoint(refreshToken);
         assertIntrospectResponse(jsonResponse, UPDATED_REFRESH_TOKEN_EXPIRY_TIME_BY_ACTION_AT_REFRESH_GRANT);
+    }
+
+    @Test(groups = "wso2.is", description =
+            "Test obtaining a refresh token using authorization code grant when the pre-issue access token action completes successfully.",
+            dependsOnMethods = "tesRefreshTokenExpiryTimeInIntrospectForRefreshGrant")
+    public void testGetRefreshTokenWithCodeGrantForReLogin() throws Exception {
+
+        sendAuthorizeRequestForReLogin();
+        HttpResponse response = sendTokenRequestForCodeGrant();
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+
+        assertTokenResponse(jsonResponse);
+
+        accessTokenClaims = getJWTClaimSetFromToken(accessToken);
+        assertNotNull(accessTokenClaims);
+    }
+
+    @Test(groups = "wso2.is", description =
+            "Verify that the refresh token expiry time is correctly updated by the action in the authorization code grant flow.",
+            dependsOnMethods = "testGetRefreshTokenWithCodeGrantForReLogin")
+    public void tesRefreshTokenExpiryTimeInIntrospectForCodeGrantForReLogin() throws Exception {
+
+        JSONObject jsonResponse = invokeIntrospectEndpoint(refreshToken);
+        assertIntrospectResponse(jsonResponse, UPDATED_REFRESH_TOKEN_EXPIRY_TIME_BY_ACTION_AT_CODE_GRANT);
     }
 
     private void assertTokenResponse(JSONObject jsonResponse) throws JSONException {
@@ -352,6 +383,27 @@ public class PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase extends 
         sessionDataKey = keyValues.get(0).getValue();
         assertNotNull(sessionDataKey, "Session data key is null");
         EntityUtils.consume(response.getEntity());
+    }
+
+    private void sendAuthorizeRequestForReLogin() throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("client_id", clientId));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", OAuth2Constant.CALLBACK_URL));
+
+        String scopes = String.join(" ", requestedScopes);
+        urlParameters.add(new BasicNameValuePair("scope", scopes));
+
+        HttpResponse response = sendPostRequestWithParameters(client, urlParameters,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Redirection URL to the application with authorization code is null.");
+        EntityUtils.consume(response.getEntity());
+
+        authorizationCode = getAuthorizationCodeFromURL(locationHeader.getValue());
+        assertNotNull(authorizationCode);
     }
 
     private void performUserLogin() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-issue-access-token-response-code-before-refresh-with-refresh-token-expiry.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-issue-access-token-response-code-before-refresh-with-refresh-token-expiry.json
@@ -8,6 +8,11 @@
         "name": "custom_claim_string_0",
         "value": "testCustomClaim0"
       }
+    },
+    {
+      "op": "replace",
+      "path": "/refreshToken/claims/expires_in",
+      "value": 47400
     }
   ]
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-issue-access-token-response-code-before-refresh-with-refresh-token-expiry.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-issue-access-token-response-code-before-refresh-with-refresh-token-expiry.json
@@ -1,0 +1,13 @@
+{
+  "actionStatus": "SUCCESS",
+  "operations": [
+    {
+      "op": "add",
+      "path": "/accessToken/claims/-",
+      "value": {
+        "name": "custom_claim_string_0",
+        "value": "testCustomClaim0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR consists of 

- Failure scenarios for refresh token expiry time update in the pre-issue access token action flow.
- Refresh token expiry time success test case for re-login 

Parent issue

- https://github.com/wso2/product-is/issues/23898
