### PR TITLE
uncommented the testcases that failed due to unresolved email templates.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionFailureTestCase.java
@@ -228,21 +228,21 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
                 PreUpdatePasswordEvent.Action.UPDATE);
     }
 
-//     @Test(dependsOnMethods = "testAdminUpdatePassword",
-//             description = "Verify the user password reset with pre update password action")
-//     public void testUserResetPassword() throws Exception {
+    @Test(dependsOnMethods = "testAdminUpdatePassword",
+            description = "Verify the user password reset with pre update password action")
+    public void testUserResetPassword() throws Exception {
 
-//         String passwordRecoveryFormURL = retrievePasswordResetURL(application);
-//         submitPasswordRecoveryForm(passwordRecoveryFormURL, TEST_USER1_USERNAME);
+        String passwordRecoveryFormURL = retrievePasswordResetURL(application);
+        submitPasswordRecoveryForm(passwordRecoveryFormURL, TEST_USER1_USERNAME);
 
-//         String recoveryLink = getRecoveryURLFromEmail();
-//         HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
-//         Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
-//         assertErrors(postResponse);
+        String recoveryLink = getRecoveryURLFromEmail();
+        HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
+        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        assertErrors(postResponse);
 
-//         assertActionRequestPayload(userId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
-//                 PreUpdatePasswordEvent.Action.RESET);
-//     }
+        assertActionRequestPayload(userId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
+                PreUpdatePasswordEvent.Action.RESET);
+    }
 
 //    @Test(dependsOnMethods = "testAdminUpdatePassword",
 //            description = "Verify the user password recovery flow failure with pre update password action")
@@ -271,7 +271,7 @@ public class PreUpdatePasswordActionFailureTestCase extends PreUpdatePasswordAct
 //        updateFlowStatus(PASSWORD_RECOVERY_FLOW_TYPE, false);
 //    }
 
-    @Test(dependsOnMethods = "testAdminUpdatePassword",
+    @Test(dependsOnMethods = "testUserResetPassword",
             description = "Verify the admin force password reset with pre update password action")
     public void testAdminForcePasswordReset() throws Exception {
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -244,21 +244,21 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
                 PreUpdatePasswordEvent.Action.UPDATE);
     }
 
-//     @Test(dependsOnMethods = "testApplicationUpdatePassword",
-//             description = "Verify the user password reset with pre update password action")
-//     public void testUserResetPassword() throws Exception {
+    @Test(dependsOnMethods = "testApplicationUpdatePassword",
+            description = "Verify the user password reset with pre update password action")
+    public void testUserResetPassword() throws Exception {
 
-//         String passwordRecoveryFormURL = retrievePasswordResetURL(application);
-//         submitPasswordRecoveryForm(passwordRecoveryFormURL, TEST_USER1_USERNAME);
+        String passwordRecoveryFormURL = retrievePasswordResetURL(application);
+        submitPasswordRecoveryForm(passwordRecoveryFormURL, TEST_USER1_USERNAME);
 
-//         String recoveryLink = getRecoveryURLFromEmail();
-//         HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
-//         Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
-//         Assert.assertTrue(EntityUtils.toString(postResponse.getEntity()).contains("Password Reset Successfully"));
+        String recoveryLink = getRecoveryURLFromEmail();
+        HttpResponse postResponse = resetPassword(recoveryLink, RESET_PASSWORD);
+        Assert.assertEquals(postResponse.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK);
+        Assert.assertTrue(EntityUtils.toString(postResponse.getEntity()).contains("Password Reset Successfully"));
 
-//         assertActionRequestPayload(userId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
-//                 PreUpdatePasswordEvent.Action.RESET);
-//     }
+        assertActionRequestPayload(userId, RESET_PASSWORD, PreUpdatePasswordEvent.FlowInitiatorType.USER,
+                PreUpdatePasswordEvent.Action.RESET);
+    }
 
 //    @Test(dependsOnMethods = "testApplicationUpdatePassword",
 //            description = "Verify the user password recovery flow with pre update password action")
@@ -278,7 +278,7 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
 //        updateFlowStatus(PASSWORD_RECOVERY_FLOW_TYPE, false);
 //    }
 
-    @Test(dependsOnMethods = "testApplicationUpdatePassword",
+    @Test(dependsOnMethods = "testUserResetPassword",
             description = "Verify the user password set with pre update password action via offline invite link")
     public void testUserSetPasswordViaOfflineInviteLink() throws Exception {
 

--- a/pom.xml
+++ b/pom.xml
@@ -2555,7 +2555,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.595</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.597</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
the issue https://github.com/wso2/product-is/issues/25123 mention about commenting out test cases due to failing test cases https://github.com/wso2/product-is/pull/25109 . now the issue is fixed and merged (https://github.com/wso2/carbon-identity-framework/pull/7562), this pr uncomment the test cases mentioned on the issue(https://github.com/wso2/product-is/issues/25123#issuecomment-3185051391).