### PR TITLE
Bump scim2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2583,7 +2583,7 @@
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.13.2</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.14</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.212</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.213</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.12</identity.user.account.association.version>


### PR DESCRIPTION
This pull request contains a minor update to the `pom.xml` file, specifically upgrading the version of the `identity.inbound.provisioning.scim2` dependency. This is a routine dependency version bump to ensure the project uses the latest compatible features and fixes. 

* Upgraded `identity.inbound.provisioning.scim2.version` from `3.4.212` to `3.4.213` in `pom.xml`