### PR TITLE
Update doc link to 7.2.0

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -74,7 +74,7 @@
   "legacy_authz_runtime.enable": false,
   "management_console_deprecation_banner.enable": true,
 
-  "console.doc_site_path": "https://is.docs.wso2.com/en/latest",
+  "console.doc_site_path": "https://is.docs.wso2.com/en/7.2.0",
 
   "admin_service.deny_list": [
     "CarbonAppUploader",


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/26022

Note: with this fix the doc link will not work properly as the 7.2.0 docs are not deployed yet. It will redirect to a 404 page.