### PR TITLE
bump webhook event handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2565,7 +2565,7 @@
         <identity.event.handler.account.lock.version>1.9.18</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.9.63</identity.event.handler.notification.version>
 
-        <org.wso2.identity.webhook.event.handlers.version>1.0.343</org.wso2.identity.webhook.event.handlers.version>
+        <org.wso2.identity.webhook.event.handlers.version>1.0.344</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.0.26</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->


### PR DESCRIPTION
This pull request includes a version update in the `pom.xml` file. The version of `org.wso2.identity.webhook.event.handlers` has been incremented from `1.0.343` to `1.0.344` to include the latest changes or fixes.