### PR TITLE
Bump authenticator.local.auth.smsotp.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2667,7 +2667,7 @@
         <authenticator.magiclink.version>1.1.45</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.1.36</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.0.52</authenticator.local.auth.emailotp.version>
-        <authenticator.local.auth.smsotp.version>1.0.42</authenticator.local.auth.smsotp.version>
+        <authenticator.local.auth.smsotp.version>1.0.43</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.1.2</authenticator.twitter.version>
         <authenticator.x509.version>3.1.34</authenticator.x509.version>
         <identity.extension.utils>1.0.22</identity.extension.utils>


### PR DESCRIPTION
Note $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SMS One-Time Password authenticator component to version 1.0.43, improving dependency management and system stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->