### PR TITLE
Add depth attribute to Organization object in actions Tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Organization.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Organization.java
@@ -31,6 +31,8 @@ public class Organization {
 
     private String orgHandle;
 
+    private int depth;
+
     public Organization(String id, String name) {
 
         this.id = id;
@@ -69,6 +71,16 @@ public class Organization {
     public void setOrgHandle(String orgHandle) {
 
         this.orgHandle = orgHandle;
+    }
+
+    public int getDepth() {
+
+        return depth;
+    }
+
+    public void setDepth(int depth) {
+
+        this.depth = depth;
     }
 
     @Override


### PR DESCRIPTION
### Purpose
> This will add the new `depth` attribute to the Organization object in the action request payload

### Related PR
- https://github.com/wso2/carbon-identity-framework/pull/6989

### Related Issue
- 