### PR TITLE
Format timestamps in workflow approval details

### DIFF
--- a/modules/features/org.wso2.identity.jaggery.apps.feature/pom.xml
+++ b/modules/features/org.wso2.identity.jaggery.apps.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.is</groupId>
         <artifactId>identity-features</artifactId>
-        <version>5.10.0-m8-SNAPSHOT</version>
+        <version>7.2.0-beta2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/features/org.wso2.identity.jaggery.apps.feature/src/main/resources/portal/gadgets/approvals/controllers/approvals/form-client.jag
+++ b/modules/features/org.wso2.identity.jaggery.apps.feature/src/main/resources/portal/gadgets/approvals/controllers/approvals/form-client.jag
@@ -24,6 +24,28 @@ var cookie = request.getParameter("cookie");
 var id = request.getParameter("id");
 var user = request.getParameter("user");
 var endPoint = request.getParameter("endPoint");
+
+function formatISODate(isoDateString) {
+    if (!isoDateString) {
+        return "";
+    }
+    var date = new Date(isoDateString);
+    if (isNaN(date.getTime())) {
+        return isoDateString; // Return original string if it's not a valid date
+    }
+    var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    var year = date.getFullYear();
+    var month = months[date.getMonth()];
+    var day = date.getDate();
+    var hour = date.getHours();
+    var min = date.getMinutes();
+    var ampm = hour >= 12 ? 'PM' : 'AM';
+    hour = hour % 12;
+    hour = hour ? hour : 12; // the hour '0' should be '12'
+    min = min < 10 ? '0' + min : min;
+    return month + ' ' + day + ', ' + year + ' ' + hour + ':' + min + ' ' + ampm;
+}
+
 accessService();
 function accessService() {
     session.put('auth-cookie', cookie);
@@ -43,6 +65,23 @@ function accessService() {
             version.send(payload);
             result = E4XtoJSON(version.responseE4X);
             result = new XML(result.taskData);
+
+            var ht_ns = new Namespace("http://ht.bpel.mgt.workflow.identity.carbon.wso2.org/wsdl/schema");
+            var nodes = result.*::["xsd-complex-type-wrapper"];
+
+            for (var i = 0; i < nodes.length(); i++) {
+                var node = nodes[i];
+                var itemName = node.attribute(ht_ns::itemName).toString();
+
+                if (itemName === "Created Time" || itemName === "Last Modified Time") {
+                    var timestamp = node.toString();
+                    if (timestamp) {
+                        var formattedDate = formatISODate(timestamp);
+                        node.setChildren(formattedDate);
+                    }
+                }
+            }
+
         } catch (e) {
             log.error(e.toString());
             return e.toString();

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -38,6 +38,7 @@
 		<module>org.wso2.identity.styles.feature</module>
 		<module>org.wso2.identity.utils.feature</module>
 		<module>org.wso2.identity.ui.feature</module>
+		<module>org.wso2.identity.jaggery.apps.feature</module>
 	</modules>
 
 </project>


### PR DESCRIPTION
Fix: #25100 

The timestamps for 'Created Time' and 'Last Modified Time' on the workflow approval details page were not formatted, making them difficult to read.

This change introduces a `formatISODate` function in `modules/features/org.wso2.identity.jaggery.apps.feature/src/main/resources/portal/gadgets/approvals/controllers/approvals/form-client.jag` to format the ISO date strings into a more user-friendly format (e.g., 'MMM d, yyyy, h:mm:ss a').

The `accessService` function in the same file has been updated to parse the XML response from the backend, extract the 'Created Time' and 'Last Modified Time' values, and apply the new formatting before sending the data to the frontend.