### PR TITLE
Ignore unknown properties in LocalClaimRes

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/LocalClaimRes.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/claim/management/v1/model/LocalClaimRes.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.integration.test.rest.api.server.claim.management.v1.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -28,6 +29,7 @@ import java.util.List;
 /**
  * Local claim response.
  **/
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LocalClaimRes {
 
     private String id = null;


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced JSON deserialization robustness in test utilities to gracefully handle unknown properties, improving test flexibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->