### PR TITLE
Integration Tests for organization management API get response improvements

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementBaseTest.java
@@ -77,6 +77,8 @@ public class OrganizationManagementBaseTest extends RESTAPIServerTestBase {
     protected static final String ORGANIZATION_ID = "id";
     protected static final String ORGANIZATION_NAME = "name";
     protected static final String ORGANIZATION_HANDLE = "orgHandle";
+    protected static final String HAS_CHILDREN = "hasChildren";
+    protected static final String ANCESTOR_PATH = "ancestorPath";
     protected static final String ORGANIZATION_NAME_FORMAT = "Org-%d";
 
     protected static final String ORGANIZATION_EMAIL_FORMAT_1 = "org%d.com";

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/organization-self-service-apis.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/organization-self-service-apis.json
@@ -30,6 +30,7 @@
     "internal_org_application_mgt_view"
   ],
   "/o/api/server/v1/organizations": [
+    "internal_org_organization_view",
     "internal_org_organization_create",
     "internal_org_organization_delete"
   ]

--- a/pom.xml
+++ b/pom.xml
@@ -2645,7 +2645,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.146</identity.server.api.version>
+        <identity.server.api.version>1.3.147</identity.server.api.version>
         <identity.user.api.version>1.3.66</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION

This pull request enhances the organization management integration tests by adding new test cases and updating dependencies. The changes include adding new constants, importing additional libraries, introducing new test methods for verifying organization attributes, and updating the project dependencies.

Part of https://github.com/wso2/product-is/issues/24612

### Enhancements to Organization Management Tests:

* [`OrganizationManagementBaseTest.java`](diffhunk://#diff-41a8eb44a3115cad08f6f190369ca54b615a3681acf20f4798ccda67ddce781fR80-R81): Added new constants `HAS_CHILDREN` and `ANCESTOR_PATH` to support testing organization attributes.
* `OrganizationManagementSuccessTest.java`:
  - Imported `HttpGet` and `JsonArray` to support new test methods. [[1]](diffhunk://#diff-6182fbc9926b22a5008177b6a7cc195cb07d398642fef23599465cbe590d25e0R21) [[2]](diffhunk://#diff-6182fbc9926b22a5008177b6a7cc195cb07d398642fef23599465cbe590d25e0R51)
  - Introduced three new test methods:
    1. `testHasChildrenStatusOnOrganizationList`: Verifies the `hasChildren` attribute in the organization list.
    2. `testAncestorPathOfChildFromRoot`: Validates the `ancestorPath` attribute for a child organization accessed from the root.
    3. `testAncestorPathOfChildFromParent`: Checks the `ancestorPath` attribute for a child organization accessed from its parent.
  - Updated existing test methods (`testPatchOrganizationName` and `testPutOrganization`) to assert the `HAS_CHILDREN` attribute. [[1]](diffhunk://#diff-6182fbc9926b22a5008177b6a7cc195cb07d398642fef23599465cbe590d25e0R588) [[2]](diffhunk://#diff-6182fbc9926b22a5008177b6a7cc195cb07d398642fef23599465cbe590d25e0L536-R603)

### Configuration and Dependency Updates:

* [`organization-self-service-apis.json`](diffhunk://#diff-af121a04d8434b7c3705cd340a7238fe6686ba5e9d3f5142324c223a21fa5c06R33): Added a new permission, `internal_org_organization_view`, to the `/o/api/server/v1/organizations` endpoint.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2648-R2648): Upgraded `identity.server.api.version` from `1.3.146` to `1.3.147`.