### PR TITLE
bump event handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2555,7 +2555,7 @@
         <identity.event.handler.account.lock.version>1.9.16</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.9.61</identity.event.handler.notification.version>
 
-        <org.wso2.identity.webhook.event.handlers.version>1.0.315</org.wso2.identity.webhook.event.handlers.version>
+        <org.wso2.identity.webhook.event.handlers.version>1.0.318</org.wso2.identity.webhook.event.handlers.version>
 
         <org.wso2.identity.event.publishers.version>1.0.25</org.wso2.identity.event.publishers.version>
 


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file. The change upgrades the version of the `org.wso2.identity.webhook.event.handlers` dependency from `1.0.315` to `1.0.318`.