### PR TITLE
Bump framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2535,7 +2535,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.9.43</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.9.45</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request makes a minor update to the project dependencies by bumping the `carbon.identity.framework.version` in the `pom.xml` file from `7.9.43` to `7.9.45`. This ensures the project uses the latest compatible version of the Carbon Identity Framework.