### PR TITLE
Bump framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2519,7 +2519,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.339</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.342</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
$subject

This pull request updates the version of the Carbon Identity Framework dependency in the `pom.xml` file.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2522-R2522): Updated the `carbon.identity.framework.version` from `7.8.339` to `7.8.342` to include the latest fixes and improvements.