### PR TITLE
Fix: dynamically set html lang on all auth pages

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -483,6 +483,22 @@
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/authenticationendpoint.war" />
 
+                                <!-- Ensure correct HTML lang attribute in authenticationendpoint pages -->
+                                <!-- Remove existing lang attribute on <html ...> to avoid duplicates -->
+                                <replaceregexp byline="false" flags="i" match="(\&lt;html)([^\&gt;]*?)\s+lang=\&quot;[^\&quot;]*\&quot;([^\&gt;]*?\&gt;)" replace="\1\2\3">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/authenticationendpoint">
+                                        <include name="**/*.jsp" />
+                                        <include name="**/*.html" />
+                                    </fileset>
+                                </replaceregexp>
+                                <!-- Inject dynamic lang using ui_locales (if present) or request locale -->
+                                <replaceregexp byline="false" flags="i" match="(\&lt;html)([^\&gt;]*?)\&gt;" replace="\1\2 lang=\&quot;\&lt;%=(request.getParameter(\&quot;ui_locales\&quot;)!=null?request.getParameter(\&quot;ui_locales\&quot;):request.getLocale().toLanguageTag())%\&gt;\&quot;\&gt;">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/authenticationendpoint">
+                                        <include name="**/*.jsp" />
+                                        <include name="**/*.html" />
+                                    </fileset>
+                                </replaceregexp>
+
                                 <!-- Explode the accounts.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/accounts">
                                     <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps">
@@ -498,6 +514,22 @@
                                     </fileset>
                                 </unzip>
                                 <delete file="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/accountrecoveryendpoint.war" />
+
+                                <!-- Ensure correct HTML lang attribute in accountrecoveryendpoint pages -->
+                                <!-- Remove existing lang attribute on <html ...> to avoid duplicates -->
+                                <replaceregexp byline="false" flags="i" match="(\&lt;html)([^\&gt;]*?)\s+lang=\&quot;[^\&quot;]*\&quot;([^\&gt;]*?\&gt;)" replace="\1\2\3">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/accountrecoveryendpoint">
+                                        <include name="**/*.jsp" />
+                                        <include name="**/*.html" />
+                                    </fileset>
+                                </replaceregexp>
+                                <!-- Inject dynamic lang using ui_locales (if present) or request locale -->
+                                <replaceregexp byline="false" flags="i" match="(\&lt;html)([^\&gt;]*?)\&gt;" replace="\1\2 lang=\&quot;\&lt;%=(request.getParameter(\&quot;ui_locales\&quot;)!=null?request.getParameter(\&quot;ui_locales\&quot;):request.getLocale().toLanguageTag())%\&gt;\&quot;\&gt;">
+                                    <fileset dir="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/accountrecoveryendpoint">
+                                        <include name="**/*.jsp" />
+                                        <include name="**/*.html" />
+                                    </fileset>
+                                </replaceregexp>
 
                                 <!-- Explode the x509certificateauthenticationendpoint.war -->
                                 <unzip dest="../p2-profile-gen/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps/x509certificateauthenticationendpoint">


### PR DESCRIPTION
**Description**

This PR fixes the issue where the `lang` attribute in the HTML `<html>` tag did not update correctly on some pages, such as `verify.do` and `completepasswordreset.do`, after switching languages.

Previously, the `lang` attribute was only updated by `language-switcher.jsp`. Pages that did not include this JSP remained stuck at `en-US` even when a different language was selected.

**What was done**
- Modified the distribution module (`modules/distribution/pom.xml`) to ensure all `authenticationendpoint` and `accountrecoveryendpoint` pages dynamically set the `<html lang>` attribute.
- The `lang` is now set from the selected `ui_locales` parameter, or falls back to the request locale if `ui_locales` is not provided.
- Any pre-existing `lang` attribute is removed first to avoid duplicates.

**Impact**
- All pages in the authentication and account recovery flows now correctly reflect the selected language.
- Resolves the issue where pages without `language-switcher.jsp` stayed at `en-US` after switching languages.

**Related Issue**
Resolves: #24222 
