### PR TITLE
Integration test for supporting RT in Impersonation

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2ImpersonationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/Oauth2ImpersonationTestCase.java
@@ -305,6 +305,39 @@ public class Oauth2ImpersonationTestCase extends OAuth2ServiceAbstractIntegratio
         Map<String, String>  actClaimSet = (Map) jwtClaimsSet.getClaim("act");
         Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
         Assert.assertEquals(actClaimSet.get("sub"), impersonatorId, "Impersonator Id is not in the act claim." );
+        String refreshToken = (String) jsonResponse.get(OAuth2Constant.REFRESH_TOKEN);
+        Assert.assertNotNull(jsonResponse.get(OAuth2Constant.REFRESH_TOKEN), "Refresh token is null.");
+        urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair(GRANT_TYPE_KEY, OAUTH2_GRANT_TYPE_REFRESH_TOKEN));
+        urlParameters.add(new BasicNameValuePair(OAUTH2_GRANT_TYPE_REFRESH_TOKEN, refreshToken));
+
+        jsonResponse = responseObject(url, urlParameters, consumerKey, consumerSecret);
+        Assert.assertNotNull(jsonResponse.get(OAuth2Constant.ACCESS_TOKEN), "Access token is null.");
+        accessToken = (String) jsonResponse.get(OAuth2Constant.ACCESS_TOKEN);
+        jwtClaimsSet = SignedJWT.parse(accessToken).getJWTClaimsSet();
+        Assert.assertEquals(jwtClaimsSet.getSubject(), endUserId,
+                "Subject Id is not end user Id in the impersonation flow." );
+
+        actClaimSet = (Map) jwtClaimsSet.getClaim("act");
+        Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
+        Assert.assertEquals(actClaimSet.get("sub"), impersonatorId, "Impersonator Id is not in the act claim.");
+
+        refreshToken = (String) jsonResponse.get(OAuth2Constant.REFRESH_TOKEN);
+        Assert.assertNotNull(jsonResponse.get(OAuth2Constant.REFRESH_TOKEN), "Refresh token is null.");
+        urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair(GRANT_TYPE_KEY, OAUTH2_GRANT_TYPE_REFRESH_TOKEN));
+        urlParameters.add(new BasicNameValuePair(OAUTH2_GRANT_TYPE_REFRESH_TOKEN, refreshToken));
+
+        jsonResponse = responseObject(url, urlParameters, consumerKey, consumerSecret);
+        Assert.assertNotNull(jsonResponse.get(OAuth2Constant.ACCESS_TOKEN), "Access token is null.");
+        accessToken = (String) jsonResponse.get(OAuth2Constant.ACCESS_TOKEN);
+        jwtClaimsSet = SignedJWT.parse(accessToken).getJWTClaimsSet();
+        Assert.assertEquals(jwtClaimsSet.getSubject(), endUserId,
+                "Subject Id is not end user Id in the impersonation flow." );
+
+        actClaimSet = (Map) jwtClaimsSet.getClaim("act");
+        Assert.assertNotNull(actClaimSet, "Act claim of impersonated access token is empty");
+        Assert.assertEquals(actClaimSet.get("sub"), impersonatorId, "Impersonator Id is not in the act claim.");
     }
 
     @Test(groups = "wso2.is", description = "Send authorize user request to SSO as the impersonatee for code.",


### PR DESCRIPTION
Issue: https://github.com/wso2/product-is/issues/25778

<img width="3457" height="2710" alt="image" src="https://github.com/user-attachments/assets/a5d616bb-dcbf-4c28-8ab0-b8ae873c4085" />


This pull request enhances the OAuth2 impersonation integration tests by adding comprehensive validation for refresh token flows. The changes ensure that refresh tokens issued during impersonation can be used to obtain new access tokens, and that the claims in the resulting tokens remain correct. This improves the reliability and coverage of the test suite for OAuth2 impersonation scenarios.

### Refresh Token Flow Validation

* Added checks to verify that refresh tokens are issued and not null in both `testSendTokenExchangeRequestPost` and `testSendCodeTokenRequestPost` methods. [[1]](diffhunk://#diff-8e7284f7d1a553f1f77287b25dc13cb179e4dcea46a23be60da28ae732dd169bR308-R340) [[2]](diffhunk://#diff-8e7284f7d1a553f1f77287b25dc13cb179e4dcea46a23be60da28ae732dd169bR398-R430)
* Extended tests to use the refresh token to request new access tokens, and validated that the returned access tokens have the expected subject and impersonator claims. These refresh flow checks are performed multiple times to ensure consistency. [[1]](diffhunk://#diff-8e7284f7d1a553f1f77287b25dc13cb179e4dcea46a23be60da28ae732dd169bR308-R340) [[2]](diffhunk://#diff-8e7284f7d1a553f1f77287b25dc13cb179e4dcea46a23be60da28ae732dd169bR398-R430)

### Test Imports and Setup

* Imported `OAUTH2_GRANT_TYPE_REFRESH_TOKEN` constant to support the new refresh token grant type checks in the test methods.