### PR TITLE
Make bearer token part in the authorisation header case insensitive

### DIFF
--- a/oidc-fapi-conformance-tests/resource-server/resource-server.py
+++ b/oidc-fapi-conformance-tests/resource-server/resource-server.py
@@ -34,7 +34,7 @@ def getAccessToken(request):
     if authHeader is None:
         raise Unauthorized('Missing Authorization header.')
     authHeaderParts = authHeader.split(" ")
-    if len(authHeaderParts) != 2 or authHeaderParts[0] != 'Bearer':
+    if len(authHeaderParts) != 2 or authHeaderParts[0].lower() != 'bearer':
         raise Unauthorized('Bearer token missing.')
     accessToken = authHeaderParts[1]
     if accessToken == None or accessToken == '':


### PR DESCRIPTION
Part of https://github.com/wso2/product-is/issues/22178

OIDC FAPI Conformance suite is calling this /resource endpoint to test the bearer token authorisation header