### PR TITLE
Bump framework version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2550,7 +2550,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.581</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.583</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file, bumping the `carbon.identity.framework.version` from `7.8.581` to `7.8.583`. This ensures the project uses the latest patch version of the Carbon Identity Framework dependency.