### PR TITLE
Align integration tests with organization info addition in Pre-Issue Access Token request

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Organization.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Organization.java
@@ -29,6 +29,8 @@ public class Organization {
 
     private String name;
 
+    private String orgHandle;
+
     public Organization(String id, String name) {
 
         this.id = id;
@@ -57,6 +59,16 @@ public class Organization {
     public void setName(String name) {
 
         this.name = name;
+    }
+
+    public String getOrgHandle() {
+
+        return orgHandle;
+    }
+
+    public void setOrgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
     }
 
     @Override

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/User.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/User.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 public class User {
 
     private String id;
+    private Organization organization;
 
     public User(String id) {
 
@@ -44,6 +45,16 @@ public class User {
     public void setId(String id) {
 
         this.id = id;
+    }
+
+    public Organization getOrganization() {
+
+        return organization;
+    }
+
+    public void setOrganization(Organization organization) {
+
+        this.organization = organization;
     }
 
     @Override


### PR DESCRIPTION
This PR updates the integration tests to reflect the recent enhancement that adds organization information to the PreIssueAccessTokenRequest.

The changes ensure compatibility with the updated request structure by:
Updating the test model classes to include the organization and user fields.

No changes to core logic or functionality—this is solely to keep tests in sync with the latest modification.