### PR TITLE
Add webhook management api integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/management/v1/WebhookManagementFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/management/v1/WebhookManagementFailureTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.webhook.management.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.*;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.model.WebhookRequest;
+import org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.model.WebhookRequestEventProfile;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ * Negative-path tests for the Webhook Management REST API.
+ */
+public class WebhookManagementFailureTest extends WebhookManagementTestBase {
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public WebhookManagementFailureTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void concludeClass() {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setBasePath() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void clearBasePath() {
+
+        RestAssured.basePath = StringUtils.EMPTY;
+    }
+
+    @Test
+    public void testCreateWebhookWithInvalidEndpointUrl() {
+
+        WebhookRequest req = validRequest()
+                .endpoint("not-a-url");
+
+        getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH, toJSONString(req))
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_BAD_REQUEST).body("code", equalTo("WEBHOOKMGT-60012"))
+                .body("message", equalTo("Invalid request."))
+                .body("description", equalTo("Endpoint URI is invalid."));
+    }
+
+    @Test
+    public void testCreateWebhookWithEmptyEventProfileFields() {
+
+        WebhookRequest req = validRequest()
+                .eventProfile(new WebhookRequestEventProfile().name("").uri(""));
+
+        getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH, toJSONString(req))
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_BAD_REQUEST).body("code", equalTo("WEBHOOKMGT-60011"))
+                .body("message", equalTo("Invalid request."))
+                .body("description",
+                        equalTo("Event Profile Name is empty."));
+    }
+
+    @Test
+    public void testGetWebhookByInvalidId() {
+
+        getResponseOfGet(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + INVALID_ID)
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND).body("code", equalTo("WEBHOOKMGT-60010"))
+                .body("message", equalTo("Webhook is not found."))
+                .body("description", equalTo("No webhook is found for given webhook id: " + INVALID_ID));
+    }
+
+    @Test
+    public void testUpdateWebhookWithInvalidId() {
+
+        WebhookRequest update = validRequest();
+
+        getResponseOfPut(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + INVALID_ID, toJSONString(update))
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND).body("code", equalTo("WEBHOOKMGT-60010"))
+                .body("message", equalTo("Webhook is not found."))
+                .body("description", equalTo("No webhook is found for given webhook id: " + INVALID_ID));
+    }
+
+    @Test
+    public void testActivateWebhookWithInvalidId() {
+
+        getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + INVALID_ID + "/activate", "")
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND).body("code", equalTo("WEBHOOKMGT-60010"))
+                .body("message", equalTo("Webhook is not found."))
+                .body("description", equalTo("No webhook is found for given webhook id: " + INVALID_ID));
+    }
+
+    @Test
+    public void testDeactivateWebhookWithInvalidId() {
+
+        getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + INVALID_ID + "/deactivate", "")
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND).body("code", equalTo("WEBHOOKMGT-60010"))
+                .body("message", equalTo("Webhook is not found."))
+                .body("description", equalTo("No webhook is found for given webhook id: " + INVALID_ID));
+    }
+
+    @Test
+    public void testRetryWebhookWithInvalidId() {
+
+        getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + INVALID_ID + "/retry", "")
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND).body("code", equalTo("WEBHOOKMGT-60010"))
+                .body("message", equalTo("Webhook is not found."))
+                .body("description", equalTo("No webhook is found for given webhook id: " + INVALID_ID));
+    }
+
+    @Test
+    public void testDeleteWebhookWithInvalidId() {
+
+        getResponseOfDelete(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + INVALID_ID)
+                .then().log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND).body("code", equalTo("WEBHOOKMGT-60010"))
+                .body("message", equalTo("Webhook is not found."))
+                .body("description", equalTo("No webhook is found for given webhook id: " + INVALID_ID));
+    }
+
+
+    @Test
+    public void testRetryWebhook() {
+
+        String testWebhookId = createWebhook();
+        Response response = getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + testWebhookId + "/retry", "");
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_BAD_REQUEST).body("code", equalTo("WEBHOOKMGT-65028"))
+                .body("message", equalTo("Unable to perform the operation."))
+                .body("description", equalTo("Operation is not supported for Publisher adapter type."));
+    }
+
+    // -------- Helpers --------
+
+    private WebhookRequest validRequest() {
+
+        return new WebhookRequest()
+                .endpoint(TEST_ENDPOINT_URI)
+                .name(TEST_WEBHOOK_NAME)
+                .secret(TEST_SECRET)
+                .eventProfile(
+                        new WebhookRequestEventProfile().name(TEST_EVENT_PROFILE_NAME).uri(TEST_EVENT_PROFILE_URI))
+                .addChannelsSubscribedItem(CHANNEL_LOGIN)
+                .addChannelsSubscribedItem(CHANNEL_REG)
+                .status(WebhookRequest.StatusEnum.ACTIVE);
+    }
+
+    /**
+     * Creates one valid webhook and returns its id (used for negative update-body test).
+     */
+    private String createWebhook() {
+
+        Response res = getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH, toJSONString(validRequest()));
+        res.then().statusCode(HttpStatus.SC_CREATED);
+        return res.getBody().jsonPath().getString("id");
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/management/v1/WebhookManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/management/v1/WebhookManagementSuccessTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.webhook.management.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.hamcrest.CoreMatchers;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.model.WebhookRequest;
+import org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.model.WebhookRequestEventProfile;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.hasKey;
+
+/**
+ * Tests for happy paths of the Webhook Management REST API.
+ */
+public class WebhookManagementSuccessTest extends WebhookManagementTestBase {
+
+    private static String testWebhookId;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public WebhookManagementSuccessTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void concludeClass() {
+
+        testWebhookId = null;
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setBasePath() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @Test
+    public void testCreateWebhook() {
+
+        WebhookRequestEventProfile profile = new WebhookRequestEventProfile()
+                .name(TEST_EVENT_PROFILE_NAME)
+                .uri(TEST_EVENT_PROFILE_URI);
+
+        WebhookRequest request = new WebhookRequest()
+                .endpoint(TEST_ENDPOINT_URI)
+                .name(TEST_WEBHOOK_NAME)
+                .secret(TEST_SECRET)
+                .addChannelsSubscribedItem(CHANNEL_LOGIN)
+                .addChannelsSubscribedItem(CHANNEL_REG)
+                .eventProfile(profile)
+                .status(WebhookRequest.StatusEnum.ACTIVE);
+
+        String body = toJSONString(request);
+
+        Response response = getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("id", notNullValue())
+                .body("name", equalTo(TEST_WEBHOOK_NAME))
+                .body("endpoint", equalTo(TEST_ENDPOINT_URI))
+                .body("eventProfile.name", equalTo(TEST_EVENT_PROFILE_NAME))
+                .body("eventProfile.uri", equalTo(TEST_EVENT_PROFILE_URI))
+                .body("status", equalTo(STATUS_ACTIVE))
+                // response must not echo secrets
+                .body("$", not(hasKey("secret")))
+                // subscribed channels should be reflected as objects with channelUri
+                .body("channelsSubscribed.find { it.channelUri == '" + CHANNEL_LOGIN + "' }", notNullValue())
+                .body("channelsSubscribed.find { it.channelUri == '" + CHANNEL_REG + "' }", notNullValue());
+
+        testWebhookId = response.getBody().jsonPath().getString("id");
+    }
+
+    @Test(dependsOnMethods = "testCreateWebhook")
+    public void testListWebhooks() {
+
+        Response response = getResponseOfGet(WEBHOOK_MANAGEMENT_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("webhooks.find { it.id == '" + testWebhookId + "' }.name", equalTo(TEST_WEBHOOK_NAME))
+                .body("webhooks.find { it.id == '" + testWebhookId + "' }.endpoint", equalTo(TEST_ENDPOINT_URI))
+                // "self" link exists and ends with /webhooks/{id}
+                .body("webhooks.find { it.id == '" + testWebhookId + "' }.self",
+                        CoreMatchers.endsWith("/webhooks/" + testWebhookId));
+    }
+
+    @Test(dependsOnMethods = "testListWebhooks")
+    public void testGetWebhookById() {
+
+        Response response = getResponseOfGet(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + testWebhookId);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(testWebhookId))
+                .body("name", equalTo(TEST_WEBHOOK_NAME))
+                .body("endpoint", equalTo(TEST_ENDPOINT_URI))
+                .body("eventProfile.name", equalTo(TEST_EVENT_PROFILE_NAME))
+                .body("eventProfile.uri", equalTo(TEST_EVENT_PROFILE_URI))
+                .body("status", anyOf(equalTo(STATUS_ACTIVE), equalTo("PARTIALLY_ACTIVE")))
+                .body("channelsSubscribed.find { it.channelUri == '" + CHANNEL_LOGIN + "' }", notNullValue())
+                .body("channelsSubscribed.find { it.channelUri == '" + CHANNEL_REG + "' }", notNullValue());
+    }
+
+    @Test(dependsOnMethods = "testGetWebhookById")
+    public void testUpdateWebhook() {
+
+        // PUT uses the same request model. Update name, endpoint and subscriptions; set INACTIVE.
+        WebhookRequest update = new WebhookRequest()
+                .endpoint(TEST_UPDATED_ENDPOINT_URI)
+                .name(TEST_WEBHOOK_UPDATED_NAME)
+                .secret("updated-secret")
+                .addChannelsSubscribedItem(CHANNEL_LOGIN) // drop the registration channel in this update
+                .eventProfile(new WebhookRequestEventProfile()
+                        .name(TEST_EVENT_PROFILE_NAME)
+                        .uri(TEST_EVENT_PROFILE_URI))
+                .status(WebhookRequest.StatusEnum.INACTIVE);
+
+        String body = toJSONString(update);
+
+        System.out.println(body);
+
+        Response response = getResponseOfPut(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + testWebhookId, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(testWebhookId))
+                .body("name", equalTo(TEST_WEBHOOK_UPDATED_NAME))
+                .body("endpoint", equalTo(TEST_UPDATED_ENDPOINT_URI))
+                .body("status", equalTo(STATUS_INACTIVE))
+                .body("$", not(hasKey("secret")))
+                .body("channelsSubscribed.find { it.channelUri == '" + CHANNEL_LOGIN + "' }", notNullValue())
+                .body("channelsSubscribed.find { it.channelUri == '" + CHANNEL_REG + "' }", nullValue());
+    }
+
+    @Test(dependsOnMethods = "testUpdateWebhook")
+    public void testActivateWebhook() {
+
+        Response response = getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + testWebhookId + "/activate", "");
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(testWebhookId))
+                // Allow partial active in case any subscription is pending/error.
+                .body("status", anyOf(equalTo("ACTIVE"), equalTo("PARTIALLY_ACTIVE")));
+    }
+
+    @Test(dependsOnMethods = "testActivateWebhook")
+    public void testDeactivateWebhook() {
+
+        Response response =
+                getResponseOfPost(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + testWebhookId + "/deactivate", "");
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(testWebhookId))
+                .body("status", anyOf(equalTo("INACTIVE"), equalTo("PARTIALLY_INACTIVE")));
+    }
+
+    @Test(dependsOnMethods = "testDeactivateWebhook")
+    public void testDeleteWebhook() {
+
+        getResponseOfDelete(WEBHOOK_MANAGEMENT_API_BASE_PATH + "/" + testWebhookId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Ensure it no longer appears in list.
+        getResponseOfGet(WEBHOOK_MANAGEMENT_API_BASE_PATH)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("webhooks.find { it.id == '" + testWebhookId + "' }", nullValue());
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/management/v1/WebhookManagementTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/management/v1/WebhookManagementTestBase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.webhook.management.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.restassured.RestAssured;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
+
+import java.io.IOException;
+
+public class WebhookManagementTestBase extends RESTAPIServerTestBase {
+
+    private static final String API_DEFINITION_NAME = "webhook-management.yaml";
+    protected static final String API_VERSION = "v1";
+    protected static final String WEBHOOK_MANAGEMENT_API_BASE_PATH = "/webhooks";
+
+    protected static final String INVALID_ID = "00000000-0000-0000-0000-000000000000";
+
+    protected static final String CHANNEL_LOGIN = "https://schemas.identity.wso2.org/events/login";
+    protected static final String CHANNEL_REG = "https://schemas.identity.wso2.org/events/registration";
+
+    protected static final String TEST_WEBHOOK_NAME = "Login Webhook";
+    protected static final String TEST_WEBHOOK_UPDATED_NAME = "Login Webhook Updated";
+    protected static final String TEST_ENDPOINT_URI = "https://example.com/webhook";
+    protected static final String TEST_UPDATED_ENDPOINT_URI = "https://example.com/webhook-updated";
+    protected static final String TEST_EVENT_PROFILE_NAME = "WSO2";
+    protected static final String TEST_EVENT_PROFILE_URI = "https://schemas.identity.wso2.org/events";
+    protected static final String TEST_SECRET = "my-secret";
+
+    protected static final String STATUS_ACTIVE = "ACTIVE";
+    protected static final String STATUS_INACTIVE = "INACTIVE";
+
+    protected static String swaggerDefinition;
+
+    static {
+        String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.webhook.management.v1";
+        try {
+            swaggerDefinition = getAPISwaggerDefinition(API_PACKAGE_NAME, API_DEFINITION_NAME);
+        } catch (IOException e) {
+            Assert.fail(String.format("Unable to read the swagger definition %s from %s", API_DEFINITION_NAME,
+                    API_PACKAGE_NAME), e);
+        }
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.init();
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    /**
+     * To convert object to a json string.
+     *
+     * @param object Respective java object.
+     * @return Relevant json string.
+     */
+    protected String toJSONString(Object object) {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(object);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -274,6 +274,8 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.action.management.v1.preupdatepassword.PreUpdatePasswordActionFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.action.management.v1.preupdateprofile.PreUpdateProfileActionSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.action.management.v1.preupdateprofile.PreUpdateProfileActionFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.WebhookManagementSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.WebhookManagementFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.extension.management.v1.ExtensionManagementSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.authenticator.management.v1.AuthenticatorSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.authenticator.management.v1.AuthenticatorFailureTest"/>


### PR DESCRIPTION
This pull request introduces comprehensive integration tests for the Webhook Management REST API, covering both successful (happy path) and failure (negative path) scenarios. It adds two new test classes—one for validating correct API behavior and another for ensuring robust error handling. Additionally, a shared test base class is provided to centralize common logic and constants, and the test suite configuration is updated to include these new tests.

**New Webhook Management Integration Tests**

* Added `WebhookManagementSuccessTest` to validate all major happy path operations for the webhook API, including create, list, get, update, activate, deactivate, and delete actions. These tests assert correct status codes, response bodies, and business logic (e.g., secrets are not echoed, channels are handled correctly).
* Added `WebhookManagementFailureTest` to verify negative scenarios such as invalid endpoint URLs, empty event profile fields, and operations on non-existent webhook IDs. These tests assert appropriate error codes, messages, and descriptions for each failure case.

**Test Framework Improvements**

* Introduced `WebhookManagementTestBase`, a shared base class for webhook management tests. It provides common constants, test setup/teardown, utility methods for JSON conversion, and a data provider for user modes, ensuring consistency and reducing duplication.

**Test Suite Configuration**

* Updated `testng.xml` to include both the success and failure webhook management test classes, ensuring they are executed as part of the integration test suite.