### PR TITLE
Bump identity apps console version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2693,7 +2693,7 @@
         <conditional.authentication.functions.version>1.2.84</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.81.3</identity.apps.console.version>
+        <identity.apps.console.version>2.81.4</identity.apps.console.version>
         <identity.apps.myaccount.version>2.25.14</identity.apps.myaccount.version>
         <identity.apps.core.version>3.3.21</identity.apps.core.version>
         <identity.apps.tests.version>1.6.383</identity.apps.tests.version>


### PR DESCRIPTION
This pull request updates the version of the Identity Apps Console dependency in the `pom.xml` file.

- Dependency update:
  * Bumped the `identity.apps.console.version` from `2.81.3` to `2.81.4` in `pom.xml` to use the latest version of the Identity Apps Console.