### PR TITLE
Retrieve all logs for FAPI and OIDC Conformance suites 

### DIFF
--- a/oidc-conformance-tests/export_results.py
+++ b/oidc-conformance-tests/export_results.py
@@ -34,7 +34,7 @@ def get_failed_tests(plan):
     test_fails = []
     test_warnings = []
     test_others = []
-    test_log = json.loads(requests.get(url=conformance_suite_url + "/api/log?length=100&search=" + plan['_id'], verify=False).content)
+    test_log = json.loads(requests.get(url=conformance_suite_url + "/api/log?length=10000&search=" + plan['_id'], verify=False).content)
     for test in test_log['data']:
         if "result" in test and test['result'] == "FAILED":
             test_fails.append('Test Name: ' + test['testName'] + '  id: ' + test['testId'])

--- a/oidc-fapi-conformance-tests/export_results_fapi.py
+++ b/oidc-fapi-conformance-tests/export_results_fapi.py
@@ -19,7 +19,7 @@ def get_failed_tests(plan):
     test_fails = []
     test_warnings = []
     test_others = []
-    test_log = json.loads(requests.get(url=conformance_suite_url + "/api/log?length=100&search=" + plan['_id'], verify=False).content)
+    test_log = json.loads(requests.get(url=conformance_suite_url + "/api/log?length=1000&search=" + plan['_id'], verify=False).content)
     for test in test_log['data']:
         if "result" in test and test['result'] == "FAILED":
             test_fails.append('Test Name: ' + test['testName'] + '  id: ' + test['testId'])


### PR DESCRIPTION
Currently, not all logs are retrieved to analyse the status of the test suite. That is resolved with this PR

Issue : https://github.com/wso2/product-is/issues/25132