### PR TITLE
Bump framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2535,7 +2535,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.9.38</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.9.39</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file, upgrading the `carbon.identity.framework.version` from `7.9.38` to `7.9.39`.