### PR TITLE
Add Pre Update Profile integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ActionsRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/ActionsRestClient.java
@@ -42,9 +42,11 @@ public class ActionsRestClient extends RestBaseClient {
 
     private static final String PRE_ISSUE_ACCESS_TOKEN_TYPE = "preIssueAccessToken";
     private static final String PRE_UPDATE_PASSWORD_TYPE = "preUpdatePassword";
+    private static final String PRE_UPDATE_PROFILE_TYPE = "preUpdateProfile";
     private static final String ACTIONS_PATH = "/actions";
     private static final String PRE_ISSUE_ACCESS_TOKEN_PATH = "/preIssueAccessToken";
     private static final String PRE_UPDATE_PASSWORD_PATH = "/preUpdatePassword";
+    private static final String PRE_UPDATE_PROFILE_PATH = "/preUpdateProfile";
     private static final String ACTION_ACTIVATE_PATH = "/activate";
     private final String serverUrl;
     private final String tenantDomain;
@@ -151,6 +153,8 @@ public class ActionsRestClient extends RestBaseClient {
                 return actionsBasePath + PRE_ISSUE_ACCESS_TOKEN_PATH;
             case PRE_UPDATE_PASSWORD_TYPE:
                 return actionsBasePath + PRE_UPDATE_PASSWORD_PATH;
+            case PRE_UPDATE_PROFILE_TYPE:
+                return actionsBasePath + PRE_UPDATE_PROFILE_PATH;
             default:
                 return StringUtils.EMPTY;
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/dataprovider/model/ExpectedProfileUpdateResponse.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/dataprovider/model/ExpectedProfileUpdateResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.dataprovider.model;
+
+public class ExpectedProfileUpdateResponse {
+
+    private final int statusCode;
+    private final String errorMessage;
+    private final String errorDetail;
+
+    public ExpectedProfileUpdateResponse(int statusCode, String errorMessage, String errorDetail) {
+
+        this.statusCode = statusCode;
+        this.errorMessage = errorMessage;
+        this.errorDetail = errorDetail;
+    }
+
+    public int getStatusCode() {
+
+        return statusCode;
+    }
+
+    public String getErrorDetail() {
+
+        return errorDetail;
+    }
+
+    public String getErrorMessage() {
+
+        return errorMessage;
+    }
+
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/dataprovider/model/ExpectedProfileUpdateResponse.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/dataprovider/model/ExpectedProfileUpdateResponse.java
@@ -47,3 +47,4 @@ public class ExpectedProfileUpdateResponse {
     }
 
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/ActionType.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/ActionType.java
@@ -23,5 +23,6 @@ package org.wso2.identity.integration.test.serviceextensions.model;
  */
 public enum ActionType {
     PRE_ISSUE_ACCESS_TOKEN,
-    PRE_UPDATE_PASSWORD
+    PRE_UPDATE_PASSWORD,
+    PRE_UPDATE_PROFILE
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Claim.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Claim.java
@@ -108,3 +108,4 @@ public class Claim {
         }
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Claim.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Claim.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+/**
+ * Represents a claim.
+ */
+@JsonDeserialize(builder = Claim.Builder.class)
+public class Claim {
+
+    private final String uri;
+    private final String updatingValue;
+    private final String value;
+
+    private Claim(Claim.Builder builder) {
+
+        this.uri = builder.uri;
+        this.updatingValue = builder.updatingValue;
+        this.value = builder.value;
+    }
+
+    public String getUri() {
+
+        return uri;
+    }
+
+    public String getUpdatingValue() {
+
+        return updatingValue;
+    }
+
+    public String getValue() {
+
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Claim that = (Claim) o;
+
+        return Objects.equals(uri, that.uri) && Objects.equals(updatingValue, that.updatingValue) &&
+                Objects.equals(value, that.value) ;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(uri, value);
+    }
+
+
+    /**
+     * Builder for claims.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private String uri;
+        private String updatingValue;
+        private String value;
+
+        public Claim.Builder uri(String uri) {
+
+            this.uri = uri;
+            return this;
+        }
+
+        public Claim.Builder updatingValue(String updatingValue) {
+
+            this.updatingValue = updatingValue;
+            return this;
+        }
+
+        public Claim.Builder value(String value) {
+
+            this.value = value;
+            return this;
+        }
+
+        public Claim build() {
+
+            return new Claim(this);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileActionRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileActionRequest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+/**
+ * This class represents the model of the pre update profile action request sent in the request payload
+ * to the API endpoint of the pre update profile action.
+ */
+@JsonDeserialize(builder = PreUpdateProfileActionRequest.Builder.class)
+public class PreUpdateProfileActionRequest {
+
+    private final ActionType actionType;
+    private final String flowId;
+    private final String requestId;
+    private final PreUpdateProfileEvent event;
+
+    public PreUpdateProfileActionRequest(Builder builder) {
+
+        this.actionType = builder.actionType;
+        this.flowId = builder.flowId;
+        this.requestId = builder.requestId;
+        this.event = builder.event;
+    }
+
+    public ActionType getActionType() {
+
+        return actionType;
+    }
+
+    public String getFlowId() {
+
+        return flowId;
+    }
+
+    public String getRequestId() {
+
+        return requestId;
+    }
+
+    public PreUpdateProfileEvent getEvent() {
+
+        return event;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PreUpdateProfileActionRequest that = (PreUpdateProfileActionRequest) o;
+        return actionType == that.actionType &&
+                Objects.equals(event, that.event);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(actionType, event);
+    }
+
+    /**
+     * Builder for the {@link PreUpdateProfileActionRequest}.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private ActionType actionType;
+        private String flowId;
+        private String requestId;
+        private PreUpdateProfileEvent event;
+
+        public Builder actionType(ActionType actionType) {
+
+            this.actionType = actionType;
+            return this;
+        }
+
+        public Builder flowId(String flowId) {
+
+            this.flowId = flowId;
+            return this;
+        }
+
+        public Builder requestId(String requestId) {
+
+            this.requestId = requestId;
+            return this;
+        }
+
+        public Builder event(PreUpdateProfileEvent event) {
+
+            this.event = event;
+            return this;
+        }
+
+        public PreUpdateProfileActionRequest build() {
+
+            return new PreUpdateProfileActionRequest(this);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileActionRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileActionRequest.java
@@ -120,3 +120,4 @@ public class PreUpdateProfileActionRequest {
         }
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileEvent.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileEvent.java
@@ -169,3 +169,4 @@ public class PreUpdateProfileEvent extends Event {
         }
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileEvent.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileEvent.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+/**
+ * This class models the event at a pre update profile trigger.
+ * ProfileEvent is the entity that represents the event that is sent to the Action
+ * over {@link org.wso2.carbon.identity.action.execution.model.ActionExecutionRequest}.
+ */
+@JsonDeserialize(builder = PreUpdateProfileEvent.Builder.class)
+public class PreUpdateProfileEvent extends Event {
+
+    /**
+     * FlowInitiator Enum.
+     * Defines the initiator type for the profile update flow.
+     */
+    public enum FlowInitiatorType {
+        USER,
+        ADMIN,
+        APPLICATION
+    }
+
+    /**
+     * Action Enum.
+     * Defines the mode of updating the profile.
+     */
+    public enum Action {
+        UPDATE
+    }
+
+    private final PreUpdateProfileEvent.FlowInitiatorType initiatorType;
+    private final PreUpdateProfileEvent.Action action;
+    private final PreUpdateProfileRequest request;
+    private final ProfileUpdatingUser user;
+
+    private PreUpdateProfileEvent(PreUpdateProfileEvent.Builder builder) {
+
+        this.initiatorType = builder.initiatorType;
+        this.action = builder.action;
+        this.request = builder.request;
+        this.organization = builder.organization;
+        this.tenant = builder.tenant;
+        this.user = builder.user;
+        this.userStore = builder.userStore;
+    }
+
+    public PreUpdateProfileEvent.FlowInitiatorType getInitiatorType() {
+
+        return initiatorType;
+    }
+
+    public PreUpdateProfileEvent.Action getAction() {
+
+        return action;
+    }
+
+    public PreUpdateProfileRequest getRequest() {
+
+        return request;
+    }
+
+    public ProfileUpdatingUser getProfileUpdatingUser() {
+
+        return user;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PreUpdateProfileEvent that = (PreUpdateProfileEvent) o;
+
+        return Objects.equals(request, that.request) &&
+                Objects.equals(initiatorType, that.initiatorType) &&
+                Objects.equals(action, that.action) &&
+                Objects.equals(user, that.user) &&
+                Objects.equals(userStore, that.userStore) &&
+                Objects.equals(tenant, that.tenant);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(request, initiatorType, action, user, userStore, tenant);
+    }
+
+    /**
+     * Builder for PasswordEvent.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private PreUpdateProfileRequest request;
+        private Tenant tenant;
+        private Organization organization;
+        private ProfileUpdatingUser user;
+        private UserStore userStore;
+        private PreUpdateProfileEvent.FlowInitiatorType initiatorType;
+        private PreUpdateProfileEvent.Action action;
+
+        public PreUpdateProfileEvent.Builder request(PreUpdateProfileRequest request) {
+
+            this.request = request;
+            return this;
+        }
+
+        public PreUpdateProfileEvent.Builder tenant(Tenant tenant) {
+
+            this.tenant = tenant;
+            return this;
+        }
+
+        public PreUpdateProfileEvent.Builder organization(Organization organization) {
+
+            this.organization = organization;
+            return this;
+        }
+
+        public PreUpdateProfileEvent.Builder user(ProfileUpdatingUser user) {
+
+            this.user = user;
+            return this;
+        }
+
+        public PreUpdateProfileEvent.Builder userStore(UserStore userStore) {
+
+            this.userStore = userStore;
+            return this;
+        }
+
+        public PreUpdateProfileEvent.Builder initiatorType(PreUpdateProfileEvent.FlowInitiatorType initiatorType) {
+
+            this.initiatorType = initiatorType;
+            return this;
+        }
+
+        public PreUpdateProfileEvent.Builder action(PreUpdateProfileEvent.Action action) {
+
+            this.action = action;
+            return this;
+        }
+
+        public PreUpdateProfileEvent build() {
+
+            return new PreUpdateProfileEvent(this);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
+import org.wso2.carbon.identity.action.execution.api.model.Request;
+
+import java.util.Objects;
+
+/**
+ * This class models the Pre Profile Update Request
+ */
+@JsonDeserialize(builder = PreUpdateProfileRequest.Builder.class)
+public class PreUpdateProfileRequest extends Request {
+
+    private final Claim[] claims;
+
+    private PreUpdateProfileRequest(PreUpdateProfileRequest.Builder builder) {
+
+        this.claims = builder.claims;
+    }
+
+    public Claim[] getClaims() {
+
+        return claims;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PreUpdateProfileRequest that = (PreUpdateProfileRequest) o;
+
+        return Objects.equals(claims, that.claims);
+
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(claims);
+    }
+
+    /**
+     * Builder for PreUpdateProfileRequest.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private Claim[] claims;
+
+        public PreUpdateProfileRequest.Builder claims(Claim[] claims) {
+
+            this.claims = claims;
+            return this;
+        }
+
+        public PreUpdateProfileRequest build() throws ActionExecutionRequestBuilderException {
+
+            return new PreUpdateProfileRequest(this);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileRequest.java
@@ -80,3 +80,4 @@ public class PreUpdateProfileRequest extends Request {
         }
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/ProfileUpdatingUser.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/ProfileUpdatingUser.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
+
+import java.util.Objects;
+
+@JsonDeserialize(builder = ProfileUpdatingUser.Builder.class)
+public class ProfileUpdatingUser extends User {
+
+    private final Claim[] claims;
+
+    private ProfileUpdatingUser(ProfileUpdatingUser.Builder builder) {
+
+        super(builder.id);
+        this.claims = builder.claims;
+    }
+
+    public Claim[] getClaims() {
+
+        return claims;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProfileUpdatingUser that = (ProfileUpdatingUser) o;
+
+        return Objects.equals(claims, that.claims);
+
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(claims);
+    }
+
+    /**
+     * Builder for ProfileUpdatingUser.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private String id;
+        private Claim[] claims;
+
+        public ProfileUpdatingUser.Builder id(String id) {
+
+            this.id = id;
+            return this;
+        }
+
+        public ProfileUpdatingUser.Builder claims(Claim[] claims) {
+
+            this.claims = claims;
+            return this;
+        }
+
+        public ProfileUpdatingUser build() throws ActionExecutionRequestBuilderException {
+
+            return new ProfileUpdatingUser(this);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/ProfileUpdatingUser.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/ProfileUpdatingUser.java
@@ -24,6 +24,9 @@ import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRe
 
 import java.util.Objects;
 
+/**
+ * Represents the model for user updating their profile.
+ */
 @JsonDeserialize(builder = ProfileUpdatingUser.Builder.class)
 public class ProfileUpdatingUser extends User {
 
@@ -84,3 +87,4 @@ public class ProfileUpdatingUser extends User {
         }
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
@@ -56,7 +56,6 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
 
     private static final String SCIM2_USERS_API = "/scim2/Users";
     private static final String INTERNAL_USER_MANAGEMENT_UPDATE = "internal_user_mgt_update";
-    private static final String APP_CALLBACK_URL = "http://localhost:8490/playground2/oauth2client";
 
     protected static final String TEST_USER1_USERNAME = "testUsername";
     protected static final String TEST_USER2_USERNAME = "testUsername2";
@@ -66,19 +65,15 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String TEST_USER_GIVEN_NAME = "test_user_given_name";
     protected static final String TEST_USER_LASTNAME = "test_user_last_name";
     protected static final String TEST_USER_EMAIL = "test.user@gmail.com";
+    protected static final String NICK_NAME_USER_SCHEMA_NAME = "nickName";
     protected static final String NICK_NAME_CLAIM_URI = "http://wso2.org/claims/nickname";
     protected static final String PRIMARY_USER_STORE_ID = "UFJJTUFSWQ==";
     protected static final String PRIMARY_USER_STORE_NAME = "PRIMARY";
-    protected static final String USER_SYSTEM_SCHEMA_ATTRIBUTE ="urn:scim:wso2:schema";
-    protected static final String FORCE_PASSWORD_RESET_ATTRIBUTE = "forcePasswordReset";
     protected static final String PRE_UPDATE_PROFILE_API_PATH = "preUpdateProfile";
     protected static final String ACTION_NAME = "Pre Update Profile Action";
     protected static final String ACTION_DESCRIPTION = "This is a test for pre update profile action type";
     protected static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
-
-    protected static final String ACCOUNT_DISABLED_ATTRIBUTE = "accountDisabled";
-    protected static final String GIVEN_NAME = "givenName";
 
     protected CloseableHttpClient client;
     protected IdentityGovernanceRestClient identityGovernanceRestClient;
@@ -125,7 +120,7 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
         actionModel.setName(actionName);
         actionModel.setDescription(actionDescription);
         actionModel.setEndpoint(endpoint);
-        actionModel.setAttributes(Collections.singletonList("http://wso2.org/claims/nickname"));
+        actionModel.setAttributes(Collections.singletonList(NICK_NAME_CLAIM_URI));
 
         return createAction(PRE_UPDATE_PROFILE_API_PATH, actionModel);
     }
@@ -160,3 +155,4 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
         return jsonResponse.getString("access_token");
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
@@ -57,7 +57,7 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     private static final String SCIM2_USERS_API = "/scim2/Users";
     private static final String INTERNAL_USER_MANAGEMENT_UPDATE = "internal_user_mgt_update";
 
-    protected static final String TEST_USER1_USERNAME = "testUsername";
+    protected static final String TEST_USER1_USERNAME = "preUpdateProfileTestUserName";
     protected static final String TEST_USER_PASSWORD = "TestPassword@123";
     protected static final String TEST_USER_CLAIM_VALUE = "testNickName";
     protected static final String TEST_USER_UPDATED_CLAIM_VALUE = "updateTestNickName";
@@ -77,7 +77,6 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String EMPTY_STRING = "";
 
     protected CloseableHttpClient client;
-    protected IdentityGovernanceRestClient identityGovernanceRestClient;
 
     private final CookieStore cookieStore = new BasicCookieStore();
 
@@ -103,7 +102,6 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
                 .setDefaultCookieStore(cookieStore)
                 .build();
 
-        identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
     }
 
     protected String createPreUpdateProfileAction(String actionName, String actionDescription) throws IOException {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
@@ -58,7 +58,6 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     private static final String INTERNAL_USER_MANAGEMENT_UPDATE = "internal_user_mgt_update";
 
     protected static final String TEST_USER1_USERNAME = "testUsername";
-    protected static final String TEST_USER2_USERNAME = "testUsername2";
     protected static final String TEST_USER_PASSWORD = "TestPassword@123";
     protected static final String TEST_USER_CLAIM_VALUE = "testNickName";
     protected static final String TEST_USER_UPDATED_CLAIM_VALUE = "updateTestNickName";
@@ -67,6 +66,7 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String TEST_USER_EMAIL = "test.user@gmail.com";
     protected static final String NICK_NAME_USER_SCHEMA_NAME = "nickName";
     protected static final String NICK_NAME_CLAIM_URI = "http://wso2.org/claims/nickname";
+    protected static final String GIVEN_NAME_CLAIM_URI = "http://wso2.org/claims/givenname";
     protected static final String PRIMARY_USER_STORE_ID = "UFJJTUFSWQ==";
     protected static final String PRIMARY_USER_STORE_NAME = "PRIMARY";
     protected static final String PRE_UPDATE_PROFILE_API_PATH = "preUpdateProfile";
@@ -74,6 +74,7 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String ACTION_DESCRIPTION = "This is a test for pre update profile action type";
     protected static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+    protected static final String EMPTY_STRING = "";
 
     protected CloseableHttpClient client;
     protected IdentityGovernanceRestClient identityGovernanceRestClient;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preupdateprofile;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.AuthenticationType;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.Endpoint;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.preupdateprofile.model.PreUpdateProfileActionModel;
+import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
+import org.wso2.identity.integration.test.utils.CarbonUtils;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.*;
+
+public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
+
+    private static final String SCIM2_USERS_API = "/scim2/Users";
+    private static final String INTERNAL_USER_MANAGEMENT_UPDATE = "internal_user_mgt_update";
+    private static final String APP_CALLBACK_URL = "http://localhost:8490/playground2/oauth2client";
+
+    protected static final String TEST_USER1_USERNAME = "testUsername";
+    protected static final String TEST_USER2_USERNAME = "testUsername2";
+    protected static final String TEST_USER_PASSWORD = "TestPassword@123";
+    protected static final String TEST_USER_CLAIM_VALUE = "testNickName";
+    protected static final String TEST_USER_UPDATED_CLAIM_VALUE = "updateTestNickName";
+    protected static final String TEST_USER_GIVEN_NAME = "test_user_given_name";
+    protected static final String TEST_USER_LASTNAME = "test_user_last_name";
+    protected static final String TEST_USER_EMAIL = "test.user@gmail.com";
+    protected static final String NICK_NAME_CLAIM_URI = "http://wso2.org/claims/nickname";
+    protected static final String PRIMARY_USER_STORE_ID = "UFJJTUFSWQ==";
+    protected static final String PRIMARY_USER_STORE_NAME = "PRIMARY";
+    protected static final String USER_SYSTEM_SCHEMA_ATTRIBUTE ="urn:scim:wso2:schema";
+    protected static final String FORCE_PASSWORD_RESET_ATTRIBUTE = "forcePasswordReset";
+    protected static final String PRE_UPDATE_PROFILE_API_PATH = "preUpdateProfile";
+    protected static final String ACTION_NAME = "Pre Update Profile Action";
+    protected static final String ACTION_DESCRIPTION = "This is a test for pre update profile action type";
+    protected static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+    protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+
+    protected static final String ACCOUNT_DISABLED_ATTRIBUTE = "accountDisabled";
+    protected static final String GIVEN_NAME = "givenName";
+
+    protected CloseableHttpClient client;
+    protected IdentityGovernanceRestClient identityGovernanceRestClient;
+
+    private final CookieStore cookieStore = new BasicCookieStore();
+
+    /**
+     * Initialize the test case.
+     *
+     * @param userMode User Mode
+     * @throws Exception If an error occurred while initializing the clients.
+     */
+    protected void init(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultCookieStore(cookieStore)
+                .build();
+
+        identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
+    }
+
+    protected String createPreUpdateProfileAction(String actionName, String actionDescription) throws IOException {
+
+        AuthenticationType authentication = new AuthenticationType()
+                .type(AuthenticationType.TypeEnum.BASIC)
+                .putPropertiesItem(USERNAME_PROPERTY, MOCK_SERVER_AUTH_BASIC_USERNAME)
+                .putPropertiesItem(PASSWORD_PROPERTY, MOCK_SERVER_AUTH_BASIC_PASSWORD);
+
+        Endpoint endpoint = new Endpoint()
+                .uri(EXTERNAL_SERVICE_URI)
+                .authentication(authentication);
+
+        PreUpdateProfileActionModel actionModel = new PreUpdateProfileActionModel();
+        actionModel.setName(actionName);
+        actionModel.setDescription(actionDescription);
+        actionModel.setEndpoint(endpoint);
+        actionModel.setAttributes(Collections.singletonList("http://wso2.org/claims/nickname"));
+
+        return createAction(PRE_UPDATE_PROFILE_API_PATH, actionModel);
+    }
+
+    protected String getTokenWithClientCredentialsGrant(String applicationId, String clientId, String clientSecret) throws Exception {
+
+        if (!CarbonUtils.isLegacyAuthzRuntimeEnabled()) {
+            authorizeSystemAPIs(applicationId, Collections.singletonList(SCIM2_USERS_API));
+        }
+
+        List<String> requestedScopes = new ArrayList<>();
+        Collections.addAll(requestedScopes,INTERNAL_USER_MANAGEMENT_UPDATE);
+        String scopes = String.join(" ", requestedScopes);
+
+        List<NameValuePair> parameters = new ArrayList<>();
+        parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
+        parameters.add(new BasicNameValuePair("scope", scopes));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER, OAuth2Constant.BASIC_HEADER + " " +
+                getBase64EncodedString(clientId, clientSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(client, headers, parameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+
+        assertTrue(jsonResponse.has("access_token"));
+        return jsonResponse.getString("access_token");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionFailureTestCase.java
@@ -38,8 +38,16 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
+/**
+ * Integration test class for testing the pre update profile action execution.
+ * This test case extends {@link ActionsBaseTestCase} and focuses on failure scenarios related
+ * to profile update flows.
+ */
 public class PreUpdateProfileActionFailureTestCase extends PreUpdateProfileActionBaseTestCase {
 
     private final String tenantId;
@@ -244,3 +252,4 @@ public class PreUpdateProfileActionFailureTestCase extends PreUpdateProfileActio
         assertEquals(request.getClaims()[0].getValue(), updateClaimValue);
     }
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionFailureTestCase.java
@@ -156,7 +156,6 @@ public class PreUpdateProfileActionFailureTestCase extends PreUpdateProfileActio
         deleteApp(application.getId());
         scim2RestClient.deleteUser(userId);
         restClient.closeHttpClient();
-        identityGovernanceRestClient.closeHttpClient();
         scim2RestClient.closeHttpClient();
         actionsRestClient.closeHttpClient();
         client.close();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionFailureTestCase.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preupdateprofile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.*;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.user.common.model.*;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UsersRestClient;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ActionResponse;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ExpectedProfileUpdateResponse;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.serviceextensions.model.*;
+import org.wso2.identity.integration.test.util.Utils;
+import org.wso2.identity.integration.test.utils.FileUtils;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.testng.Assert.*;
+
+public class PreUpdateProfileActionFailureTestCase extends PreUpdateProfileActionBaseTestCase {
+
+    private final String tenantId;
+    private final TestUserMode userMode;
+
+    private SCIM2RestClient scim2RestClient;
+    private UsersRestClient usersRestClient;
+
+    private String clientId;
+    private String clientSecret;
+    private String actionId;
+    private String userId;
+    private ApplicationResponseModel application;
+    private ServiceExtensionMockServer serviceExtensionMockServer;
+    private final ActionResponse actionResponse;
+    private final ExpectedProfileUpdateResponse expectedProfileUpdateResponse;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public PreUpdateProfileActionFailureTestCase(TestUserMode testUserMode, ActionResponse actionResponse,
+                                                 ExpectedProfileUpdateResponse expectedProfileUpdateResponse) {
+
+        this.userMode = testUserMode;
+        this.tenantId = testUserMode == TestUserMode.SUPER_TENANT_USER ? "-1234" : "1";
+        this.actionResponse = actionResponse;
+        this.expectedProfileUpdateResponse = expectedProfileUpdateResponse;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() throws IOException, URISyntaxException {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(HttpServletResponse.SC_OK,
+                        FileUtils.readFileInClassPathAsString("actions/response/failure-response.json")),
+                        new ExpectedProfileUpdateResponse(HttpServletResponse.SC_BAD_REQUEST,
+                                "Some failure reason",
+                                "Some description")},
+                {TestUserMode.TENANT_USER, new ActionResponse(HttpServletResponse.SC_OK,
+                        FileUtils.readFileInClassPathAsString("actions/response/failure-response.json")),
+                        new ExpectedProfileUpdateResponse(HttpServletResponse.SC_BAD_REQUEST,
+                                "Some failure reason",
+                                "Some description")},
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        FileUtils.readFileInClassPathAsString("actions/response/error-response.json")),
+                        new ExpectedProfileUpdateResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                                "Invalid value",
+                                "Error while updating attributes of user")},
+                {TestUserMode.TENANT_USER, new ActionResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        FileUtils.readFileInClassPathAsString("actions/response/error-response.json")),
+                        new ExpectedProfileUpdateResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                                "Invalid value",
+                                "Error while updating attributes of user")},
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        usersRestClient = new UsersRestClient(serverURL, tenantInfo);
+
+        application = addApplicationWithGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(application.getId());
+        clientId = oidcConfig.getClientId();
+        clientSecret = oidcConfig.getClientSecret();
+
+        UserObject userInfo = new UserObject()
+                .userName(TEST_USER1_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
+                .addEmail(new Email().value(TEST_USER_EMAIL));
+        userId = scim2RestClient.createUser(userInfo);
+
+        actionId = createPreUpdateProfileAction(ACTION_NAME, ACTION_DESCRIPTION);
+
+        serviceExtensionMockServer = new ServiceExtensionMockServer();
+        serviceExtensionMockServer.startServer();
+        serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
+                        MOCK_SERVER_AUTH_BASIC_PASSWORD),
+                actionResponse.getResponseBody(), actionResponse.getStatusCode());
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        serviceExtensionMockServer.resetRequests();
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        deleteAction(PRE_UPDATE_PROFILE_API_PATH, actionId);
+        deleteApp(application.getId());
+        scim2RestClient.deleteUser(userId);
+        restClient.closeHttpClient();
+        identityGovernanceRestClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        client.close();
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        serviceExtensionMockServer.stopServer();
+        serviceExtensionMockServer = null;
+    }
+
+    @Test(description = "Verify the profile update in self service portal with pre update profile action")
+    public void testUserUpdateProfile() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
+        userPatchOp.setPath("name.givenName");
+        userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserMe(patchUserInfo,
+                TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(), TEST_USER_PASSWORD);
+
+        assertNotNull(response);
+        String status = response.get("status").toString();
+        assertEquals(status, String.valueOf(expectedProfileUpdateResponse.getStatusCode()));
+        if (status.equals(String.valueOf(HttpServletResponse.SC_OK))) {
+            assertEquals(response.get("scimType"), String.valueOf(expectedProfileUpdateResponse.getErrorMessage()));
+        }
+        assertTrue(response.get("detail").toString().contains(expectedProfileUpdateResponse.getErrorDetail()));
+        assertActionRequestPayload(userId, TEST_USER_GIVEN_NAME, TEST_USER_UPDATED_CLAIM_VALUE, PreUpdateProfileEvent.FlowInitiatorType.USER,
+                PreUpdateProfileEvent.Action.UPDATE);
+    }
+
+    @Test(dependsOnMethods = "testUserUpdateProfile" ,
+            description = "Verify the admin update profile with pre update profile action")
+    public void testAdminUpdateProfile() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
+        userPatchOp.setPath("name.givenName");
+        userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserAndReturnResponse(patchUserInfo, userId);
+
+        assertNotNull(response);
+        String status = response.get("status").toString();
+        assertEquals(status, String.valueOf(expectedProfileUpdateResponse.getStatusCode()));
+        if (status.equals(String.valueOf(HttpServletResponse.SC_OK))) {
+            assertEquals(response.get("scimType"), String.valueOf(expectedProfileUpdateResponse.getErrorMessage()));
+        }
+        assertTrue(response.get("detail").toString().contains(expectedProfileUpdateResponse.getErrorDetail()));
+        assertActionRequestPayload(userId, TEST_USER_GIVEN_NAME, TEST_USER_UPDATED_CLAIM_VALUE, PreUpdateProfileEvent.FlowInitiatorType.ADMIN,
+                PreUpdateProfileEvent.Action.UPDATE);
+    }
+
+    @Test(dependsOnMethods = "testAdminUpdateProfile",
+            description = "Verify the application update profile with pre update profile action")
+    public void testApplicationUpdateProfile() throws Exception {
+
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
+        userPatchOp.setPath("name.givenName");
+        userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
+
+        assertNotNull(response);
+        String status = response.get("status").toString();
+        assertEquals(status, String.valueOf(expectedProfileUpdateResponse.getStatusCode()));
+        if (status.equals(String.valueOf(HttpServletResponse.SC_OK))) {
+            assertEquals(response.get("scimType"), String.valueOf(expectedProfileUpdateResponse.getErrorMessage()));
+        }
+        assertTrue(response.get("detail").toString().contains(expectedProfileUpdateResponse.getErrorDetail()));
+        assertActionRequestPayload(userId, TEST_USER_GIVEN_NAME, TEST_USER_UPDATED_CLAIM_VALUE, PreUpdateProfileEvent.FlowInitiatorType.APPLICATION,
+                PreUpdateProfileEvent.Action.UPDATE);
+    }
+
+    private void assertActionRequestPayload(String userId, String currentClaimValue, String updateClaimValue,
+                                            PreUpdateProfileEvent.FlowInitiatorType initiatorType,
+                                            PreUpdateProfileEvent.Action action) throws JsonProcessingException {
+
+        String actualRequestPayload = serviceExtensionMockServer.getReceivedRequestPayload(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
+        PreUpdateProfileActionRequest actionRequest = new ObjectMapper()
+                .readValue(actualRequestPayload, PreUpdateProfileActionRequest.class);
+
+        assertEquals(actionRequest.getActionType(), ActionType.PRE_UPDATE_PROFILE);
+        assertEquals(actionRequest.getEvent().getTenant().getName(), tenantInfo.getDomain());
+        assertEquals(actionRequest.getEvent().getTenant().getId(), tenantId);
+        assertEquals(actionRequest.getEvent().getUserStore().getName(), PRIMARY_USER_STORE_NAME);
+        assertEquals(actionRequest.getEvent().getUserStore().getId(), PRIMARY_USER_STORE_ID);
+        assertEquals(actionRequest.getEvent().getInitiatorType(), initiatorType);
+        assertEquals(actionRequest.getEvent().getAction(), action);
+
+        ProfileUpdatingUser user = actionRequest.getEvent().getProfileUpdatingUser();
+
+        assertEquals(user.getId(), userId);
+        assertEquals(user.getClaims()[0].getUri(), NICK_NAME_CLAIM_URI);
+        assertEquals(user.getClaims()[0].getUpdatingValue(), updateClaimValue);
+        assertEquals(user.getClaims()[0].getValue(), currentClaimValue);
+
+        PreUpdateProfileRequest request = actionRequest.getEvent().getRequest();
+
+        assertEquals(request.getClaims()[0].getUri(), NICK_NAME_CLAIM_URI);
+        assertNull(request.getClaims()[0].getUpdatingValue());
+        assertEquals(request.getClaims()[0].getValue(), updateClaimValue);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
@@ -127,7 +127,6 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
         deleteApp(application.getId());
         scim2RestClient.deleteUser(userId);
         restClient.closeHttpClient();
-        identityGovernanceRestClient.closeHttpClient();
         scim2RestClient.closeHttpClient();
         actionsRestClient.closeHttpClient();
         client.close();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preupdateprofile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.*;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.serviceextensions.model.*;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.user.common.model.*;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UsersRestClient;
+import org.wso2.identity.integration.test.utils.FileUtils;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+
+/**
+ * Integration test class for testing the pre update profile action execution.
+ * This test case extends {@link ActionsBaseTestCase} and focuses on success scenarios related
+ * to profile update flows.
+ */
+public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActionBaseTestCase {
+
+    private final String tenantId;
+    private final TestUserMode userMode;
+
+    private SCIM2RestClient scim2RestClient;
+    private UsersRestClient usersRestClient;
+
+    private String clientId;
+    private String clientSecret;
+    private String actionId;
+    private String userId;
+    private String currentClaimValue;
+    private ApplicationResponseModel application;
+    private ServiceExtensionMockServer serviceExtensionMockServer;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public PreUpdateProfileActionSuccessTestCase(TestUserMode testUserMode) {
+
+        userMode = testUserMode;
+        this.tenantId = testUserMode == TestUserMode.SUPER_TENANT_USER ? "-1234" : "1";
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER},
+                {TestUserMode.TENANT_USER}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        usersRestClient = new UsersRestClient(serverURL, tenantInfo);
+
+        application = addApplicationWithGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(application.getId());
+        clientId = oidcConfig.getClientId();
+        clientSecret = oidcConfig.getClientSecret();
+
+        UserObject userInfo = new UserObject()
+                .userName(TEST_USER1_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
+                .addEmail(new Email().value(TEST_USER_EMAIL));
+        userId = scim2RestClient.createUser(userInfo);
+        currentClaimValue = TEST_USER_GIVEN_NAME;
+        actionId = createPreUpdateProfileAction(ACTION_NAME, ACTION_DESCRIPTION);
+
+        serviceExtensionMockServer = new ServiceExtensionMockServer();
+        serviceExtensionMockServer.startServer();
+        serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
+                        MOCK_SERVER_AUTH_BASIC_PASSWORD),
+                FileUtils.readFileInClassPathAsString("actions/response/pre-update-profile-response.json"));
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        serviceExtensionMockServer.resetRequests();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        deleteAction(PRE_UPDATE_PROFILE_API_PATH, actionId);
+        deleteApp(application.getId());
+        scim2RestClient.deleteUser(userId);
+        restClient.closeHttpClient();
+        identityGovernanceRestClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        client.close();
+        serviceExtensionMockServer.stopServer();
+        serviceExtensionMockServer = null;
+    }
+
+    @Test(description = "Verify the profile update in self service portal with pre update profile action for add operation")
+    public void testUserUpdateProfileWithAddOperation() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
+        userPatchOp.setPath("nickName");
+        userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserMe(patchUserInfo,
+                TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(), TEST_USER_PASSWORD);
+
+        assertNotNull(response);
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.ADD, userId, TEST_USER_CLAIM_VALUE, TEST_USER_CLAIM_VALUE,
+                PreUpdateProfileEvent.FlowInitiatorType.USER, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testUserUpdateProfileWithAddOperation" ,
+            description = "Verify the profile update in self service portal with pre update profile action for replace operation")
+    public void testUserUpdateProfileWithReplaceOperation() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
+        userPatchOp.setPath("nickName");
+        userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserMe(patchUserInfo,
+                TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(), TEST_USER_PASSWORD);
+
+        assertNotNull(response);
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.REPLACE, userId, currentClaimValue, TEST_USER_UPDATED_CLAIM_VALUE,
+                PreUpdateProfileEvent.FlowInitiatorType.USER, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_UPDATED_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testUserUpdateProfileWithReplaceOperation" ,
+            description = "Verify the profile update in self service portal with pre update profile action for remove operation")
+    public void testUserUpdateProfileWithRemoveOperation() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REMOVE);
+        userPatchOp.setPath("nickName");
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserMe(patchUserInfo,
+                TEST_USER1_USERNAME + "@" + tenantInfo.getDomain(), TEST_USER_PASSWORD);
+
+        assertNotNull(response);
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.REMOVE, userId, currentClaimValue, "",
+                PreUpdateProfileEvent.FlowInitiatorType.USER, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testUserUpdateProfileWithRemoveOperation" ,
+            description = "Verify the admin update profile with pre update profile action for add operation")
+    public void testAdminUpdateProfileWithAddOperation() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
+        userPatchOp.setPath("nickName");
+        userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        scim2RestClient.updateUser(patchUserInfo, userId);
+
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.ADD, userId, currentClaimValue, TEST_USER_CLAIM_VALUE,
+                PreUpdateProfileEvent.FlowInitiatorType.ADMIN, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testAdminUpdateProfileWithAddOperation" ,
+            description = "Verify the admin update profile with pre update profile action for replace operation")
+    public void testAdminUpdateProfileWithReplaceOperation() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
+        userPatchOp.setPath("nickName");
+        userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        scim2RestClient.updateUser(patchUserInfo, userId);
+
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.REPLACE, userId, currentClaimValue, TEST_USER_UPDATED_CLAIM_VALUE,
+                PreUpdateProfileEvent.FlowInitiatorType.ADMIN, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_UPDATED_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testAdminUpdateProfileWithReplaceOperation" ,
+            description = "Verify the admin update profile with pre update profile action for remove operation")
+    public void testAdminUpdateProfileWithRemoveOperation() throws Exception {
+
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REMOVE);
+        userPatchOp.setPath("nickName");
+        //userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        scim2RestClient.updateUser(patchUserInfo, userId);
+
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.REMOVE, userId, currentClaimValue, "",
+                PreUpdateProfileEvent.FlowInitiatorType.ADMIN, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testAdminUpdateProfileWithRemoveOperation",
+            description = "Verify the application update profile with pre update profile action for add operation")
+    public void testApplicationUpdateProfileWithAddOperation() throws Exception {
+
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
+        userPatchOp.setPath("nickName");
+        userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
+
+        assertNotNull(response);
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.ADD, userId, currentClaimValue, TEST_USER_CLAIM_VALUE,
+                PreUpdateProfileEvent.FlowInitiatorType.APPLICATION, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testApplicationUpdateProfileWithAddOperation",
+            description = "Verify the application update profile with pre update profile action for replace operation")
+    public void testApplicationUpdateProfileWithReplaceOperation() throws Exception {
+
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
+        userPatchOp.setPath("nickName");
+        userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
+
+        assertNotNull(response);
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.REPLACE, userId, currentClaimValue, TEST_USER_UPDATED_CLAIM_VALUE,
+                PreUpdateProfileEvent.FlowInitiatorType.APPLICATION, PreUpdateProfileEvent.Action.UPDATE);
+        currentClaimValue = TEST_USER_UPDATED_CLAIM_VALUE;
+    }
+
+    @Test(dependsOnMethods = "testApplicationUpdateProfileWithReplaceOperation",
+            description = "Verify the application update profile with pre update profile action for remove operation")
+    public void testApplicationUpdateProfileWithRemoveOperation() throws Exception {
+
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
+        UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REMOVE);
+        userPatchOp.setPath("nickName");
+        PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
+                .addOperations(userPatchOp);
+        org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
+
+        assertNotNull(response);
+        assertActionRequestPayload(UserItemAddGroupobj.OpEnum.REMOVE, userId, currentClaimValue, "",
+                PreUpdateProfileEvent.FlowInitiatorType.APPLICATION, PreUpdateProfileEvent.Action.UPDATE);
+    }
+
+    private void assertActionRequestPayload(UserItemAddGroupobj.OpEnum operation,String userId, String currentClaimValue,
+                                            String updateClaimValue, PreUpdateProfileEvent.FlowInitiatorType initiatorType,
+                                            PreUpdateProfileEvent.Action action) throws JsonProcessingException {
+
+        String actualRequestPayload = serviceExtensionMockServer.getReceivedRequestPayload(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
+        PreUpdateProfileActionRequest actionRequest = new ObjectMapper()
+                .readValue(actualRequestPayload, PreUpdateProfileActionRequest.class);
+
+        assertEquals(actionRequest.getActionType(), ActionType.PRE_UPDATE_PROFILE);
+        assertEquals(actionRequest.getEvent().getTenant().getName(), tenantInfo.getDomain());
+        assertEquals(actionRequest.getEvent().getTenant().getId(), tenantId);
+        assertEquals(actionRequest.getEvent().getUserStore().getName(), PRIMARY_USER_STORE_NAME);
+        assertEquals(actionRequest.getEvent().getUserStore().getId(), PRIMARY_USER_STORE_ID);
+        assertEquals(actionRequest.getEvent().getInitiatorType(), initiatorType);
+        assertEquals(actionRequest.getEvent().getAction(), action);
+
+        ProfileUpdatingUser user = actionRequest.getEvent().getProfileUpdatingUser();
+
+        assertEquals(user.getId(), userId);
+        if (operation == UserItemAddGroupobj.OpEnum.ADD) {
+            assertNull(user.getClaims());
+        } else if (operation == UserItemAddGroupobj.OpEnum.REPLACE) {
+            assertEquals(user.getClaims()[0].getUri(), NICK_NAME_CLAIM_URI);
+            assertEquals(user.getClaims()[0].getUpdatingValue(), updateClaimValue);
+            assertEquals(user.getClaims()[0].getValue(), currentClaimValue);
+        } else if (operation == UserItemAddGroupobj.OpEnum.REMOVE) {
+            assertEquals(user.getClaims()[0].getUri(), NICK_NAME_CLAIM_URI);
+            assertEquals(user.getClaims()[0].getValue(), currentClaimValue);
+        }
+
+        PreUpdateProfileRequest request = actionRequest.getEvent().getRequest();
+
+        assertEquals(request.getClaims()[0].getUri(), NICK_NAME_CLAIM_URI);
+        assertNull(request.getClaims()[0].getUpdatingValue());
+        assertEquals(request.getClaims()[0].getValue(), updateClaimValue);
+    }
+
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
@@ -129,7 +129,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
     public void testUserUpdateProfileWithAddOperation() throws Exception {
 
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -147,7 +147,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
     public void testUserUpdateProfileWithReplaceOperation() throws Exception {
 
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -165,7 +165,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
     public void testUserUpdateProfileWithRemoveOperation() throws Exception {
 
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REMOVE);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
         org.json.simple.JSONObject response = scim2RestClient.updateUserMe(patchUserInfo,
@@ -182,7 +182,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
     public void testAdminUpdateProfileWithAddOperation() throws Exception {
 
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -198,7 +198,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
     public void testAdminUpdateProfileWithReplaceOperation() throws Exception {
 
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REPLACE);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -214,7 +214,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
     public void testAdminUpdateProfileWithRemoveOperation() throws Exception {
 
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REMOVE);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         //userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -231,7 +231,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
 
         String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         userPatchOp.setValue(TEST_USER_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -249,7 +249,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
 
         String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.ADD);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         userPatchOp.setValue(TEST_USER_UPDATED_CLAIM_VALUE);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
@@ -267,7 +267,7 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
 
         String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         UserItemAddGroupobj userPatchOp = new UserItemAddGroupobj().op(UserItemAddGroupobj.OpEnum.REMOVE);
-        userPatchOp.setPath("nickName");
+        userPatchOp.setPath(NICK_NAME_USER_SCHEMA_NAME);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
                 .addOperations(userPatchOp);
         org.json.simple.JSONObject response = scim2RestClient.updateUserWithBearerToken(patchUserInfo, userId, token);
@@ -313,5 +313,5 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
         assertNull(request.getClaims()[0].getUpdatingValue());
         assertEquals(request.getClaims()[0].getValue(), updateClaimValue);
     }
-
 }
+

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-update-profile-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-update-profile-response.json
@@ -1,0 +1,3 @@
+{
+  "actionStatus": "SUCCESS"
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -143,6 +143,8 @@
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionSuccessTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionFailureTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionSmsOtpFailureTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preupdateprofile.PreUpdateProfileActionSuccessTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preupdateprofile.PreUpdateProfileActionFailureTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCHybridFlowIntegrationTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsGrantTypesTestCase"/>


### PR DESCRIPTION
#### Description

This PR adds Integration Tests for Pre Update Profile Action. This includes both Success and Failed Test scenarios for,

-  User profile update for ADD,REPLACE, REMOVE operations
-  Admin profile update for ADD, REPLACE, REMOVE operations
-  Application profile update for ADD, REPLACE, REMOVE operations

#### Related issue in product-is
- https://github.com/wso2/product-is/issues/23549