### PR TITLE
Bump identity-apps component versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2693,8 +2693,8 @@
         <conditional.authentication.functions.version>1.2.84</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.77.50</identity.apps.console.version>
-        <identity.apps.myaccount.version>2.23.18</identity.apps.myaccount.version>
+        <identity.apps.console.version>2.79.9</identity.apps.console.version>
+        <identity.apps.myaccount.version>2.25.4</identity.apps.myaccount.version>
         <identity.apps.core.version>3.3.5</identity.apps.core.version>
         <identity.apps.tests.version>1.6.383</identity.apps.tests.version>
 


### PR DESCRIPTION
Bump
- identity.apps.console.version to 2.79.9
- identity.apps.myaccount.version to 2.25.4