### PR TITLE
Temporarily update SharedUserProfileClaimMgtTestCase to check the behaviour of v0 orgs.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -131,6 +131,7 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
     private static final String ISS_CLAIM = "iss";
     private static final String ORG_ID_CLAIM = "org_id";
     private static final String ORG_NAME_CLAIM = "org_name";
+    private static final String ORG_VERSION_V0 = "v0.0.0";
     private final TestUserMode userMode;
     private ClaimManagementRestClient claimManagementRestClient;
     private SCIM2RestClient scim2RestClient;
@@ -202,6 +203,10 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
 
         switchedM2MTokenForLevel1Org = orgMgtRestClient.switchM2MToken(level1OrgId);
         switchedM2MTokenForLevel2Org = orgMgtRestClient.switchM2MToken(level2OrgId);
+
+        if (TestUserMode.TENANT_ADMIN.equals(userMode)) {
+            orgMgtRestClient.updateOrganizationVersion(ORG_VERSION_V0);
+        }
 
         // Create a custom claim setting FromFirstFoundInHierarchy as SharedProfileValueResolvingMethod.
         LocalClaimReq localClaimReq = buildLocalClaimReq(CUSTOM_CLAIM_URI, CUSTOM_CLAIM_NAME, CUSTOM_CLAIM_NAME,

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/authorized-apis.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/user/profile/mgt/authorized-apis.json
@@ -2,6 +2,7 @@
   "/api/server/v1/organizations": [
     "internal_organization_view",
     "internal_organization_create",
+    "internal_organization_update",
     "internal_organization_delete"
   ],
   "/o/scim2/Users": [


### PR DESCRIPTION
### Purpose
with [1] root orgs apart from carbon.super will be v1. This pr will temporally update the SharedUserProfileClaimMgtTestCase to make sure the behaviour for v0 orgs are verified until the tests are updated with [2]

[1] - https://github.com/wso2/carbon-identity-framework/pull/7105
[2] - https://github.com/wso2/product-is/issues/24283