### PR TITLE
Disable fail-fast in test runner strategy.

### DIFF
--- a/.github/workflows/integration-test-runner-JDK11.yml
+++ b/.github/workflows/integration-test-runner-JDK11.yml
@@ -18,6 +18,7 @@ jobs:
   run-test-runners:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runner_id: 1


### PR DESCRIPTION
### Purpose
- $subject due to one test runner failure will cancel the other test runners too. 
- With this config now all the runners will be complete even the one of them fail and developer can identify all the test failure with a single run.