### PR TITLE
Add Integration Test for User Self Registration enable Pre-Update Password Action

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -243,43 +243,35 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
 
     protected String retrievePasswordResetURL(ApplicationResponseModel application) throws Exception {
 
-        List<NameValuePair> urlParameters = new ArrayList<>();
-        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
-        urlParameters.add(new BasicNameValuePair("client_id", application.getClientId()));
-        urlParameters.add(new BasicNameValuePair("redirect_uri", APP_CALLBACK_URL));
-        urlParameters.add(new BasicNameValuePair("scope", "openid email profile"));
-        HttpResponse response = sendPostRequestWithParameters(client, urlParameters,
-                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
-
-        Header authorizeRequestURL = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
-        EntityUtils.consume(response.getEntity());
-
-        response = sendGetRequest(client, authorizeRequestURL.getValue());
-        String htmlContent = EntityUtils.toString(response.getEntity());
-        Document doc = Jsoup.parse(htmlContent);
-        Element link = doc.selectFirst("#passwordRecoverLink");
-        Assert.assertNotNull(link, "Password recovery link not found in the response.");
-        return link.attr("href");
+        return retrieveLinkFromAuthorizeFlow(application, "#passwordRecoverLink",
+                "Password recovery link not found in the response.");
     }
 
     protected String retrieveUserRegistrationURL(ApplicationResponseModel application) throws Exception {
 
+        return retrieveLinkFromAuthorizeFlow(application, "#registerLink",
+                "User registration link not found in the response.");
+    }
+
+    protected String retrieveLinkFromAuthorizeFlow(ApplicationResponseModel application, String cssSelector,
+                                                 String assertMessage) throws Exception {
+
         List<NameValuePair> urlParameters = new ArrayList<>();
         urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
         urlParameters.add(new BasicNameValuePair("client_id", application.getClientId()));
         urlParameters.add(new BasicNameValuePair("redirect_uri", APP_CALLBACK_URL));
         urlParameters.add(new BasicNameValuePair("scope", "openid email profile"));
+
         HttpResponse response = sendPostRequestWithParameters(client, urlParameters,
                 getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
-
         Header authorizeRequestURL = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
         EntityUtils.consume(response.getEntity());
-
         response = sendGetRequest(client, authorizeRequestURL.getValue());
         String htmlContent = EntityUtils.toString(response.getEntity());
         Document doc = Jsoup.parse(htmlContent);
-        Element link = doc.selectFirst("#registerLink");
-        Assert.assertNotNull(link, "User registration link not found in the response.");
+        Element link = doc.selectFirst(cssSelector);
+        Assert.assertNotNull(link, assertMessage);
+
         return link.attr("href");
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -152,6 +152,18 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
                 "YWNjb3VudC1yZWNvdmVyeQ", connectorsPatchReq);
     }
 
+    protected void updateSelfRegistrationStatus(boolean enable) throws IOException {
+
+        ConnectorsPatchReq connectorsPatchReq = new ConnectorsPatchReq();
+        connectorsPatchReq.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
+        PropertyReq propertyReq = new PropertyReq();
+        propertyReq.setName("SelfRegistration.Enable");
+        propertyReq.setValue(enable ? "true" : "false");
+        connectorsPatchReq.addProperties(propertyReq);
+        identityGovernanceRestClient.updateConnectors("VXNlciBPbmJvYXJkaW5n",
+                "c2VsZi1zaWduLXVw", connectorsPatchReq);
+    }
+
     protected void enableAdminPasswordResetRecoveryEmailLink() throws IOException {
 
         ConnectorsPatchReq connectorsPatchReq = new ConnectorsPatchReq();
@@ -250,6 +262,27 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         return link.attr("href");
     }
 
+    protected String retrieveUserRegistrationURL(ApplicationResponseModel application) throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("client_id", application.getClientId()));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", APP_CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("scope", "openid email profile"));
+        HttpResponse response = sendPostRequestWithParameters(client, urlParameters,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
+
+        Header authorizeRequestURL = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        EntityUtils.consume(response.getEntity());
+
+        response = sendGetRequest(client, authorizeRequestURL.getValue());
+        String htmlContent = EntityUtils.toString(response.getEntity());
+        Document doc = Jsoup.parse(htmlContent);
+        Element link = doc.selectFirst("#registerLink");
+        Assert.assertNotNull(link, "User registration link not found in the response.");
+        return link.attr("href");
+    }
+
     protected void submitPasswordRecoveryForm(String url, String username) throws Exception {
 
         HttpResponse response = sendGetRequest(client, url);
@@ -279,6 +312,43 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
             throw new Exception("Error occurred while submitting the password reset form.");
         }
         EntityUtils.consume(postResponse.getEntity());
+    }
+
+    protected HttpResponse submitUserRegistrationForm(String url, String testUserName, String testUserPassword)
+            throws Exception {
+
+        HttpResponse response = sendGetRequest(client, url);
+        String htmlContent = EntityUtils.toString(response.getEntity());
+        Document doc = Jsoup.parse(htmlContent);
+
+        Element form = doc.selectFirst("#register");
+        String baseURL = url.substring(0, url.lastIndexOf('/') + 1);
+        Assert.assertNotNull(form, "User registration form not found in the response.");
+        String actionURL = null;
+        try {
+            actionURL = new URL(new URL(baseURL), form.attr("action")).toString();
+        } catch (Exception e) {
+            Assert.fail("Error while constructing action URL.", e);
+        }
+
+        List<NameValuePair> formParams = new ArrayList<>();
+        for (Element input : form.select("input")) {
+            String name = input.attr("name");
+            String value = input.attr("value");
+                if ("username".equals(name)) {
+                    value = testUserName;
+                }
+                if ("password".equals(name)) {
+                    value = testUserPassword;
+                }
+            formParams.add(new BasicNameValuePair(name, value));
+        }
+
+        HttpResponse postResponse = sendPostRequestWithParameters(client, formParams, actionURL);
+        if (postResponse.getStatusLine().getStatusCode() != 200) {
+            Assert.fail("Error occurred while submitting the user registration form.");
+        }
+        return postResponse;
     }
 
     protected String createPreUpdatePasswordAction(String actionName, String actionDescription) throws IOException {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -387,8 +387,8 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
     }
 
     @Test(dependsOnMethods = "testApplicationInitiatedUserRegistration",
-            description = "Verify the user initiated registration with pre update password action failure")
-    public void testUserInitiatedUserRegistration() throws Exception {
+            description = "Verify the user initiated self registration flow with pre update password action failure")
+    public void testUserRegistrationWithSelfRegistrationFlow() throws Exception {
 
         updateFlowStatus(REGISTRATION_FLOW_TYPE, true);
         addRegistrationFlow(flowManagementClient);
@@ -413,7 +413,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         updateFlowStatus(REGISTRATION_FLOW_TYPE, false);
     }
 
-    @Test(dependsOnMethods = "testUserInitiatedUserRegistration",
+    @Test(dependsOnMethods = "testUserRegistrationWithSelfRegistrationFlow",
             description = "Verify the user initiated self registration with pre update password action failure")
     public void testUserInitiatedSelfRegistration() throws Exception {
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -138,6 +138,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         userId = scim2RestClient.createUser(userInfo);
 
         updatePasswordRecoveryFeatureStatus(true);
+        updateSelfRegistrationStatus(true);
         enableAdminPasswordResetRecoveryEmailLink();
         updateAdminInitiatedPasswordResetEmailFeatureStatus(true);
 
@@ -149,8 +150,6 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
                         MOCK_SERVER_AUTH_BASIC_PASSWORD),
                 actionResponse.getResponseBody(), actionResponse.getStatusCode());
-        updateFlowStatus(REGISTRATION_FLOW_TYPE, true);
-        addRegistrationFlow(flowManagementClient);
     }
 
     @BeforeMethod
@@ -164,6 +163,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
     public void atEnd() throws Exception {
 
         updatePasswordRecoveryFeatureStatus(false);
+        updateSelfRegistrationStatus(false);
         updateAdminInitiatedPasswordResetEmailFeatureStatus(false);
 
         deleteAction(PRE_UPDATE_PASSWORD_API_PATH, actionId);
@@ -177,7 +177,6 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
         Utils.getMailServer().purgeEmailFromAllMailboxes();
         serviceExtensionMockServer.stopServer();
         serviceExtensionMockServer = null;
-        updateFlowStatus(REGISTRATION_FLOW_TYPE, false);
     }
 
     @Test(description = "Verify the password update in self service portal with pre update password action")
@@ -391,6 +390,8 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             description = "Verify the user initiated registration with pre update password action failure")
     public void testUserInitiatedUserRegistration() throws Exception {
 
+        updateFlowStatus(REGISTRATION_FLOW_TYPE, true);
+        addRegistrationFlow(flowManagementClient);
         flowExecutionClient.initiateFlowExecution(REGISTRATION_FLOW_TYPE);
         FlowExecutionRequest flowExecutionRequest = buildUserRegistrationFlowRequest();
         Object executeResponseObj = flowExecutionClient.executeFlow(flowExecutionRequest);
@@ -407,6 +408,21 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
             assertEquals(error.getMessage(), expectedPasswordUpdateResponse.getErrorMessage(),
                     "Unexpected error message in response.");
         }
+        assertActionRequestPayload(null, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
+                PreUpdatePasswordEvent.Action.REGISTER);
+        updateFlowStatus(REGISTRATION_FLOW_TYPE, false);
+    }
+
+    @Test(dependsOnMethods = "testUserInitiatedUserRegistration",
+            description = "Verify the user initiated self registration with pre update password action failure")
+    public void testUserInitiatedSelfRegistration() throws Exception {
+
+        String userRegistrationFormURL = retrieveUserRegistrationURL(application);
+        HttpResponse httpResponse = submitUserRegistrationForm(userRegistrationFormURL, TEST_USER2_USERNAME,
+                TEST_USER_PASSWORD);
+        Assert.assertEquals(httpResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        assertErrors(httpResponse);
+
         assertActionRequestPayload(null, TEST_USER_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
                 PreUpdatePasswordEvent.Action.REGISTER);
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -326,8 +326,8 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
     }
 
     @Test(dependsOnMethods = "testApplicationInitiatedUserRegistration",
-            description = "Verify the user initiated registration with pre update password action")
-    public void testUserInitiatedRegistration() throws Exception {
+            description = "Verify the user initiated self registration flow with pre update password action")
+    public void testUserRegistrationWithSelfRegistrationFlow() throws Exception {
 
         updateFlowStatus(REGISTRATION_FLOW_TYPE, true);
         addRegistrationFlow(flowManagementClient);
@@ -346,7 +346,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         updateFlowStatus(REGISTRATION_FLOW_TYPE, false);
     }
 
-    @Test(dependsOnMethods = "testUserInitiatedRegistration",
+    @Test(dependsOnMethods = "testUserRegistrationWithSelfRegistrationFlow",
             description = "Verify the user initiated self registration with pre update password action")
     public void testUserInitiatedSelfRegistration() throws Exception {
 


### PR DESCRIPTION
This pull request enhances the integration tests for pre-update password actions by adding support for self-registration. It introduces new utilities for enabling/disabling self-registration, retrieving and submitting user registration forms, and restructures the test cases to explicitly test both user-initiated registration via self-registration flows and the application-initiated path.

**Test case restructuring and improvements:**

* Updated test initialization and cleanup to enable/disable self-registration and removed redundant registration flow management from setup/teardown.
* Split user registration tests into two: one for user-initiated self-registration flows and another for application-initiated registration, ensuring both flows are explicitly tested.

**Related Issue:** 
- https://github.com/wso2/product-is/issues/25793