### PR TITLE
Update the order

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -285,6 +285,12 @@
     </classes>
 </test>
 
+<test name="is-test-webhooks" preserve-order="true" parallel="false">
+    <classes>
+        <class name="org.wso2.identity.integration.test.webhooks.usermanagement.AdminInitUserManagementEventTestCase"/>
+    </classes>
+</test>
+
 <test name="is-tests-scim2" preserve-order="true" parallel="false">
     <classes>
         <class name="org.wso2.identity.integration.test.scim2.SCIM2PaginationTestCase"/>
@@ -363,12 +369,6 @@
         <class name="org.wso2.identity.integration.test.user.mgt.uuid.UUIDUserManagerInitializerTestCase"/>
         <class name="org.wso2.identity.integration.test.user.mgt.uuid.ReadWriteLDAPUUIDUMTestCase"/>
         <class name="org.wso2.identity.integration.test.user.mgt.uuid.JDBCUUIDUMTestCase"/>
-    </classes>
-</test>
-
-<test name="is-test-webhooks" preserve-order="true" parallel="false">
-    <classes>
-        <class name="org.wso2.identity.integration.test.webhooks.usermanagement.AdminInitUserManagementEventTestCase"/>
     </classes>
 </test>
 


### PR DESCRIPTION
This pull request updates the `testng.xml` file in the integration tests to reorganize the placement of the `is-test-webhooks` test block. The changes involve moving this test block to a different section of the file to align with the intended test structure.

### Test configuration updates:

* Moved the `<test name="is-test-webhooks">` block, which includes the `AdminInitUserManagementEventTestCase` class, from its original location to an earlier section in the `testng.xml` file. This ensures proper ordering and grouping of related tests. [[1]](diffhunk://#diff-1b74947603b96c39cb701293ed58cdfd520e3fb3dc1e7e455ca179ea1e763cd0R288-R293) [[2]](diffhunk://#diff-1b74947603b96c39cb701293ed58cdfd520e3fb3dc1e7e455ca179ea1e763cd0L369-L374)