### PR TITLE
Pack http publisher

### DIFF
--- a/modules/connectors/pom.xml
+++ b/modules/connectors/pom.xml
@@ -191,6 +191,29 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>download_http_publisher</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2.identity.event.publishers</groupId>
+                                    <artifactId>
+                                        org.wso2.identity.event.http.publisher
+                                    </artifactId>
+                                    <version>${org.wso2.identity.event.publishers.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/target/authenticatorCopied/jar
+                                    </outputDirectory>
+                                    <includes>**/*.jar</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -378,6 +378,11 @@
                                     org.wso2.identity.webhook.event.handlers:org.wso2.identity.webhook.event.handlers.server.feature:${org.wso2.identity.webhook.event.handlers.version}
                                 </featureArtifactDef>
 
+                                <!-- Common Event Publisher Feature -->
+                                <featureArtifactDef>
+                                    org.wso2.identity.event.publishers:org.wso2.identity.event.http.publisher.server.feature:${org.wso2.identity.event.publishers.version}
+                                </featureArtifactDef>
+
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.system.config.mgt.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
@@ -940,6 +945,10 @@
                                 <feature>
                                     <id>org.wso2.identity.webhook.event.handlers.server.feature.group</id>
                                     <version>${org.wso2.identity.webhook.event.handlers.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.identity.event.http.publisher.server.feature.group</id>
+                                    <version>${org.wso2.identity.event.publishers.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.certificate.management.server.feature.group</id>

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -378,11 +378,6 @@
                                     org.wso2.identity.webhook.event.handlers:org.wso2.identity.webhook.event.handlers.server.feature:${org.wso2.identity.webhook.event.handlers.version}
                                 </featureArtifactDef>
 
-                                <!-- Common Event Publisher Feature -->
-                                <featureArtifactDef>
-                                    org.wso2.identity.event.publishers:org.wso2.identity.event.http.publisher.server.feature:${org.wso2.identity.event.publishers.version}
-                                </featureArtifactDef>
-
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.system.config.mgt.server.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
@@ -945,10 +940,6 @@
                                 <feature>
                                     <id>org.wso2.identity.webhook.event.handlers.server.feature.group</id>
                                     <version>${org.wso2.identity.webhook.event.handlers.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.identity.event.http.publisher.server.feature.group</id>
-                                    <version>${org.wso2.identity.event.publishers.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.certificate.management.server.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2519,7 +2519,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.319</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.322</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2571,7 +2571,7 @@
         <identity.event.handler.notification.version>1.9.63</identity.event.handler.notification.version>
 
         <org.wso2.identity.webhook.event.handlers.version>1.0.349</org.wso2.identity.webhook.event.handlers.version>
-        <org.wso2.identity.event.publishers.version>1.0.31-SNAPSHOT</org.wso2.identity.event.publishers.version>
+        <org.wso2.identity.event.publishers.version>1.0.31</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -2519,7 +2519,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.318</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.319</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2571,7 +2571,7 @@
         <identity.event.handler.notification.version>1.9.63</identity.event.handler.notification.version>
 
         <org.wso2.identity.webhook.event.handlers.version>1.0.349</org.wso2.identity.webhook.event.handlers.version>
-        <org.wso2.identity.event.publishers.version>1.0.31</org.wso2.identity.event.publishers.version>
+        <org.wso2.identity.event.publishers.version>1.0.31-SNAPSHOT</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -1807,6 +1807,11 @@
                 <version>${org.wso2.identity.webhook.event.handlers.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.identity.event.publishers</groupId>
+                <artifactId>org.wso2.identity.event.http.publisher</artifactId>
+                <version>${org.wso2.identity.event.publishers.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.metadata.saml2</groupId>
                 <artifactId>org.wso2.carbon.identity.idp.metadata.saml2.server.feature</artifactId>
                 <version>${identity.metadata.saml.version}</version>
@@ -2514,7 +2519,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.317</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.318</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2566,7 +2571,7 @@
         <identity.event.handler.notification.version>1.9.63</identity.event.handler.notification.version>
 
         <org.wso2.identity.webhook.event.handlers.version>1.0.349</org.wso2.identity.webhook.event.handlers.version>
-        <org.wso2.identity.event.publishers.version>1.0.26</org.wso2.identity.event.publishers.version>
+        <org.wso2.identity.event.publishers.version>1.0.31-SNAPSHOT</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
         <!--<identity.carbon.auth.signedjwt.version>5.1.1</identity.carbon.auth.signedjwt.version>-->


### PR DESCRIPTION
### Purpose

This pull request updates the `pom.xml` files to include new dependencies and configurations for the HTTP event publisher, as well as version upgrades for related components. The most important changes include adding a new Maven plugin execution, introducing a new dependency for the HTTP event publisher, and updating version properties for various components.

### Additions for HTTP Event Publisher:
* [`modules/connectors/pom.xml`](diffhunk://#diff-8b3341cfeffcd397bd00714bb6661ba2447fcf20795e68c5a53325f88b7eefcbR194-R216): Added a new Maven plugin execution to copy the `org.wso2.identity.event.http.publisher` artifact during the `compile` phase. This includes specifying the artifact details and output directory.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R1809-R1813): Added a new dependency for `org.wso2.identity.event.http.publisher` to integrate the HTTP event publisher into the project.

### Version Updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2517-R2522): Updated the `carbon.identity.framework.version` property from `7.8.317` to `7.8.319`.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2569-R2574): Updated the `org.wso2.identity.event.publishers.version` property from `1.0.26` to `1.0.31`.