### PR TITLE
Update Carbon Identity Framework version to 7.9.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2535,7 +2535,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.9.42</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.9.43</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request makes a minor update to the project dependencies by bumping the Carbon Identity Framework version in `pom.xml` from 7.9.42 to 7.9.43.