### PR TITLE
Add Integration Tests for Pre-Update Password Action in Registration Flow

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/FlowExecutionClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/FlowExecutionClient.java
@@ -26,6 +26,7 @@ import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowExecutionRequest;
@@ -132,5 +133,21 @@ public class FlowExecutionClient extends RestBaseClient {
                 Base64.encodeBase64String((username + ":" + password).getBytes()).trim());
         headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
         return headerList;
+    }
+
+    public JSONObject executeFlowAndReturnResponse(FlowExecutionRequest userRegistrationRequest) {
+
+        String jsonRequestBody = toJSONString(userRegistrationRequest);
+        String executionUrl = flowExecutionBasePath + PATH_SEPARATOR + FLOW_EXECUTION_ENDPOINT;
+        try (CloseableHttpResponse response = getResponseOfHttpPost(executionUrl, jsonRequestBody,
+                getHeadersWithBasicAuth())) {
+            String responseString = EntityUtils.toString(response.getEntity());
+            JSONObject responseObject = new JSONObject();
+            responseObject.put("statusCode", response.getStatusLine().getStatusCode());
+            responseObject.put("body", responseString);
+            return responseObject;
+        } catch (Exception e) {
+            throw new RuntimeException("Error while executing the flow.", e);
+        }
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/FlowExecutionClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/FlowExecutionClient.java
@@ -134,20 +134,4 @@ public class FlowExecutionClient extends RestBaseClient {
         headerList[2] = new BasicHeader(CONTENT_TYPE_ATTRIBUTE, String.valueOf(ContentType.JSON));
         return headerList;
     }
-
-    public JSONObject executeFlowAndReturnResponse(FlowExecutionRequest userRegistrationRequest) {
-
-        String jsonRequestBody = toJSONString(userRegistrationRequest);
-        String executionUrl = flowExecutionBasePath + PATH_SEPARATOR + FLOW_EXECUTION_ENDPOINT;
-        try (CloseableHttpResponse response = getResponseOfHttpPost(executionUrl, jsonRequestBody,
-                getHeadersWithBasicAuth())) {
-            String responseString = EntityUtils.toString(response.getEntity());
-            JSONObject responseObject = new JSONObject();
-            responseObject.put("statusCode", response.getStatusLine().getStatusCode());
-            responseObject.put("body", responseString);
-            return responseObject;
-        } catch (Exception e) {
-            throw new RuntimeException("Error while executing the flow.", e);
-        }
-    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/FlowExecutionClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/FlowExecutionClient.java
@@ -26,7 +26,6 @@ import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
-import org.json.simple.JSONObject;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowExecutionRequest;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -885,9 +885,10 @@ public class SCIM2RestClient extends RestBaseClient {
      *
      * @param appRegisteredUserInfo UserObject containing user details.
      * @param token                 Bearer token for authentication.
-     * @return ID of the created user.
+     * @param returnFullResponse    Flag to determine whether to return the full response as a JSONObject.
+     * @return Object containing either the user ID (String) or the full response (JSONObject), depending on the flag.
      */
-    public String createUserWithBearerToken(UserObject appRegisteredUserInfo, String token) {
+    public Object createUserWithBearerToken(UserObject appRegisteredUserInfo, String token, boolean returnFullResponse) {
         String jsonRequest = toJSONString(appRegisteredUserInfo);
         if (appRegisteredUserInfo.getScimSchemaExtensionEnterprise() != null) {
             jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_ENTERPRISE, USER_ENTERPRISE_SCHEMA);
@@ -898,13 +899,38 @@ public class SCIM2RestClient extends RestBaseClient {
 
         try (CloseableHttpResponse response = getResponseOfHttpPost(getUsersPath(), jsonRequest,
                 getHeadersWithBearerToken(token))) {
-            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
-                    "User creation failed");
-            JSONObject jsonResponse = getJSONObject(EntityUtils.toString(response.getEntity()));
-            return jsonResponse.get("id").toString();
+            int statusCode = response.getStatusLine().getStatusCode();
+            String responseString = response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : "";
+
+            if (!returnFullResponse) {
+                Assert.assertEquals(statusCode, HttpServletResponse.SC_CREATED, "User creation failed");
+                JSONObject jsonResponse = getJSONObject(responseString);
+                return jsonResponse.get("id").toString();
+            }
+
+            if (responseString == null || responseString.trim().isEmpty()) {
+                JSONObject result = new JSONObject();
+                result.put("status", statusCode);
+                result.put("message", "Empty response body");
+                return result;
+            }
+
+            try {
+                return getJSONObject(responseString);
+            } catch (org.json.simple.parser.ParseException pe) {
+                JSONObject errorObj = new JSONObject();
+                errorObj.put("error", "ParseException: " + pe.getMessage());
+                errorObj.put("rawResponse", responseString);
+                errorObj.put("statusCode", statusCode);
+                return errorObj;
+            }
         } catch (Exception e) {
-            Assert.fail("Error occurred while creating user with bearer token.", e);
-            return null;
+            if (!returnFullResponse) {
+                return null;
+            }
+            JSONObject errorObj = new JSONObject();
+            errorObj.put("error", "Exception: " + (e.getMessage() != null ? e.getMessage() : e.getClass().getName()));
+            return errorObj;
         }
     }
 
@@ -940,65 +966,6 @@ public class SCIM2RestClient extends RestBaseClient {
             JSONObject errorObj = new JSONObject();
             errorObj.put("error", "Exception: " + (e.getMessage() != null ? e.getMessage() : e.getClass().getName()));
             return errorObj;
-        }
-    }
-
-    /**
-     * Create a user with the provided bearer token and return the full response as a JSONObject.
-     * This method does not assert the response status code, allowing the caller to handle different scenarios.
-     *
-     * @param appRegisteredUserInfo UserObject containing user details.
-     * @param token                 Bearer token for authentication.
-     * @return JSONObject containing the full response, including status code and any error messages.
-     */
-    public JSONObject createUserWithBearerTokenAndReturnResponse(UserObject appRegisteredUserInfo, String token) {
-        String jsonRequest = toJSONString(appRegisteredUserInfo);
-        if (appRegisteredUserInfo.getScimSchemaExtensionEnterprise() != null) {
-            jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_ENTERPRISE, USER_ENTERPRISE_SCHEMA);
-        }
-        if (appRegisteredUserInfo.getScimSchemaExtensionSystem() != null) {
-            jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_SYSTEM, USER_SYSTEM_SCHEMA);
-        }
-
-        try (CloseableHttpResponse response = getResponseOfHttpPost(getUsersPath(), jsonRequest,
-                getHeadersWithBearerToken(token))) {
-            int statusCode = response.getStatusLine().getStatusCode();
-            String responseString = response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : "";
-            if (responseString == null || responseString.trim().isEmpty()) {
-                JSONObject result = new JSONObject();
-                result.put("status", statusCode);
-                result.put("message", "Empty response body");
-                return result;
-            }
-            try {
-                return getJSONObject(responseString);
-            } catch (org.json.simple.parser.ParseException pe) {
-                JSONObject errorObj = new JSONObject();
-                errorObj.put("error", "ParseException: " + pe.getMessage());
-                errorObj.put("rawResponse", responseString);
-                errorObj.put("statusCode", statusCode);
-                return errorObj;
-            }
-        } catch (Exception e) {
-            JSONObject errorObj = new JSONObject();
-            errorObj.put("error", "Exception: " + (e.getMessage() != null ? e.getMessage() : e.getClass().getName()));
-            return errorObj;
-        }
-    }
-
-    /**
-     * Get the ID of a user by username.
-     *
-     * @param s Username of the user.
-     * @return ID of the user.
-     */
-    public String getUserId(String s) {
-        try {
-            JSONObject user = getUser(s, null);
-            return user.get("id").toString();
-        } catch (Exception e) {
-            Assert.fail("Error occurred while retrieving user ID.", e);
-            return null;
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -881,12 +881,12 @@ public class SCIM2RestClient extends RestBaseClient {
     }
 
     /**
-     * Create a user with the provided bearer token.
+     * Create a user with bearer token and return either the user ID or the full response based on the flag.
      *
      * @param appRegisteredUserInfo UserObject containing user details.
      * @param token                 Bearer token for authentication.
-     * @param returnFullResponse    Flag to determine whether to return the full response as a JSONObject.
-     * @return Object containing either the user ID (String) or the full response (JSONObject), depending on the flag.
+     * @param returnFullResponse    If true, returns the full response as a JSONObject. if false, returns only the user ID.
+     * @return Either the user ID (String) or the full response based on the flag.
      */
     public Object createUserWithBearerToken(UserObject appRegisteredUserInfo, String token, boolean returnFullResponse) {
         String jsonRequest = toJSONString(appRegisteredUserInfo);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -121,13 +121,11 @@ public class SCIM2RestClient extends RestBaseClient {
         Header[] headers = (bearerToken != null) ? getHeadersWithBearerToken(bearerToken) : getHeaders();
         String usersPath = getUsersPath();
         try (CloseableHttpResponse response = getResponseOfHttpPost(usersPath, jsonRequest, headers)) {
-
             String responseString = EntityUtils.toString(response.getEntity());
             JSONObject responseObject = new JSONObject();
             responseObject.put("statusCode", response.getStatusLine().getStatusCode());
             responseObject.put("body", responseString);
             return responseObject;
-
         } catch (Exception e) {
             throw new RuntimeException("Error while creating the user.", e);
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -121,10 +121,10 @@ public class SCIM2RestClient extends RestBaseClient {
         Header[] headers = (bearerToken != null) ? getHeadersWithBearerToken(bearerToken) : getHeaders();
         String usersPath = getUsersPath();
         try (CloseableHttpResponse response = getResponseOfHttpPost(usersPath, jsonRequest, headers)) {
-            String responseString = EntityUtils.toString(response.getEntity());
+            JSONObject jsonResponse = getJSONObject(EntityUtils.toString(response.getEntity()));
             JSONObject responseObject = new JSONObject();
             responseObject.put("statusCode", response.getStatusLine().getStatusCode());
-            responseObject.put("body", responseString);
+            responseObject.put("body", jsonResponse);
             return responseObject;
         } catch (Exception e) {
             throw new RuntimeException("Error while creating the user.", e);
@@ -419,6 +419,25 @@ public class SCIM2RestClient extends RestBaseClient {
                 getHeadersWithBearerToken(switchedM2MToken))) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_NO_CONTENT,
                     "User deletion failed.");
+        }
+    }
+
+    /**
+     * Get the details of a user by filtering with the given filter.
+     *
+     * @param filter filter string.
+     * @return JSONObject of the HTTP response.
+     * @throws Exception If an error occurred while getting a user.
+     */
+    public JSONObject filterUsers(String filter) throws Exception {
+
+        String endPointUrl = getUsersPath();
+        if (StringUtils.isNotEmpty(filter)) {
+            endPointUrl += "?filter=" + filter;
+        }
+
+        try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -102,13 +102,13 @@ public class SCIM2RestClient extends RestBaseClient {
     }
 
     /**
-     * Create a user with a bearer token.
+     * Create a user with bearer token.
      *
-     * @param userInfo    Object with user creation details.
+     * @param userInfo object with user creation details.
      * @param bearerToken Bearer token to be used in the request.
      * @return JSONObject of the HTTP response.
      */
-    public JSONObject createUserWithBearerToken(UserObject userInfo, String bearerToken) {
+    public JSONObject createUser(UserObject userInfo, String bearerToken) {
         
         String jsonRequest = toJSONString(userInfo);
         if (userInfo.getScimSchemaExtensionEnterprise() != null) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/SCIM2RestClient.java
@@ -109,6 +109,7 @@ public class SCIM2RestClient extends RestBaseClient {
      * @return JSONObject of the HTTP response.
      */
     public JSONObject createUserWithBearerToken(UserObject userInfo, String bearerToken) {
+        
         String jsonRequest = toJSONString(userInfo);
         if (userInfo.getScimSchemaExtensionEnterprise() != null) {
             jsonRequest = jsonRequest.replace(SCIM_SCHEMA_EXTENSION_ENTERPRISE, USER_ENTERPRISE_SCHEMA);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -290,10 +290,22 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         return createAction(PRE_UPDATE_PASSWORD_API_PATH, actionModel);
     }
 
-    protected String getTokenWithClientCredentialsGrant(String applicationId, String clientId, String clientSecret,
-                                                        String scope) throws Exception {
+    protected String getTokenWithClientCredentialsGrant(String applicationId, String clientId,
+                                                        String clientSecret, String actionType) throws Exception {
         if (!CarbonUtils.isLegacyAuthzRuntimeEnabled()) {
             authorizeSystemAPIs(applicationId, Collections.singletonList(SCIM2_USERS_API));
+        }
+
+        String scope;
+        switch (actionType) {
+            case "update":
+                scope = "internal_user_mgt_update";
+                break;
+            case "create":
+                scope = "internal_user_mgt_create";
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported action type: " + actionType);
         }
 
         List<NameValuePair> parameters = new ArrayList<>();
@@ -315,4 +327,5 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         assertTrue(jsonResponse.has("access_token"));
         return jsonResponse.getString("access_token");
     }
+
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowConfig;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowExecutionRequest;
 import org.wso2.identity.integration.test.rest.api.server.flow.management.v1.model.FlowRequest;
+import org.wso2.identity.integration.test.restclients.FlowExecutionClient;
 import org.wso2.identity.integration.test.restclients.FlowManagementClient;
 import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
 import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.AuthenticationType;
@@ -103,9 +104,12 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
     protected static final String REGISTRATION_FLOW =
             "/org/wso2/identity/integration/test/rest/api/server/flow/execution/v1/registration-flow.json";
+    protected static final String REGISTRATION_FLOW_TYPE = "REGISTRATION";
 
     protected CloseableHttpClient client;
     protected IdentityGovernanceRestClient identityGovernanceRestClient;
+    protected FlowExecutionClient flowExecutionClient;
+    protected FlowManagementClient flowManagementClient;
 
     private final CookieStore cookieStore = new BasicCookieStore();
 
@@ -325,20 +329,22 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         return jsonResponse.getString("access_token");
     }
 
-    protected void enableFlow(FlowManagementClient client, String flowType) throws Exception {
+    protected void updateFlowStatus(String flowType, boolean enable) throws Exception {
 
         FlowConfig flowConfigDTO = new FlowConfig();
-        flowConfigDTO.setIsEnabled(true);
+        flowConfigDTO.setIsEnabled(enable);
         flowConfigDTO.setFlowType(flowType);
-        client.updateFlowConfig(flowConfigDTO);
+        flowManagementClient.updateFlowConfig(flowConfigDTO);
     }
 
-    protected void disableFlow(FlowManagementClient client, String flowType) throws Exception {
+    protected void enableFlow(String flowType) throws Exception {
 
-        FlowConfig flowConfigDTO = new FlowConfig();
-        flowConfigDTO.setIsEnabled(false);
-        flowConfigDTO.setFlowType(flowType);
-        client.updateFlowConfig(flowConfigDTO);
+        updateFlowStatus(flowType, true);
+    }
+
+    protected void disableFlow(String flowType) throws Exception {
+
+        updateFlowStatus(flowType, false);
     }
 
     protected void addRegistrationFlow(FlowManagementClient client) throws Exception {
@@ -352,7 +358,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     protected FlowExecutionRequest buildUserRegistrationFlowRequest() {
 
         FlowExecutionRequest flowExecutionRequest = new FlowExecutionRequest();
-        flowExecutionRequest.setFlowType("REGISTRATION");
+        flowExecutionRequest.setFlowType(REGISTRATION_FLOW_TYPE);
         flowExecutionRequest.setActionId("button_5zqc");
 
         Map<String, String> inputs = new HashMap<>();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -337,16 +337,6 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         flowManagementClient.updateFlowConfig(flowConfigDTO);
     }
 
-    protected void enableFlow(String flowType) throws Exception {
-
-        updateFlowStatus(flowType, true);
-    }
-
-    protected void disableFlow(String flowType) throws Exception {
-
-        updateFlowStatus(flowType, false);
-    }
-
     protected void addRegistrationFlow(FlowManagementClient client) throws Exception {
 
         String registrationFlowRequestJson = readResource(REGISTRATION_FLOW, this.getClass());

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -350,6 +350,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     }
 
     protected FlowExecutionRequest buildUserRegistrationFlowRequest() {
+
         FlowExecutionRequest flowExecutionRequest = new FlowExecutionRequest();
         flowExecutionRequest.setFlowType("REGISTRATION");
         flowExecutionRequest.setActionId("button_5zqc");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -46,7 +46,6 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowConfig;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowExecutionRequest;
 import org.wso2.identity.integration.test.rest.api.server.flow.management.v1.model.FlowRequest;
-import org.wso2.identity.integration.test.restclients.FlowExecutionClient;
 import org.wso2.identity.integration.test.restclients.FlowManagementClient;
 import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
 import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.AuthenticationType;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -77,6 +77,9 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
 
     protected static final String TEST_USER1_USERNAME = "testUsername";
     protected static final String TEST_USER2_USERNAME = "testUsername2";
+    protected static final String TEST_USER3_USERNAME = "testUsername3";
+    protected static final String TEST_USER4_USERNAME = "testUsername4";
+    protected static final String TEST_USER5_USERNAME = "testUsername5";
     protected static final String TEST_USER_PASSWORD = "TestPassword@123";
     protected static final String TEST_USER_UPDATED_PASSWORD = "UpdatedTestPassword@123";
     protected static final String RESET_PASSWORD = "ResetTestPassword@123";
@@ -92,6 +95,8 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String ACTION_DESCRIPTION = "This is a test for pre update password action type";
     protected static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+    protected static final String REGISTRATION_FLOW =
+            "/org/wso2/identity/integration/test/rest/api/server/flow/execution/v1/registration-flow.json";
 
 
     protected CloseableHttpClient client;
@@ -285,8 +290,8 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         return createAction(PRE_UPDATE_PASSWORD_API_PATH, actionModel);
     }
 
-    protected String getTokenWithClientCredentialsGrant(String applicationId, String clientId, String clientSecret) throws Exception {
-
+    protected String getTokenWithClientCredentialsGrant(String applicationId, String clientId, String clientSecret,
+                                                        String scope) throws Exception {
         if (!CarbonUtils.isLegacyAuthzRuntimeEnabled()) {
             authorizeSystemAPIs(applicationId, Collections.singletonList(SCIM2_USERS_API));
         }
@@ -297,7 +302,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
 
         List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
-        parameters.add(new BasicNameValuePair("scope", scopes));
+        parameters.add(new BasicNameValuePair("scope", scope));
 
         List<Header> headers = new ArrayList<>();
         headers.add(new BasicHeader(AUTHORIZATION_HEADER, OAuth2Constant.BASIC_HEADER + " " +

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -296,10 +296,6 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
             authorizeSystemAPIs(applicationId, Collections.singletonList(SCIM2_USERS_API));
         }
 
-        List<String> requestedScopes = new ArrayList<>();
-        Collections.addAll(requestedScopes,INTERNAL_USER_MANAGEMENT_UPDATE);
-        String scopes = String.join(" ", requestedScopes);
-
         List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
         parameters.add(new BasicNameValuePair("scope", scope));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -87,9 +87,6 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
 
     protected static final String TEST_USER1_USERNAME = "testUsername";
     protected static final String TEST_USER2_USERNAME = "testUsername2";
-    protected static final String TEST_USER3_USERNAME = "testUsername3";
-    protected static final String TEST_USER4_USERNAME = "testUsername4";
-    protected static final String TEST_USER5_USERNAME = "testUsername5";
     protected static final String TEST_USER_PASSWORD = "TestPassword@123";
     protected static final String TEST_USER_UPDATED_PASSWORD = "UpdatedTestPassword@123";
     protected static final String RESET_PASSWORD = "ResetTestPassword@123";
@@ -107,7 +104,6 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
     protected static final String REGISTRATION_FLOW =
             "/org/wso2/identity/integration/test/rest/api/server/flow/execution/v1/registration-flow.json";
-
 
     protected CloseableHttpClient client;
     protected IdentityGovernanceRestClient identityGovernanceRestClient;
@@ -307,7 +303,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         }
 
         List<String> requestedScopes = new ArrayList<>();
-        Collections.addAll(requestedScopes,INTERNAL_USER_MANAGEMENT_UPDATE, INTERNAL_USER_MANAGEMENT_CREATE);
+        Collections.addAll(requestedScopes, INTERNAL_USER_MANAGEMENT_UPDATE, INTERNAL_USER_MANAGEMENT_CREATE);
         String scopes = String.join(" ", requestedScopes);
 
         List<NameValuePair> parameters = new ArrayList<>();
@@ -330,32 +326,28 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         return jsonResponse.getString("access_token");
     }
 
-    protected void enableFlow(FlowManagementClient client) throws Exception {
+    protected void enableFlow(FlowManagementClient client, String flowType) throws Exception {
 
         FlowConfig flowConfigDTO = new FlowConfig();
         flowConfigDTO.setIsEnabled(true);
-        flowConfigDTO.setFlowType(FlowTypes.REGISTRATION);
+        flowConfigDTO.setFlowType(flowType);
         client.updateFlowConfig(flowConfigDTO);
     }
 
-    protected void disableFlow(FlowManagementClient client) throws Exception {
+    protected void disableFlow(FlowManagementClient client, String flowType) throws Exception {
 
         FlowConfig flowConfigDTO = new FlowConfig();
         flowConfigDTO.setIsEnabled(false);
-        flowConfigDTO.setFlowType(FlowTypes.REGISTRATION);
+        flowConfigDTO.setFlowType(flowType);
         client.updateFlowConfig(flowConfigDTO);
     }
 
     protected void addRegistrationFlow(FlowManagementClient client) throws Exception {
+
         String registrationFlowRequestJson = readResource(REGISTRATION_FLOW, this.getClass());
         FlowRequest flowRequest = new ObjectMapper()
                 .readValue(registrationFlowRequestJson, FlowRequest.class);
         client.putFlow(flowRequest);
-    }
-
-    protected static class FlowTypes {
-
-        public static final String REGISTRATION = "REGISTRATION";
     }
 
     protected FlowExecutionRequest buildUserRegistrationFlowRequest() {
@@ -364,7 +356,7 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         flowExecutionRequest.setActionId("button_5zqc");
 
         Map<String, String> inputs = new HashMap<>();
-        inputs.put("http://wso2.org/claims/username", TEST_USER5_USERNAME);
+        inputs.put("http://wso2.org/claims/username", TEST_USER2_USERNAME);
         inputs.put("password", TEST_USER_PASSWORD);
         inputs.put("http://wso2.org/claims/emailaddress", TEST_USER_EMAIL);
         inputs.put("http://wso2.org/claims/givenname", TEST_USER_GIVEN_NAME);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -135,6 +135,8 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
                 .setDefaultCookieStore(cookieStore)
                 .build();
 
+        flowExecutionClient = new FlowExecutionClient(serverURL, tenantInfo);
+        flowManagementClient = new FlowManagementClient(serverURL, tenantInfo);
         identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -350,7 +350,10 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         assertEquals(statusCode, expectedPasswordUpdateResponse.getStatusCode());
 
         org.json.simple.JSONObject body = (org.json.simple.JSONObject) response.get("body");
-        if (expectedPasswordUpdateResponse.getStatusCode() == HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
+        if (expectedPasswordUpdateResponse.getStatusCode() == HttpServletResponse.SC_BAD_REQUEST) {
+            assertEquals(body.get("scimType"), expectedPasswordUpdateResponse.getErrorMessage());
+            assertTrue(body.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
+        } else if (expectedPasswordUpdateResponse.getStatusCode() == HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
             assertTrue(body.get("detail").toString().contains("Error in adding the user"));
         }
         assertActionRequestPayload(null, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
@@ -374,7 +377,10 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         assertEquals(statusCode, expectedPasswordUpdateResponse.getStatusCode());
 
         org.json.simple.JSONObject body = (org.json.simple.JSONObject) response.get("body");
-        if (expectedPasswordUpdateResponse.getStatusCode() == HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
+        if (expectedPasswordUpdateResponse.getStatusCode() == HttpServletResponse.SC_BAD_REQUEST) {
+            assertEquals(body.get("scimType"), expectedPasswordUpdateResponse.getErrorMessage());
+            assertTrue(body.get("detail").toString().contains(expectedPasswordUpdateResponse.getErrorDetail()));
+        } else if (expectedPasswordUpdateResponse.getStatusCode() == HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
             assertTrue(body.get("detail").toString().contains("Error in adding the user"));
         }
         assertActionRequestPayload(null, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -154,7 +154,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
                         MOCK_SERVER_AUTH_BASIC_PASSWORD),
                 actionResponse.getResponseBody(), actionResponse.getStatusCode());
-        enableFlow(flowManagementClient);
+        enableFlow(flowManagementClient, "REGISTRATION");
         addRegistrationFlow(flowManagementClient);
     }
 
@@ -182,7 +182,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         Utils.getMailServer().purgeEmailFromAllMailboxes();
         serviceExtensionMockServer.stopServer();
         serviceExtensionMockServer = null;
-        disableFlow(flowManagementClient);
+        disableFlow(flowManagementClient, "REGISTRATION");
     }
 
     @Test(description = "Verify the password update in self service portal with pre update password action")
@@ -344,7 +344,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
     public void testAdminInitiatedUserRegistration() throws Exception {
 
         UserObject adminRegisteredUserInfo = new UserObject()
-                .userName(TEST_USER3_USERNAME)
+                .userName(TEST_USER2_USERNAME)
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
@@ -370,7 +370,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
 
         String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         UserObject appRegisteredUserInfo = new UserObject()
-                .userName(TEST_USER4_USERNAME)
+                .userName(TEST_USER2_USERNAME)
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -28,10 +28,8 @@ import org.jsoup.select.Elements;
 import org.testng.Assert;
 import org.testng.annotations.*;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
-import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowConfig;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowExecutionRequest;
 import org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.model.FlowExecutionResponse;
-import org.wso2.identity.integration.test.rest.api.server.flow.management.v1.model.FlowRequest;
 import org.wso2.identity.integration.test.restclients.*;
 import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
 import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ActionResponse;
@@ -46,9 +44,7 @@ import org.wso2.identity.integration.test.restclients.UsersRestClient;
 import org.wso2.identity.integration.test.util.Utils;
 import org.wso2.identity.integration.test.utils.FileUtils;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
@@ -188,54 +184,6 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         serviceExtensionMockServer = null;
         disableFlow(flowManagementClient);
     }
-    protected void enableFlow(FlowManagementClient client) throws Exception {
-
-        FlowConfig flowConfigDTO = new FlowConfig();
-        flowConfigDTO.setIsEnabled(true);
-        flowConfigDTO.setFlowType(PreUpdatePasswordActionSuccessTestCase.FlowTypes.REGISTRATION);
-        client.updateFlowConfig(flowConfigDTO);
-    }
-
-    protected void disableFlow(FlowManagementClient client) throws Exception {
-
-        FlowConfig flowConfigDTO = new FlowConfig();
-        flowConfigDTO.setIsEnabled(false);
-        flowConfigDTO.setFlowType(FlowTypes.REGISTRATION);
-        client.updateFlowConfig(flowConfigDTO);
-    }
-
-    protected void addRegistrationFlow(FlowManagementClient client) throws Exception {
-        String registrationFlowRequestJson = readResource(REGISTRATION_FLOW);
-        FlowRequest flowRequest = new ObjectMapper()
-                .readValue(registrationFlowRequestJson, FlowRequest.class);
-        client.putFlow(flowRequest);
-    }
-
-    protected String readResource(String filename) throws IOException {
-
-        return readResource(filename, this.getClass());
-    }
-
-    public static String readResource(String filename, Class cClass) throws IOException {
-
-        try (InputStream resourceAsStream = cClass.getResourceAsStream(filename);
-             BufferedInputStream bufferedInputStream = new BufferedInputStream(resourceAsStream)) {
-            StringBuilder resourceFile = new StringBuilder();
-
-            int character;
-            while ((character = bufferedInputStream.read()) != -1) {
-                char value = (char) character;
-                resourceFile.append(value);
-            }
-
-            return resourceFile.toString();
-        }
-    }
-
-    protected static class FlowTypes {
-
-        public static final String REGISTRATION = "REGISTRATION";
-    }
 
     @Test(description = "Verify the password update in self service portal with pre update password action")
     public void testUserUpdatePassword() throws Exception {
@@ -345,7 +293,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the password update by an authorized application with pre update password action")
     public void testApplicationUpdatePassword() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret, "update");
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         Map<String, String> passwordValue = new HashMap<>();
         passwordValue.put(PASSWORD_PROPERTY, TEST_USER_PASSWORD);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
@@ -420,8 +368,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the application initiated user registration with pre update password action failure")
     public void testApplicationInitiatedUserRegistration() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret, "create");
-
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         UserObject appRegisteredUserInfo = new UserObject()
                 .userName(TEST_USER4_USERNAME)
                 .password(TEST_USER_PASSWORD)
@@ -451,17 +398,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         assertNotNull(responseObj, "Flow initiation response is null.");
         assertTrue(responseObj instanceof FlowExecutionResponse, "Unexpected response type for flow initiation.");
 
-        FlowExecutionRequest flowExecutionRequest = new FlowExecutionRequest();
-        flowExecutionRequest.setFlowType("REGISTRATION");
-        flowExecutionRequest.setActionId("button_5zqc");
-        Map<String, String> inputs = new HashMap<>();
-        inputs.put("http://wso2.org/claims/username", TEST_USER5_USERNAME);
-        inputs.put("password", TEST_USER_PASSWORD);
-        inputs.put("http://wso2.org/claims/emailaddress", TEST_USER_EMAIL);
-        inputs.put("http://wso2.org/claims/givenname", TEST_USER_GIVEN_NAME);
-        inputs.put("http://wso2.org/claims/lastname", TEST_USER_LASTNAME);
-        flowExecutionRequest.setInputs(inputs);
-
+        FlowExecutionRequest flowExecutionRequest = buildUserRegistrationFlowRequest();
         org.json.simple.JSONObject response = flowExecutionClient.executeFlowAndReturnResponse(flowExecutionRequest);
         assertNotNull(response, "User creation response is null");
         if (response.containsKey("error")) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -429,7 +429,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerTokenAndReturnResponse(appRegisteredUserInfo, token);
+        org.json.simple.JSONObject response = (org.json.simple.JSONObject) scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token, true);
         assertNotNull(response, "User creation response is null");
         if (response.containsKey("error")) {
             Assert.fail("User creation failed: " + response.get("error"));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -348,8 +348,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        org.json.simple.JSONObject response = scim2RestClient.createUserAndReturnResponse(adminRegisteredUserInfo);
-
+        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerToken(adminRegisteredUserInfo, null);
         assertNotNull(response, "User creation response is null");
         if (response.containsKey("error")) {
             Assert.fail("User creation failed: " + response.get("error"));
@@ -375,7 +374,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        org.json.simple.JSONObject response = (org.json.simple.JSONObject) scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token, true);
+        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token);
         assertNotNull(response, "User creation response is null");
         if (response.containsKey("error")) {
             Assert.fail("User creation failed: " + response.get("error"));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -70,8 +70,6 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
 
     private SCIM2RestClient scim2RestClient;
     private UsersRestClient usersRestClient;
-    private FlowExecutionClient flowExecutionClient;
-    private FlowManagementClient flowManagementClient;
 
     private String clientId;
     private String clientSecret;
@@ -154,7 +152,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
                         MOCK_SERVER_AUTH_BASIC_PASSWORD),
                 actionResponse.getResponseBody(), actionResponse.getStatusCode());
-        enableFlow(flowManagementClient, "REGISTRATION");
+        enableFlow(REGISTRATION_FLOW_TYPE);
         addRegistrationFlow(flowManagementClient);
     }
 
@@ -182,7 +180,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         Utils.getMailServer().purgeEmailFromAllMailboxes();
         serviceExtensionMockServer.stopServer();
         serviceExtensionMockServer = null;
-        disableFlow(flowManagementClient, "REGISTRATION");
+        disableFlow(REGISTRATION_FLOW_TYPE);
     }
 
     @Test(description = "Verify the password update in self service portal with pre update password action")
@@ -348,7 +346,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerToken(adminRegisteredUserInfo, null);
+        org.json.simple.JSONObject response = scim2RestClient.createUser(adminRegisteredUserInfo, null);
         assertNotNull(response, "User creation response is null");
         if (response.containsKey("error")) {
             Assert.fail("User creation failed: " + response.get("error"));
@@ -374,7 +372,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token);
+        org.json.simple.JSONObject response = scim2RestClient.createUser(appRegisteredUserInfo, token);
         assertNotNull(response, "User creation response is null");
         if (response.containsKey("error")) {
             Assert.fail("User creation failed: " + response.get("error"));
@@ -394,7 +392,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the user initiated registration with pre update password action failure")
     public void testUserInitiatedUserRegistration() throws Exception {
 
-        Object responseObj = flowExecutionClient.initiateFlowExecution("REGISTRATION");
+        Object responseObj = flowExecutionClient.initiateFlowExecution(REGISTRATION_FLOW_TYPE);
         assertNotNull(responseObj, "Flow initiation response is null.");
         assertTrue(responseObj instanceof FlowExecutionResponse, "Unexpected response type for flow initiation.");
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -345,8 +345,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the password update by an authorized application with pre update password action")
     public void testApplicationUpdatePassword() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret,
-                "internal_user_mgt_update");
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret, "update");
         Map<String, String> passwordValue = new HashMap<>();
         passwordValue.put(PASSWORD_PROPERTY, TEST_USER_PASSWORD);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
@@ -421,8 +420,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the application initiated user registration with pre update password action failure")
     public void testApplicationInitiatedUserRegistration() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret,
-                "internal_user_mgt_create");
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret, "create");
 
         UserObject appRegisteredUserInfo = new UserObject()
                 .userName(TEST_USER4_USERNAME)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -296,6 +296,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
         String adminRegisteredUserId = scim2RestClient.createUser(adminRegisteredUserInfo);
+        assertNotNull(adminRegisteredUserId);
 
         assertActionRequestPayloadWithUserCreation(PreUpdatePasswordEvent.FlowInitiatorType.ADMIN,
                 PreUpdatePasswordEvent.Action.REGISTER);
@@ -331,7 +332,6 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         flowExecutionClient.initiateFlowExecution(REGISTRATION_FLOW_TYPE);
         FlowExecutionRequest flowExecutionRequest = buildUserRegistrationFlowRequest();
         Object executionResponseObj = flowExecutionClient.executeFlow(flowExecutionRequest);
-        assertNotNull(executionResponseObj, "Flow execution response is null.");
         assertTrue(executionResponseObj instanceof FlowExecutionResponse,
                 "Unexpected response type for flow execution.");
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -324,16 +324,11 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         String createdUserId = null;
         ObjectMapper mapper = new ObjectMapper();
         JsonNode body = mapper.readTree(response.get("body").toString());
-        if (body.has("id")) {
-            createdUserId = body.get("id").asText();
-        }
+        createdUserId = body.get("id").asText();
 
-        try {
-            assertActionRequestPayload(null, TEST_USER_PASSWORD,
-                    PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION, PreUpdatePasswordEvent.Action.REGISTER);
-        } finally {
-            scim2RestClient.deleteUser(createdUserId);
-        }
+        assertActionRequestPayload(null, TEST_USER_PASSWORD,
+                PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION, PreUpdatePasswordEvent.Action.REGISTER);
+        scim2RestClient.deleteUser(createdUserId);
     }
 
     @Test(dependsOnMethods = "testApplicationInitiatedUserRegistration",
@@ -349,6 +344,11 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
 
         assertActionRequestPayloadWithUserCreation(PreUpdatePasswordEvent.FlowInitiatorType.USER,
                 PreUpdatePasswordEvent.Action.REGISTER);
+        JsonNode node = new ObjectMapper().valueToTree(executionResponseObj);
+        String createdUserId = node.path("id").asText();
+        if (createdUserId != null && !createdUserId.isEmpty()) {
+            scim2RestClient.deleteUser(createdUserId);
+        }
     }
 
     private void assertActionRequestPayload(String userId, String updatedPassword,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -317,8 +317,8 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        String appRegisteredUserId = (String) scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo,
-                token, false);
+        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token);
+        String appRegisteredUserId = (String) response.get("id");
 
         assertActionRequestPayloadWithUserCreation(PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION,
                 PreUpdatePasswordEvent.Action.REGISTER);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -374,8 +374,8 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-
-        String appRegisteredUserId = scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token);
+        String appRegisteredUserId = (String) scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo,
+                token, false);
 
         assertActionRequestPayloadWithUserCreation(PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION,
                 PreUpdatePasswordEvent.Action.REGISTER);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -61,8 +61,6 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
 
     private SCIM2RestClient scim2RestClient;
     private UsersRestClient usersRestClient;
-    private FlowExecutionClient flowExecutionClient;
-    private FlowManagementClient flowManagementClient;
 
     private String clientId;
     private String clientSecret;
@@ -122,7 +120,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
                         MOCK_SERVER_AUTH_BASIC_PASSWORD),
                 FileUtils.readFileInClassPathAsString("actions/response/pre-update-password-response.json"));
-        enableFlow(flowManagementClient, "REGISTRATION");
+        enableFlow(REGISTRATION_FLOW_TYPE);
         addRegistrationFlow(flowManagementClient);
     }
 
@@ -151,7 +149,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         Utils.getMailServer().purgeEmailFromAllMailboxes();
         serviceExtensionMockServer.stopServer();
         serviceExtensionMockServer = null;
-        disableFlow(flowManagementClient, "REGISTRATION");
+        disableFlow(REGISTRATION_FLOW_TYPE);
     }
 
     @Test(description = "Verify the password update in self service portal with pre update password action")
@@ -317,7 +315,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
-        org.json.simple.JSONObject response = scim2RestClient.createUserWithBearerToken(appRegisteredUserInfo, token);
+        org.json.simple.JSONObject response = scim2RestClient.createUser(appRegisteredUserInfo, token);
         String appRegisteredUserId = (String) response.get("id");
 
         assertActionRequestPayloadWithUserCreation(PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION,
@@ -329,7 +327,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
             description = "Verify the user initiated registration with pre update password action")
     public void testUserInitiatedRegistration() throws Exception {
 
-        Object responseObj = flowExecutionClient.initiateFlowExecution("REGISTRATION");
+        Object responseObj = flowExecutionClient.initiateFlowExecution(REGISTRATION_FLOW_TYPE);
         assertNotNull(responseObj, "Flow initiation response is null.");
         assertTrue(responseObj instanceof FlowExecutionResponse, "Unexpected response type for flow initiation.");
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -122,7 +122,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
                         MOCK_SERVER_AUTH_BASIC_PASSWORD),
                 FileUtils.readFileInClassPathAsString("actions/response/pre-update-password-response.json"));
-        enableFlow(flowManagementClient);
+        enableFlow(flowManagementClient, "REGISTRATION");
         addRegistrationFlow(flowManagementClient);
     }
 
@@ -151,7 +151,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         Utils.getMailServer().purgeEmailFromAllMailboxes();
         serviceExtensionMockServer.stopServer();
         serviceExtensionMockServer = null;
-        disableFlow(flowManagementClient);
+        disableFlow(flowManagementClient, "REGISTRATION");
     }
 
     @Test(description = "Verify the password update in self service portal with pre update password action")
@@ -295,7 +295,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
     public void testAdminInitiatedUserRegistration() throws Exception {
 
         UserObject adminRegisteredUserInfo = new UserObject()
-                .userName(TEST_USER3_USERNAME)
+                .userName(TEST_USER2_USERNAME)
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
@@ -313,7 +313,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
 
         String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret);
         UserObject appRegisteredUserInfo = new UserObject()
-                .userName(TEST_USER4_USERNAME)
+                .userName(TEST_USER2_USERNAME)
                 .password(TEST_USER_PASSWORD)
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -287,8 +287,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
             description = "Verify the password update by an authorized application with pre update password action")
     public void testApplicationUpdatePassword() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret,
-                "internal_user_mgt_update");
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret, "update");
         Map<String, String> passwordValue = new HashMap<>();
         passwordValue.put(PASSWORD_PROPERTY, TEST_USER_PASSWORD);
         PatchOperationRequestObject patchUserInfo = new PatchOperationRequestObject()
@@ -366,8 +365,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
             description = "Verify the application initiated user registration with pre update password action")
     public void testApplicationInitiatedUserRegistration() throws Exception {
 
-        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret,
-                "internal_user_mgt_create");
+        String token = getTokenWithClientCredentialsGrant(application.getId(), clientId, clientSecret, "create");
 
         UserObject appRegisteredUserInfo = new UserObject()
                 .userName(TEST_USER4_USERNAME)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -314,6 +314,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 .name(new Name().givenName(TEST_USER_GIVEN_NAME).familyName(TEST_USER_LASTNAME))
                 .addEmail(new Email().value(TEST_USER_EMAIL));
         org.json.simple.JSONObject response = scim2RestClient.createUser(appRegisteredUserInfo, token);
+        assertNotNull(response);
 
         int statusCode = Integer.parseInt(response.get("statusCode").toString());
         assertEquals(statusCode, HttpServletResponse.SC_CREATED,


### PR DESCRIPTION
This pull request enhances the integration test suite for pre-update password actions by introducing new utilities and integration test support for flow execution and user management. Notably, it adds methods to facilitate flow-based registration and user creation with bearer tokens, improves test setup and teardown for flow management, and expands test coverage with additional user constants and configuration options.

### Related Issue:
- https://github.com/wso2/product-is/issues/25550