### PR TITLE
Fix missing version in identity dashboard UI dependency Update pom.xml

### DIFF
--- a/modules/features/org.wso2.identity.ui.feature/pom.xml
+++ b/modules/features/org.wso2.identity.ui.feature/pom.xml
@@ -32,11 +32,12 @@
     <description>This feature contains the bundles required for Cloud Identity login UI and dashboard</description>
 
     <dependencies>
-        <dependency>
-            <groupId>org.wso2.identity</groupId>
-            <artifactId>org.wso2.stratos.identity.dashboard.ui</artifactId>
-        </dependency>
-    </dependencies>
+    <dependency>
+        <groupId>org.wso2.identity</groupId>
+        <artifactId>org.wso2.stratos.identity.dashboard.ui</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
Fix: Add missing version tag for org.wso2.stratos.identity.dashboard.ui dependency

The POM failed to build due to a missing dependency version.  Added <version>${project.version}</version> to ensure proper resolution  and maintain consistency with the parent project version.

### Summary
This PR fixes a build issue caused by a missing `<version>` tag in the
`org.wso2.stratos.identity.dashboard.ui` dependency declared in the
`org.wso2.identity.ui.feature` module.

### Issue
The POM file did not specify a version for the dependency, which results in:
- Maven build errors: 'dependencies.dependency.version' is missing
- Failure to resolve the artifact properly

### Fix
Added:
```xml
<version>${project.version}</version>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven dependency versioning to use project version reference for consistent build management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->