### PR TITLE
Bump oauth version for organization information in pre issue access token request payloads.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2525,7 +2525,7 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.0.298</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.301</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.11.55</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.12.11</identity.inbound.auth.sts.version>


### PR DESCRIPTION
Bump oauth version for organization information in pre issue access token request payloads.

Parent issue

- https://github.com/wso2/product-is/issues/24186