### PR TITLE
Add ELK analytics logger and appender to log4j2.properties file

### DIFF
--- a/modules/distribution/src/repository/resources/conf/log4j2.properties
+++ b/modules/distribution/src/repository/resources/conf/log4j2.properties
@@ -18,7 +18,19 @@
 
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, CORRELATION, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, DELETE_EVENT_LOGFILE, TRANSACTION_LOGFILE, osgi, DIAGNOSTICS
+# Added ANALYTICS_EVENT_LOGFILE for ELK analytics integration
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, CORRELATION, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, DELETE_EVENT_LOGFILE, TRANSACTION_LOGFILE, osgi, DIAGNOSTICS, ANALYTICS_EVENT_LOGFILE
+# Appender for analytics event logs (ELK integration)
+appender.ANALYTICS_EVENT_LOGFILE.type = RollingFile
+appender.ANALYTICS_EVENT_LOGFILE.name = ANALYTICS_EVENT_LOGFILE
+appender.ANALYTICS_EVENT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/analytics-event.log
+appender.ANALYTICS_EVENT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/analytics-event-%d{MM-dd-yyyy}.%i.log
+appender.ANALYTICS_EVENT_LOGFILE.layout.type = PatternLayout
+appender.ANALYTICS_EVENT_LOGFILE.layout.pattern = [%d] %5p {%c} - %mm%ex%n
+appender.ANALYTICS_EVENT_LOGFILE.policies.type = Policies
+appender.ANALYTICS_EVENT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ANALYTICS_EVENT_LOGFILE.policies.time.interval = 1
+appender.ANALYTICS_EVENT_LOGFILE.policies.time.modulate = true
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -148,7 +160,12 @@ appender.osgi.type = PaxOsgi
 appender.osgi.name = PaxOsgi
 appender.osgi.filter = *
 
-loggers = AUDIT_LOG, trace-messages, diagnostics, correlation, org-apache-coyote, com-hazelcast, javax-mail, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-apache-axis2-description, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml, org-wso2-carbon-identity-application, org-wso2-carbon-identity-application-authentication-framework, org-wso2-carbon-identity-oauth2, org-wso2-carbon-identity-oauth, org-wso2-carbon-identity-application-authenticator, org-wso2-carbon-identity-scim, org-wso2-carbon-identity-scim2, org-wso2-charon-core, org-wso2-charon3-core, org-eclipse-jetty, org-apache-cxf-endpoint-ServerImpl, org-wso2-carbon-event, org-wso2-carbon-webapp-mgt-TomcatGenericWebappsDeployer, org-wso2-carbon-core-deployment-DeploymentInterceptor, org-wso2-carbon-registry-core
+loggers = AUDIT_LOG, trace-messages, diagnostics, correlation, org-apache-coyote, com-hazelcast, javax-mail, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-apache-axis2-description, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache, axis2Deployment, equinox, tomcat2, StAXDialectDetector, org-apache-directory-api, org-apache-directory-api-ldap-model-entry, TRANSACTION_LOGGER, DELETE_EVENT_LOGGER, org-springframework, org-opensaml-xml-security-credential-criteria, org-wso2-carbon-user-core, org-wso2-carbon-identity, org-wso2-carbon-identity-sso-saml, org-wso2-carbon-identity-application, org-wso2-carbon-identity-application-authentication-framework, org-wso2-carbon-identity-oauth2, org-wso2-carbon-identity-oauth, org-wso2-carbon-identity-application-authenticator, org-wso2-carbon-identity-scim, org-wso2-carbon-identity-scim2, org-wso2-charon-core, org-wso2-charon3-core, org-eclipse-jetty, org-apache-cxf-endpoint-ServerImpl, org-wso2-carbon-event, org-wso2-carbon-webapp-mgt-TomcatGenericWebappsDeployer, org-wso2-carbon-core-deployment-DeploymentInterceptor, org-wso2-carbon-registry-core, org-wso2-carbon-event-output-adapter-logger-LoggerEventAdapter
+# Logger for ELK analytics integration
+logger.org-wso2-carbon-event-output-adapter-logger-LoggerEventAdapter.name = org.wso2.carbon.event.output.adapter.logger.LoggerEventAdapter
+logger.org-wso2-carbon-event-output-adapter-logger-LoggerEventAdapter.level = INFO
+logger.org-wso2-carbon-event-output-adapter-logger-LoggerEventAdapter.appenderRef.CUSTOM_LOGFILE.ref = ANALYTICS_EVENT_LOGFILE
+logger.org-wso2-carbon-event-output-adapter-logger-LoggerEventAdapter.additivity = false
 
 logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO


### PR DESCRIPTION
**What was changed**

- Added a new logger configuration for org.wso2.carbon.event.output.adapter.logger.LoggerEventAdapter in [log4j2.properties]
- Added a corresponding appender (ANALYTICS_EVENT_LOGFILE) to support ELK analytics integration as per the official WSO2 documentation.
- Updated the loggers and appenders lists to include the new logger and appender.

**Why this change was made**

- This change addresses the Log4J2 configuration error:
No name attribute provided for Logger org.wso2.carbon.event.output.adapter.logger.LoggerEventAdapter.
- The error occurred when following the ELK analytics installation guide, which requires this logger for event output.
- The new configuration ensures that analytics events are properly logged and can be integrated with ELK stack tools.

**Additional notes**

- No other functionality or configuration was modified.
- The change strictly follows the WSO2 documentation and does not affect existing loggers or application behavior.
- The update was tested by restarting the server and confirming that the Log4J2 error no longer appears in the logs.
