### PR TITLE
Rename soap service disable toml configurations.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/analytics/config/analytics_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/analytics/config/analytics_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/analytics/config/identity_event_analytics_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/analytics/config/identity_event_analytics_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_disabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_disabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/application/mgt/role_validation_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/challenge-questions/challenge_questions_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/challenge-questions/challenge_questions_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/email/email_otp_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/email/email_otp_config.toml
@@ -3,7 +3,7 @@ hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
 disable_addressing = true
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identityMgt/case_insensitive_user_false.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identityMgt/case_insensitive_user_false.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identityMgt/user_mgt_regex_changed.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identityMgt/user_mgt_regex_changed.toml
@@ -3,7 +3,7 @@ hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
 offset = "410"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_encryption_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_encryption_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_hash_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_hash_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_new_resource.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_new_resource.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_new_resource_nashorn.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_new_resource_nashorn.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_new_resource_openjdknashorn.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identity_new_resource_openjdknashorn.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/jit/jit_user_association_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/jit/jit_user_association_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/add_scope_deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/add_scope_deployment.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt-token-gen-enabled-identity.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt-token-gen-enabled-identity.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt_token_issuer_add_remaining_user_attribute.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt_token_issuer_add_remaining_user_attribute.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt_token_issuer_convert_to_oidc.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt_token_issuer_convert_to_oidc.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt_token_issuer_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/jwt_token_issuer_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/oauth2_service_resource_owner.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/oauth2_service_resource_owner.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/skip_consent_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/skip_consent_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/token_renewal_per_request_enabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/oauth/token_renewal_per_request_enabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/organizationDiscovery/email_as_username.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/organizationDiscovery/email_as_username.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/provisioning/db_separation_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/provisioning/db_separation_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/provisioning/default_configs_with_h2_db.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/provisioning/default_configs_with_h2_db.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/recovery/non_unique_user_disable.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/recovery/non_unique_user_disable.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/recovery/non_unique_user_enable.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/recovery/non_unique_user_enable.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/application_authentication_changed_acs.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/application_authentication_changed_acs.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/saml-assertion-query-enabled-deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/saml-assertion-query-enabled-deployment.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/saml-sso-for-admin-console.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/saml-sso-for-admin-console.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/saml_ecp_consent_management_disabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/saml/saml_ecp_consent_management_disabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scim/IDENTITY4776/catalina_server_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scim/IDENTITY4776/catalina_server_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scim2/me_unsecured_identity.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scim2/me_unsecured_identity.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/nashorn_script_engine_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/nashorn_script_engine_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/openjdknashorn_script_engine_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/openjdknashorn_script_engine_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/tenant.qualified/tenant_qualified_url_tenanted_sessions_disabled.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/tenant.qualified/tenant_qualified_url_tenanted_sessions_disabled.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/user/enable_email_username_deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/user/enable_email_username_deployment.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/user/enable_federated_association.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/user/enable_federated_association.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/carbon15051/email_login_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/carbon15051/email_login_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/jdbc_user_mgt_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/jdbc_user_mgt_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/ldap_user_mgt_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/ldap_user_mgt_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/read_only_ldap_user_mgt_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/read_only_ldap_user_mgt_config.toml
@@ -2,7 +2,7 @@
 hostname = "localhost"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-disable_admin_services = false
+enable_admin_services = true
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/automation.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/automation.xml
@@ -67,8 +67,8 @@
     <!--  Configs to add in deployment.toml at startup to enable admin/SOAP services. -->
     <enableAdminServices>
         <expectedParentKey>server</expectedParentKey>
-        <expectedKey>disable_admin_services</expectedKey>
-        <expectedValue>false</expectedValue>
+        <expectedKey>enable_admin_services</expectedKey>
+        <expectedValue>true</expectedValue>
     </enableAdminServices>
 
     <!--  SMTP Server configs to be added to the deployment.toml during the initial server startup  -->

--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.10.95" useFeatures="true" includeLaunchers="true">
+version="4.10.97" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.10.95" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.10.95"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.10.97"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2702,7 +2702,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.10.95</carbon.kernel.version>
+        <carbon.kernel.version>4.10.97</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.0.16</identity.verification.version>


### PR DESCRIPTION
## Purpose
> part of https://github.com/wso2/product-is/issues/20755#issuecomment-3210063462

Related fix https://github.com/wso2/carbon-kernel/pull/4394