### PR TITLE
Add ca certificate management api integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/CACertificatesFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/CACertificatesFailureTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates.model.CACertificateAddRequest;
+import org.wso2.identity.integration.test.util.Utils;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ * Tests for failure/negative paths of the Certificate Validation Management REST API CA Certificates.
+ */
+public class CACertificatesFailureTest extends CACertificatesTestBase {
+
+    private static CACertificateAddRequest cacertificate;
+    private ServerConfigurationManager serverConfigurationManager;
+    private File defaultConfigFile;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public CACertificatesFailureTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+        super.init();
+        String carbonHome = Utils.getResidentCarbonHome();
+        defaultConfigFile = getDeploymentTomlFile(carbonHome);
+        File challengeQuestionsConfigFile = new File(
+                getISResourceLocation() + File.separator + "certificate-validation-mgt" + File.separator +
+                        ADD_CA_CERTIFICATE_VALIDATION_CONFIG);
+        serverConfigurationManager = new ServerConfigurationManager(isServer);
+        serverConfigurationManager.applyConfigurationWithoutRestart(challengeQuestionsConfigFile, defaultConfigFile,
+                true);
+        serverConfigurationManager.restartGracefully();
+        serverConfigurationManager.restoreToLastConfiguration(false);
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void testConclude() throws Exception {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @Test
+    public void testAddInvalidCACertificate() {
+
+        cacertificate = new CACertificateAddRequest()
+                .certificate(TEST_INVALID_CERTIFICATE);
+
+        String body = toJSONString(cacertificate);
+        Response responseOfPost = getResponseOfPost(CERTIFICATE_VALIDATION_API_BASE_PATH +
+                CA_CERTIFICATES_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body("code", equalTo("65005"))
+                .body("message", equalTo("Error while adding CA Certificate."))
+                .body("description", equalTo("Error while persisting CA Certificate in the system."));
+    }
+
+    @Test
+    public void testGetNonExistentCACertificateByCertificateId() {
+
+        Response responseOfGet = getResponseOfGet(CERTIFICATE_VALIDATION_API_BASE_PATH +
+                CA_CERTIFICATES_PATH + "/" + TEST_INVALID_CERTIFICATE_ID);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("code", equalTo("60004"))
+                .body("message", equalTo("Unable to perform the operation."))
+                .body("description", equalTo("Certificate with the id: " + TEST_INVALID_CERTIFICATE_ID +
+                        " does not exist in tenant " + this.tenant + "."));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/CACertificatesSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/CACertificatesSuccessTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates.model.CACertificateAddRequest;
+import org.wso2.identity.integration.test.util.Utils;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+/**
+ * Tests for happy paths of the Certificate Validation Management REST API CA Certificates.
+ */
+public class CACertificatesSuccessTest extends CACertificatesTestBase {
+
+    private static CACertificateAddRequest cacertificate;
+    private static String testCACertificateId;
+    private ServerConfigurationManager serverConfigurationManager;
+    private File defaultConfigFile;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public CACertificatesSuccessTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+        super.init();
+        String carbonHome = Utils.getResidentCarbonHome();
+        defaultConfigFile = getDeploymentTomlFile(carbonHome);
+        File challengeQuestionsConfigFile = new File(
+                getISResourceLocation() + File.separator + "certificate-validation-mgt" + File.separator +
+                        ADD_CA_CERTIFICATE_VALIDATION_CONFIG);
+        serverConfigurationManager = new ServerConfigurationManager(isServer);
+        serverConfigurationManager.applyConfigurationWithoutRestart(challengeQuestionsConfigFile, defaultConfigFile,
+                true);
+        serverConfigurationManager.restartGracefully();
+        serverConfigurationManager.restoreToLastConfiguration(false);
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void testConclude() throws Exception {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @Test
+    public void testAddCACertificate() {
+
+        cacertificate = new CACertificateAddRequest()
+                .certificate(TEST_CERTIFICATE);
+
+        String body = toJSONString(cacertificate);
+        Response responseOfPost = getResponseOfPost(CERTIFICATE_VALIDATION_API_BASE_PATH +
+                CA_CERTIFICATES_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("id", notNullValue())
+                .body("serialNumber", equalTo(TEST_SERIAL_NUMBER))
+                .body("crlUrls", notNullValue())
+                .body("ocspUrls", notNullValue())
+                .body("issuerDN", equalTo(TEST_ISSUER_DN));
+
+        testCACertificateId = responseOfPost.getBody().jsonPath().getString("id");
+    }
+
+    @Test(dependsOnMethods = {"testAddCACertificate"})
+    public void testGetCACertificates() {
+
+        Response responseOfGet = getResponseOfGet(CERTIFICATE_VALIDATION_API_BASE_PATH + CA_CERTIFICATES_PATH);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(CERTIFICATES_KEY, notNullValue())
+                .body(CERTIFICATES_KEY + ".size()", equalTo(1));
+    }
+
+    @Test(dependsOnMethods = {"testGetCACertificates"})
+    public void testGetCACertificateByCertificateId() {
+
+        Response responseOfGet = getResponseOfGet(CERTIFICATE_VALIDATION_API_BASE_PATH +
+                CA_CERTIFICATES_PATH + "/" + testCACertificateId);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(testCACertificateId))
+                .body("serialNumber", equalTo(TEST_SERIAL_NUMBER))
+                .body("crlUrls", notNullValue())
+                .body("ocspUrls", notNullValue())
+                .body("issuerDN", equalTo(TEST_ISSUER_DN));
+    }
+
+    @Test(dependsOnMethods = {"testGetCACertificateByCertificateId"})
+    public void testUpdateCACertificate() {
+
+        cacertificate = new CACertificateAddRequest()
+                .certificate(TEST_CERTIFICATE);
+
+        String body = toJSONString(cacertificate);
+        Response responseOfPut = getResponseOfPut(CERTIFICATE_VALIDATION_API_BASE_PATH +
+                CA_CERTIFICATES_PATH + "/" + testCACertificateId, body);
+
+        responseOfPut.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(testCACertificateId))
+                .body("serialNumber", equalTo(TEST_SERIAL_NUMBER))
+                .body("crlUrls", notNullValue())
+                .body("ocspUrls", notNullValue())
+                .body("issuerDN", equalTo(TEST_ISSUER_DN));
+    }
+
+    @Test(dependsOnMethods = {"testUpdateCACertificate"})
+    public void testDeleteAction() {
+
+        getResponseOfDelete(CERTIFICATE_VALIDATION_API_BASE_PATH + CA_CERTIFICATES_PATH + "/" +
+                testCACertificateId).then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        Response responseOfGet = getResponseOfGet(CERTIFICATE_VALIDATION_API_BASE_PATH +
+                CA_CERTIFICATES_PATH);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_OK)
+                .body(CERTIFICATES_KEY + ".size()", equalTo(0));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/CACertificatesTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/CACertificatesTestBase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates;
+
+import org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.common.CertificateValidationTestBase;
+
+public class CACertificatesTestBase extends CertificateValidationTestBase {
+
+    protected static final String CA_CERTIFICATES_PATH = "/ca";
+    protected static final String ADD_CA_CERTIFICATE_VALIDATION_CONFIG = "certificate_validation_config.toml";
+    protected static final String CERTIFICATES_KEY = "Certificates";
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/model/CACertificateAddRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/cacertificates/model/CACertificateAddRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+import javax.validation.Valid;
+
+public class CACertificateAddRequest  {
+
+    private String certificate;
+
+    /**
+    * Base64 encoded certificate
+    **/
+    public CACertificateAddRequest certificate(String certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+
+    @ApiModelProperty(example = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t", value = "Base64 encoded certificate")
+    @JsonProperty("certificate")
+    @Valid
+    public String getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CACertificateAddRequest caCertificateAddRequest = (CACertificateAddRequest) o;
+        return Objects.equals(this.certificate, caCertificateAddRequest.certificate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(certificate);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class CACertificateAddRequest {\n");
+
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/common/CertificateValidationTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/common/CertificateValidationTestBase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.common;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.restassured.RestAssured;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
+
+import java.io.IOException;
+
+public class CertificateValidationTestBase extends RESTAPIServerTestBase {
+
+    private static final String API_DEFINITION_NAME = "certificate-validation-management.yaml";
+    protected static final String API_VERSION = "v1";
+    protected static final String CERTIFICATE_VALIDATION_API_BASE_PATH = "/certificate-validation";
+    protected static final String TEST_CERTIFICATE = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t";
+    protected static final String TEST_SERIAL_NUMBER = "0";
+    protected static final String TEST_ISSUER_DN = "cn=gnutlscertificateauthority,st=leuven,ou=gnutlscertificateauthority,o=gnutls,c=be";
+    protected static final String TEST_INVALID_CERTIFICATE = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURRakNDQWdvZ0F3SUJBZ0lJWVZBbjV1cHlvZ0F3RFFZSktvWklodmNOQVFFTEJRQXdHakVTTUJBR0ExVUUKQ2hNSFZtbHVaWEowYVc5dUlFTkJNQjRYRFRJek1ETXhOakUwTWpFMU5Wb1hEVE16TURNeE1UQXhNakUxTlZvdwpHakVTTUJBR0ExVUVBd3dHVm1sdVpYSjBhVzl1SUVObGNuUnBabWxqWVhScGIyNXpNUmN3RlFZRFZRUUxFd0pCCmJXOTFiblFnUTBFd0hoY05NakF3T0RJMk1USTNNalV4V2hjTk1qQXdPREkyTVRJek1qVXhXakJTTUJBR0ExVUUKQ2hNSFZtbHVaWEowYVc5dUlFTkJNQjRYRFRJek1ETXhOakUwTWpFMU5Wb1hEVE16TURNeE1UQXhNakUxTlZvdwpNUXN3Q1FZRFZRUUdFd0pDU1RFUE1BMEdBMVVFQ2hNSFZtbHVaWEowYVc5dUlFTkJNQjRYRFRJek1ETXhOakUwCk1qRTFOVm93R0pFUk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFJRHUKOGdTYzY3TW9PNUhHRVUyUUJ2b3gycWdxQ3doeTh5emNaYXpTMGZqY2dKbFRhVkxyb3JvVUdZQ2N4SlFoa0prVQpsZ05PTlMrRzUwM2I3M2NrcmhSZUJzZzZ4Q0lnL2FQUGFHa3Z2U1puaUZYd2tMcnpPbGpISmF3V0o5alZkbCtjCnRrcmM3ejVYaExwbnE1UjhMY3F1blZzazlzVjd2VG82cW1CVWhTSXhoTktsRjVPRVlaVEZLbHllbFNhTUVtQmQKRXphUFRka0VKeThJVGxWNklUZ2xDYmUrM1hxajFRPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t";
+    protected static final String TEST_INVALID_CERTIFICATE_ID = "invalid_certificate_id";
+
+    protected static String swaggerDefinition;
+
+    static {
+        String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.certificate.validation.management.v1";
+        try {
+            swaggerDefinition = getAPISwaggerDefinition(API_PACKAGE_NAME, API_DEFINITION_NAME);
+        } catch (IOException e) {
+            Assert.fail(String.format("Unable to read the swagger definition %s from %s", API_DEFINITION_NAME,
+                    API_PACKAGE_NAME), e);
+        }
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.init();
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() throws Exception {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    /**
+     * To convert object to a json string.
+     *
+     * @param object Respective java object.
+     * @return Relevant json string.
+     */
+    protected String toJSONString(Object object) {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(object);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/revocationvalidators/RevocationValidatorsFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/revocationvalidators/RevocationValidatorsFailureTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.revocationvalidators;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ * Tests for negative paths of the Certificate Validation Management REST API Revocation Validators.
+ */
+public class RevocationValidatorsFailureTest extends RevocationValidatorsTestBase {
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public RevocationValidatorsFailureTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws IOException {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void testConclude() throws Exception {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void testFinish() {
+
+        RestAssured.basePath = StringUtils.EMPTY;
+    }
+
+    @Test
+    public void testGetValidatorByInvalidName() {
+
+        String invalidValidatorName = "non_existing_validator";
+        Response response = getResponseOfGet(
+                CERTIFICATE_VALIDATION_API_BASE_PATH + REVOCATION_VALIDATORS_PATH + "/" + invalidValidatorName
+        );
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("description",
+                        equalTo("Invalid validator name " + invalidValidatorName + " in the tenant " + this.tenant +
+                                "."));
+    }
+
+    @Test
+    public void testUpdateValidatorWithInvalidKeys() throws JsonProcessingException {
+
+        String endpoint = CERTIFICATE_VALIDATION_API_BASE_PATH + REVOCATION_VALIDATORS_PATH + "/" + OCSP_VALIDATOR;
+
+        // Invalid values: negative priority and retryCount
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("wrong_key", true);
+        requestBody.put(PRIORITY_KEY, 1);
+        requestBody.put(FULL_CHAIN_VALIDATION_KEY, true);
+        requestBody.put(RETRY_COUNT_KEY, 5);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBody);
+
+        Response response = getResponseOfPut(endpoint, requestBodyJson);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Provided request body content is not in the expected format."));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/revocationvalidators/RevocationValidatorsSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/revocationvalidators/RevocationValidatorsSuccessTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.revocationvalidators;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+/**
+ * Tests for happy paths of the Certificate Validation Management REST API Revocation Validators.
+ */
+public class RevocationValidatorsSuccessTest extends RevocationValidatorsTestBase {
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public RevocationValidatorsSuccessTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws IOException {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void testConclude() throws Exception {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @Test
+    public void testGetRevocationValidators() {
+
+        Response responseOfGet = getResponseOfGet(CERTIFICATE_VALIDATION_API_BASE_PATH + REVOCATION_VALIDATORS_PATH);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(VALIDATORS_KEY, notNullValue())
+                .body(VALIDATORS_KEY + ".size()", equalTo(2))
+                .body(VALIDATORS_KEY, org.hamcrest.Matchers.hasItems(OCSP_VALIDATOR, CRL_VALIDATOR));
+    }
+
+    @Test
+    public void testGetFullChainValidationValidator() {
+
+        Response response = getResponseOfGet(
+                CERTIFICATE_VALIDATION_API_BASE_PATH + REVOCATION_VALIDATORS_PATH + "/" + OCSP_VALIDATOR
+        );
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(ENABLE_KEY, equalTo(ENABLED_VALUE))
+                .body(PRIORITY_KEY, equalTo(PRIORITY_VALUE))
+                .body(FULL_CHAIN_VALIDATION_KEY, equalTo(FULL_CHAIN_VALIDATION_VALUE))
+                .body(RETRY_COUNT_KEY, equalTo(RETRY_COUNT_VALUE));
+    }
+
+    @Test
+    public void testUpdateFullChainValidationValidator() throws JsonProcessingException {
+
+        String endpoint = CERTIFICATE_VALIDATION_API_BASE_PATH + REVOCATION_VALIDATORS_PATH + "/" + OCSP_VALIDATOR;
+
+        // Prepare request body
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put(ENABLE_KEY, ENABLED_VALUE);
+        requestBody.put(PRIORITY_KEY, PRIORITY_VALUE);
+        requestBody.put(FULL_CHAIN_VALIDATION_KEY, FULL_CHAIN_VALIDATION_VALUE);
+        requestBody.put(RETRY_COUNT_KEY, 3); // Use 3 as per the test requirement
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBody);
+
+        Response response = getResponseOfPut(endpoint, requestBodyJson);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body(ENABLE_KEY, equalTo(ENABLED_VALUE))
+                .body(PRIORITY_KEY, equalTo(PRIORITY_VALUE))
+                .body(FULL_CHAIN_VALIDATION_KEY, equalTo(FULL_CHAIN_VALIDATION_VALUE))
+                .body(RETRY_COUNT_KEY, equalTo(3));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/revocationvalidators/RevocationValidatorsTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/certificate/validation/management/v1/revocationvalidators/RevocationValidatorsTestBase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.revocationvalidators;
+
+import org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.common.CertificateValidationTestBase;
+
+public class RevocationValidatorsTestBase extends CertificateValidationTestBase {
+
+    protected static final String REVOCATION_VALIDATORS_PATH = "/revocation-validators";
+    protected static final String VALIDATORS_KEY = "Validators";
+    protected static final String OCSP_VALIDATOR = "ocspvalidator";
+    protected static final String CRL_VALIDATOR = "crlvalidator";
+
+    protected static final String ENABLE_KEY = "enable";
+    protected static final String PRIORITY_KEY = "priority";
+    protected static final String FULL_CHAIN_VALIDATION_KEY = "fullChainValidation";
+    protected static final String RETRY_COUNT_KEY = "retryCount";
+    protected static final boolean ENABLED_VALUE = true;
+    protected static final int PRIORITY_VALUE = 1;
+    protected static final boolean FULL_CHAIN_VALIDATION_VALUE = true;
+    protected static final int RETRY_COUNT_VALUE = 2;
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/certificate-validation-mgt/certificate_validation_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/certificate-validation-mgt/certificate_validation_config.toml
@@ -1,0 +1,60 @@
+[server]
+hostname = "localhost"
+node_ip = "127.0.0.1"
+base_path = "https://$ref{server.hostname}:${carbon.management.port}"
+enable_admin_services = true
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[user_store]
+type = "database_unique_id"
+
+[database.identity_db]
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
+
+[database.shared_db]
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
+
+[keystore.primary]
+file_name = "wso2carbon.p12"
+password = "wso2carbon"
+type = "PKCS12"
+
+[truststore]
+file_name = "client-truststore.p12"
+password = "wso2carbon"
+type = "PKCS12"
+
+[custom_transport.x509.properties]
+protocols="HTTP/1.1"
+port="8443"
+maxThreads="200"
+scheme="https"
+secure=true
+SSLEnabled=true
+keystoreFile="./repository/resources/security/wso2carbon.p12"
+keystorePass="wso2carbon"
+truststoreFile="./repository/resources/security/client-truststore.p12"
+truststorePass="wso2carbon"
+bindOnInit=false
+clientAuth="want"
+ssl_protocol = "TLS"
+
+[certificate_validation]
+ocsp_validator_enabled = false
+crl_validator_enabled = false
+
+[authentication.authenticator.x509_certificate.parameters]
+name ="x509CertificateAuthenticator"
+enable=true
+AuthenticationEndpoint="https://localhost:8443/x509-certificate-servlet"
+username= "CN"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -464,6 +464,10 @@
             <class name="org.wso2.identity.integration.test.oauth2.Oauth2TokenRenewalPerRequestTestCase"/>
             <!--<class name="org.wso2.identity.integration.test.saml.SAMLECPSSOTestCase"/>-->
             <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.revocationvalidators.RevocationValidatorsSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.revocationvalidators.RevocationValidatorsFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates.CACertificatesSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.certificate.validation.management.v1.cacertificates.CACertificatesFailureTest"/>
             <class name="org.wso2.identity.integration.test.idp.mgt.ChallengeQuestionsUITestCase"/>
             <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockWhileCaseInsensitiveUserFalseTestCase"/>
             <class name="org.wso2.identity.integration.test.EmailOTPTestCase"/>


### PR DESCRIPTION
This pull request introduces a new suite of integration tests for the Certificate Validation Management REST API, specifically targeting the CA Certificates endpoints. The changes add comprehensive test coverage for both successful and failure scenarios, along with supporting base classes and models to facilitate these tests.

### New CA Certificates Integration Test Suite

**Test Coverage for CA Certificates API:**
- Added `CACertificatesSuccessTest` to validate the full lifecycle of CA certificates (add, get, update, delete) through the REST API, ensuring correct behavior for valid inputs.
- Added `CACertificatesFailureTest` to verify error handling for invalid operations, such as adding malformed certificates and querying non-existent certificate IDs.

**Supporting Test Infrastructure:**
- Introduced `CACertificatesTestBase` to provide shared constants and setup for CA certificate tests, inheriting from a new common test base.
- Added `CertificateValidationTestBase` for shared setup, test data, and utility methods across certificate validation tests, including common constants and JSON serialization.

**Model for Test Requests:**
- Implemented `CACertificateAddRequest` model representing the payload for adding CA certificates, with support for base64 encoded certificates and proper serialization.