### PR TITLE
Override the console config to show IS version

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -48,6 +48,7 @@
 
   "monitoring.jmx.rmi_server_start": false,
   "product.version" : "${product.version}",
+  "console.product_version.configs.productVersion": "${product.version}",
 
   "transport.http.enabled" : true,
   "transport.https.enabled" : true,


### PR DESCRIPTION
Override the existing console config to show IS version

Related issue https://github.com/wso2/product-is/issues/24623