### PR TITLE
Bump framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2544,7 +2544,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.9.53</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.9.55</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request updates the version of the Carbon Identity Framework used in the project. The version is incremented from 7.9.53 to 7.9.55 in the `pom.xml` file, ensuring the project uses the latest compatible framework release.