### PR TITLE
Add webhook metadata api integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/metadata/v1/WebhookMetadataFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/metadata/v1/WebhookMetadataFailureTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.webhook.metadata.v1;
+
+import io.restassured.RestAssured;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Negative-path tests for the Webhook Metadata REST API.
+ */
+public class WebhookMetadataFailureTest extends WebhookMetadataTestBase {
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public WebhookMetadataFailureTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void concludeClass() {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setBasePath() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void clearBasePath() {
+
+        RestAssured.basePath = StringUtils.EMPTY;
+    }
+
+    /**
+     * GET /webhooks/metadata/event-profiles/{profileName} with a non-existing profile name.
+     * Expect 404 Not Found with an Error payload.
+     */
+    @Test
+    public void testGetEventProfileWithInvalidName() {
+
+        getResponseOfGet(WEBHOOK_METADATA_API_BASE_PATH + "/event-profiles/" + INVALID_PROFILE_NAME)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("code", equalTo(PROFILE_NOT_FOUND_ERROR_CODE))
+                .body("message", equalTo(PROFILE_NOT_FOUND_MESSAGE))
+                .body("description", notNullValue());
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/metadata/v1/WebhookMetadataSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/metadata/v1/WebhookMetadataSuccessTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.webhook.metadata.v1;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+/**
+ * Tests for happy paths of the Webhook Metadata REST API.
+ */
+public class WebhookMetadataSuccessTest extends WebhookMetadataTestBase {
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public WebhookMetadataSuccessTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void concludeClass() {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setBasePath() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    /**
+     * GET /webhooks/metadata
+     * - Returns 200
+     * - Contains at least one profile
+     * - Contains adapter info
+     * - organizationPolicy.policyName is one of allowed enum values
+     * - Self link of a profile points to /webhooks/metadata/event-profiles/{name}
+     */
+    @Test
+    public void testGetWebhookMetadata() {
+
+        Response response = getResponseOfGet(WEBHOOK_METADATA_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                // Basic structure
+                .body("profiles", notNullValue())
+                .body("profiles.size()", Matchers.greaterThan(0))
+                // First profile is the expected one with correct uri & self link
+                .body("profiles[0].name", equalTo(TEST_EVENT_PROFILE_NAME))
+                .body("profiles[0].uri", equalTo(TEST_EVENT_PROFILE_URI))
+                .body("profiles[0].self",
+                        CoreMatchers.endsWith("/api/server/v1/webhooks/metadata/event-profiles/" +
+                                TEST_EVENT_PROFILE_NAME))
+                // Adapter info
+                .body("adapter.name", equalTo("httppublisher"))
+                .body("adapter.type", equalTo("Publisher"));
+    }
+
+    /**
+     * GET /webhooks/metadata/event-profiles/{profileName}
+     * - Uses a profile name discovered from GET /webhooks/metadata
+     * - Returns 200
+     * - Contains profile, uri, channels array
+     */
+    @Test
+    public void testGetEventProfileDetails() {
+
+        Response response = getResponseOfGet(
+                WEBHOOK_METADATA_API_BASE_PATH + "/event-profiles/WSO2");
+
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("profile", equalTo(TEST_EVENT_PROFILE_NAME))
+                .body("uri", equalTo(TEST_EVENT_PROFILE_URI))
+                // channels array exists and has the expected main channel names
+                .body("channels.find { it.name == 'Logins' }", notNullValue())
+                .body("channels.find { it.name == 'Sessions' }", notNullValue())
+                .body("channels.find { it.name == 'User account management' }", notNullValue())
+                .body("channels.find { it.name == 'Registrations' }", notNullValue())
+                .body("channels.find { it.name == 'Tokens' }", notNullValue())
+                .body("channels.find { it.name == 'Credential updates' }", notNullValue())
+                // Logins channel
+                .body("channels.find { it.name == 'Logins' }.uri",
+                        equalTo("https://schemas.identity.wso2.org/events/login"))
+                .body("channels.find { it.name == 'Logins' }.events.find { it.eventName == 'Login success' }.eventUri",
+                        equalTo("https://schemas.identity.wso2.org/events/login/event-type/loginSuccess"))
+                .body("channels.find { it.name == 'Logins' }.events.find { it.eventName == 'Login failed' }.eventUri",
+                        equalTo("https://schemas.identity.wso2.org/events/login/event-type/loginFailed"))
+                // Tokens channel
+                .body("channels.find { it.name == 'Tokens' }.uri",
+                        equalTo("https://schemas.identity.wso2.org/events/token"))
+                .body("channels.find { it.name == 'Tokens' }.events.find { it.eventName == 'Access token issued' }.eventUri",
+                        equalTo("https://schemas.identity.wso2.org/events/token/event-type/accessTokenIssued"))
+                .body("channels.find { it.name == 'Tokens' }.events.find { it.eventName == 'Access token revoked' }.eventUri",
+                        equalTo("https://schemas.identity.wso2.org/events/token/event-type/accessTokenRevoked"));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/metadata/v1/WebhookMetadataTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/webhook/metadata/v1/WebhookMetadataTestBase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.webhook.metadata.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.restassured.RestAssured;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
+
+import java.io.IOException;
+
+public class WebhookMetadataTestBase extends RESTAPIServerTestBase {
+
+    private static final String API_DEFINITION_NAME = "webhook-metadata.yaml";
+    protected static final String API_VERSION = "v1";
+    protected static final String WEBHOOK_METADATA_API_BASE_PATH = "/webhooks/metadata";
+
+    // Event profile constants.
+    protected static final String TEST_EVENT_PROFILE_NAME = "WSO2";
+    protected static final String TEST_EVENT_PROFILE_URI = "https://schemas.identity.wso2.org/events";
+
+    protected static final String PROFILE_NOT_FOUND_ERROR_CODE = "WEBHOOKMETA-61001";
+    protected static final String PROFILE_NOT_FOUND_MESSAGE = "Profile not found";
+
+    protected static final String INVALID_PROFILE_NAME = "NON_EXISTING_PROFILE";
+
+    protected static String swaggerDefinition;
+
+    static {
+        String API_PACKAGE_NAME = "org.wso2.carbon.identity.api.server.webhook.metadata.v1";
+        try {
+            swaggerDefinition = getAPISwaggerDefinition(API_PACKAGE_NAME, API_DEFINITION_NAME);
+        } catch (IOException e) {
+            Assert.fail(String.format("Unable to read the swagger definition %s from %s", API_DEFINITION_NAME,
+                    API_PACKAGE_NAME), e);
+        }
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void init() throws Exception {
+
+        super.init();
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() {
+
+        super.conclude();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void testInit() {
+
+        RestAssured.basePath = basePath;
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    /**
+     * To convert object to a json string.
+     *
+     * @param object Respective java object.
+     * @return Relevant json string.
+     */
+    protected String toJSONString(Object object) {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(object);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -277,6 +277,8 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.action.management.v1.preupdateprofile.PreUpdateProfileActionFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.WebhookManagementSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.webhook.management.v1.WebhookManagementFailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.webhook.metadata.v1.WebhookMetadataSuccessTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.webhook.metadata.v1.WebhookMetadataFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.extension.management.v1.ExtensionManagementSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.authenticator.management.v1.AuthenticatorSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.authenticator.management.v1.AuthenticatorFailureTest"/>


### PR DESCRIPTION
This pull request introduces a comprehensive suite of integration tests for the Webhook Metadata REST API, covering both successful and failure scenarios. The changes include new test classes for validating the API's happy paths and negative paths, a shared test base for common setup and utilities, and updates to the test configuration to ensure these tests are executed.

**Webhook Metadata REST API Integration Tests**

*New test classes:*
- Added `WebhookMetadataSuccessTest` to verify successful responses and data structure for the Webhook Metadata API, including checks for profiles, adapter info, and specific event channels.
- Added `WebhookMetadataFailureTest` to validate error handling for invalid profile requests, ensuring correct error codes and messages are returned.

*Test infrastructure:*
- Introduced `WebhookMetadataTestBase` to provide shared constants, setup logic, and utility methods for the new test classes, improving code reuse and maintainability.

*Test configuration:*
- Updated `testng.xml` to include the new Webhook Metadata test classes in the integration test suite, ensuring they run as part of the automated test pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for webhook metadata REST APIs: successful retrieval of webhook metadata and event profile details.
  * Added negative-path tests validating proper 404 error responses for invalid profile names.
  * Introduced shared test setup/utilities and lifecycle hooks to standardize webhook metadata testing.
  * Expanded the REST API test suite configuration to include the new webhook metadata tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->