### PR TITLE
Fix email body decoding to extract reset link correctly

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -207,7 +207,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
 
         Assert.assertTrue(org.wso2.identity.integration.test.util.Utils.getMailServer().waitForIncomingEmail(10000, 1));
         Message[] messages = org.wso2.identity.integration.test.util.Utils.getMailServer().getReceivedMessages();
-        String body = GreenMailUtil.getBody(messages[0]).replaceAll("=\r?\n", "");
+        String body = GreenMailUtil.getBody(messages[0]).replaceAll("=3D", "=").replaceAll("=\r?\n", "");
         Document doc = Jsoup.parse(body);
 
         return doc.selectFirst("#bodyCell").selectFirst("a").attr("href");


### PR DESCRIPTION
### Purpose
Fix decoding issues in the email body content to correctly extract the password reset URL during integration tests.

### Implementation
Updated the regex to replace =3D with = in the email body, addressing quoted-printable encoding issues.

### Related Issue
- https://github.com/wso2/product-is/issues/24771