### PR TITLE
Update version numbers in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2583,12 +2583,12 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.0.392</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.394</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.11.63</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.10.2</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.13.2</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.7.14</identity.inbound.provisioning.scim.version>
-        <identity.inbound.provisioning.scim2.version>3.4.219</identity.inbound.provisioning.scim2.version>
+        <identity.inbound.provisioning.scim2.version>3.4.220</identity.inbound.provisioning.scim2.version>
 
         <!-- Identity User Versions -->
         <identity.user.account.association.version>5.5.12</identity.user.account.association.version>
@@ -2648,7 +2648,7 @@
 
         <!-- OAuth2 Grant Type extensions -->
         <identity.oauth2.jwt.bearer.grant.version>2.3.9</identity.oauth2.jwt.bearer.grant.version>
-        <identity.oauth2.token.exchange.grant.version>1.1.20</identity.oauth2.token.exchange.grant.version>
+        <identity.oauth2.token.exchange.grant.version>1.1.21</identity.oauth2.token.exchange.grant.version>
 
         <identity.oauth.dpop.version>2.0.7</identity.oauth.dpop.version>
 
@@ -2667,7 +2667,7 @@
         <authenticator.magiclink.version>1.1.45</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.1.35</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.0.52</authenticator.local.auth.emailotp.version>
-        <authenticator.local.auth.smsotp.version>1.0.40</authenticator.local.auth.smsotp.version>
+        <authenticator.local.auth.smsotp.version>1.0.41</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.1.2</authenticator.twitter.version>
         <authenticator.x509.version>3.1.34</authenticator.x509.version>
         <identity.extension.utils>1.0.22</identity.extension.utils>
@@ -2687,7 +2687,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.3.218</identity.server.api.version>
+        <identity.server.api.version>1.3.220</identity.server.api.version>
         <identity.user.api.version>1.3.71</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
This pull request updates several dependency versions in the `pom.xml` file to incorporate the latest bug fixes and improvements across authentication, provisioning, and API modules. These upgrades will help ensure compatibility with upstream changes and improve overall stability.

**Dependency Version Updates:**

_Authentication and Provisioning:_
* Upgraded `identity.inbound.auth.oauth` from `7.0.392` to `7.0.394` for improved OAuth support.
* Updated `identity.inbound.provisioning.scim2` from `3.4.219` to `3.4.220` for SCIM2 provisioning enhancements.
* Increased `authenticator.local.auth.smsotp` from `1.0.40` to `1.0.41` for SMS OTP authentication improvements.

_OAuth2 Extensions:_
* Bumped `identity.oauth2.token.exchange.grant` from `1.1.20` to `1.1.21` for token exchange grant type updates.

_API Feature:_
* Upgraded `identity.server.api` from `1.3.218` to `1.3.220` to include the latest API features and fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated versions for OAuth authentication, SCIM2 provisioning, OAuth2 token exchange, SMS OTP authentication, and Identity REST API components to latest stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->