### PR TITLE
Bump event core updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2514,7 +2514,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.299</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.303-SNAPSHOT</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2565,7 +2565,7 @@
         <identity.event.handler.account.lock.version>1.9.18</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.9.63</identity.event.handler.notification.version>
 
-        <org.wso2.identity.webhook.event.handlers.version>1.0.348</org.wso2.identity.webhook.event.handlers.version>
+        <org.wso2.identity.webhook.event.handlers.version>1.0.349-SNAPSHOT</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.0.26</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
@@ -2645,7 +2645,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.148</identity.server.api.version>
+        <identity.server.api.version>1.3.151-SNAPSHOT</identity.server.api.version>
         <identity.user.api.version>1.3.66</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
This pull request updates several dependency versions in the `pom.xml` file to their latest `-SNAPSHOT` versions. These changes ensure compatibility with the latest development versions of the respective components.

Dependency version updates:

* Updated `carbon.identity.framework.version` from `7.8.299` to `7.8.303-SNAPSHOT`.
* Updated `org.wso2.identity.webhook.event.handlers.version` from `1.0.348` to `1.0.349-SNAPSHOT`.
* Updated `identity.server.api.version` from `1.3.148` to `1.3.151-SNAPSHOT`.