### PR TITLE
Bump api-server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2651,7 +2651,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.141</identity.server.api.version>
+        <identity.server.api.version>1.3.142</identity.server.api.version>
         <identity.user.api.version>1.3.65</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
This pull request includes a minor version update to the `identity.server.api.version` in the `pom.xml` file, changing it from `1.3.141` to `1.3.142`.