### PR TITLE
Add maven command to windows

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To build the WSO2 Identity Server distribution from source, follow these steps:
       _(Builds the binary and source distributions with tests)_
     - `mvn clean install -Dmaven.test.skip=true`  
       _(Builds the binary and source distributions without running any unit/integration tests)_
-6. The binary distribution will be available in the `product-is/modules/distribution/target` directory.
+5. The binary distribution will be available in the `product-is/modules/distribution/target` directory.
 
 ## Installation and Running/Debugging
 


### PR DESCRIPTION
The `export` is used in Linux/macOS distributions and in Windows operating systems `set` is used to add the environment variables. I've added the both commands mentioning there operating system to help the user select according their system.