### PR TITLE
fix(build): correct Ant <cutdirs> usage in maven-antrun copy task (fixes build failure)Update pom.xml

### DIFF
--- a/modules/integration-ui-templates/pom.xml
+++ b/modules/integration-ui-templates/pom.xml
@@ -146,12 +146,12 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.build.directory}/templates" />
-                                <copy todir="${project.build.directory}/templates" overwrite="true">
+                               <copy todir="${project.build.directory}/templates" overwrite="true">
                                     <fileset dir="${project.build.directory}/unpacked-resources">
-                                        <include name="**/*" />
+                                          <include name="**/*" />
                                     </fileset>
-                                    <cutdirsmapper dirs="1" />
-                                </copy>
+                                    <cutdirs dirs="1"/>
+                              </copy>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
fix(build): replace invalid Ant element cutdirsmapper with cutdirs in maven-antrun copy task
### Summary
This PR fixes a build-breaking issue in the `maven-antrun-plugin` configuration. The `<copy>` task used an invalid Ant element `<cutdirsmapper dirs="1" />`, which is not supported by Ant and causes the antrun execution to fail. The element has been replaced with the correct `<cutdirs dirs="1"/>` element.

### Problem
- The POM previously contains:
  ```xml
  <cutdirsmapper dirs="1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven build configuration to use an updated directory-cutting mechanism within the template preparation process. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->