### PR TITLE
Update identity.server.api.version to 1.3.207

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2681,7 +2681,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.17</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.206</identity.server.api.version>
+        <identity.server.api.version>1.3.207</identity.server.api.version>
         <identity.user.api.version>1.3.71</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
This pull request updates a dependency version in the `pom.xml` file to ensure the project uses the latest release of the identity server API.

Dependency update:

* Upgraded the `identity.server.api.version` from `1.3.206` to `1.3.207` in `pom.xml`, which may include important bug fixes or new features from the identity server API.