### PR TITLE
Update SharedUserProfileClaimMgtTestCase to support the new claim inheritance architecture

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -621,9 +621,11 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
             description = "Verify the claims resolved from first found in hierarchy.")
     public void testClaimsResolvedFromFirstFoundInHierarchy() throws Exception {
 
-        // Sub orgs should not have custom claim before shared app mark it as requested claim.
-        verifyCustomClaimIsNotShared(customClaimId, switchedM2MTokenForLevel1Org);
-        verifyCustomClaimIsNotShared(customClaimId, switchedM2MTokenForLevel2Org);
+        if (TestUserMode.TENANT_ADMIN.equals(userMode)) {
+            // V0 sub-orgs should not have custom claims before a shared app marks them as requested claims.
+            verifyCustomClaimIsNotShared(customClaimId, switchedM2MTokenForLevel1Org);
+            verifyCustomClaimIsNotShared(customClaimId, switchedM2MTokenForLevel2Org);
+        }
 
         updateRequestedClaimsOfApp(application1WithAppAudienceRoles.getId(), getClaimConfigurationsWithCustomClaim());
 


### PR DESCRIPTION
## Purpose

The current default behaviour is that carbon.super is v1 while new root orgs are v0.

With [1], v1 organizations will inherit custom claims automatically even before they are requested by applications. 

Therefore, this PR updates the SharedUserProfileClaimMgtTestCase to support the new claim inheritance architecture in the following manner.

- For carbon.super (v1), skip the claim absence check, request the claims for the app, check whether the attribute is present **after** sharing.
  - Until the changes for [1] are merged, v0 and v1 organizations will behave the same, while the integration tests for the PR [1] will require the new behaviour. Therefore, for backward compatibility, the check whether claims are present is left after the attribute requesting step. 
- For wso2.com (v0 new root org), check whether the attribute is absent before sharing the app, share the app, then check whether the attribute is present (same as the existing tests).

Once the integration tests are run and the framework PR is merged, this logic will be further updated to test in the following manner:

- For carbon.super (v1), check whether the attribute is present **before** sharing, then request the claims for the app.
- For wso2.com (v0 new root org), check whether the attribute is absent before sharing the app, share the app, then check whether the attribute is present (same as the existing tests).