### PR TITLE
Comment out the is-test-webhooks test case in testng.xml

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -287,11 +287,11 @@
     </classes>
 </test>
 
-<test name="is-test-webhooks" preserve-order="true" parallel="false">
+<!-- <test name="is-test-webhooks" preserve-order="true" parallel="false">
     <classes>
         <class name="org.wso2.identity.integration.test.webhooks.usermanagement.AdminInitUserManagementEventTestCase"/>
     </classes>
-</test>
+</test> -->
 
 <test name="is-tests-scim2" preserve-order="true" parallel="false">
     <classes>


### PR DESCRIPTION
This pull request makes a minor change to the integration test configuration. The `is-test-webhooks` test suite has been commented out in the `testng.xml` file, which will prevent the webhooks-related tests from running during backend integration testing.