### PR TITLE
assert null of refresh token in impersonation flow

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2ImpersonationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2ImpersonationTestCase.java
@@ -304,6 +304,8 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         Map<String, String>  actClaimSet = (Map) jwtClaimsSet.getClaim("act");
         Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
         Assert.assertEquals(actClaimSet.get("sub"), impersonatorId, "Impersonator Id is not in the act claim." );
+        String refreshToken = (String) jsonResponse.get(OAuth2Constant.REFRESH_TOKEN);
+        Assert.assertNull(refreshToken, "Refresh token is not null for the impersonation flow.");
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request to SSO as the impersonatee for code.",
@@ -361,6 +363,8 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         Map<String, String>  actClaimSet = (Map) jwtClaimsSet.getClaim("act");
         Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
         Assert.assertEquals(actClaimSet.get("sub"), impersonatorId, "Impersonator Id is not in the act claim.");
+        String refreshToken = (String) jsonResponse.get(OAuth2Constant.REFRESH_TOKEN);
+        Assert.assertNull(refreshToken, "Refresh token is not null for the impersonation flow.");
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request to SSO as the impersonatee using " +
@@ -559,6 +563,8 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         Map<String, String>  actClaimSet = (Map) jwtClaimsSet.getClaim("act");
         Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
         assertEquals(actClaimSet.get("sub"), orgImpersonatorId, "Impersonator Id is not in the act claim." );
+        String refreshToken = (String) jsonResponse.get(OAuth2Constant.REFRESH_TOKEN);
+        Assert.assertNull(refreshToken, "Refresh token is not null for the impersonation flow.");
     }
 
     @Test(groups = "wso2.is", description = "Org - Send token request to get an impersonated token using code grant.",
@@ -581,6 +587,8 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         Map<String, String>  actClaimSet = (Map) jwtClaimsSet.getClaim("act");
         Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
         assertEquals(actClaimSet.get("sub"), orgImpersonatorId, "Impersonator Id is not in the act claim.");
+        String refreshToken = (String) jsonResponse.get(OAuth2Constant.REFRESH_TOKEN);
+        Assert.assertNull(refreshToken, "Refresh token is not null for the impersonation flow.");
     }
 
     @Test(dependsOnMethods = { "testOrgSendTokenExchangeRequestPost", "testOrgSendCodeTokenRequestPost" },


### PR DESCRIPTION
$
Issue: https://github.com/wso2/product-is/issues/25778
BE fix: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2925

<img width="3457" height="2710" alt="screencapture-file-Users-thumilan-Desktop-Repo-Public-product-is-modules-integration-tests-integration-tests-backend-target-surefire-reports-Identity-suite-initializer-index-html-2025-10-01-10_28_31" src="https://github.com/user-attachments/assets/8eeb8c1b-fcd2-4fe9-8978-a783cdc77be1" />
