### PR TITLE
Refactor integration tests to use tenant-qualified urls with tenant aware usernames.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/EmailOTPTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/EmailOTPTestCase.java
@@ -180,8 +180,10 @@ public class EmailOTPTestCase extends ISIntegrationTest {
             EntityUtils.consume(response.getEntity());
             response = Utils.sendRedirectRequest(response, USER_AGENT, ACS_URL, config.getSpEntityId(), httpClient);
             String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
-            response = Utils.sendPOSTMessage(sessionKey, SAML_SSO_URL, USER_AGENT, ACS_URL, config.getSpEntityId(),
-                    config.getUsername(), config.getPassword(), httpClient);
+            response = Utils.sendPOSTMessage(sessionKey, getTenantQualifiedURL(SAML_SSO_URL,
+                            config.getTenantDomain()), USER_AGENT, ACS_URL, config.getSpEntityId(),
+                    config.getTenantAwareUsername(), config.getPassword(), httpClient,
+                    getTenantQualifiedURL(SAML_SSO_URL, config.getTenantDomain()));
 
             if (Utils.requestMissingClaims(response)) {
                 String pastrCookie = Utils.getPastreCookie(response);
@@ -193,7 +195,8 @@ public class EmailOTPTestCase extends ISIntegrationTest {
             }
 
             String redirectUrl = Utils.getRedirectUrl(response);
-            Assert.assertTrue(redirectUrl.contains(EMAIL_OTP_AUTHENTICATION_ENDPOINT_URL),
+            Assert.assertTrue(redirectUrl.contains(getTenantQualifiedURL(
+                    EMAIL_OTP_AUTHENTICATION_ENDPOINT_URL, config.getTenantDomain())),
                     "Error in redirection to email OTP authentication page for user: " + config.getUsername());
         } catch (Exception e) {
             Assert.fail("Authentication failed for user: " + config.getUsername(), e);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -657,7 +657,7 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
 			IOException {
 
 		List<NameValuePair> urlParameters = new ArrayList<>();
-		urlParameters.add(new BasicNameValuePair("username", userInfo.getUserName()));
+		urlParameters.add(new BasicNameValuePair("username", userInfo.getUserNameWithoutDomain()));
 		urlParameters.add(new BasicNameValuePair("password", userInfo.getPassword()));
 		urlParameters.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
 		log.info(">>> sendLoginPost:sessionDataKey: " + sessionDataKey);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceSAML2BearerGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceSAML2BearerGrantTestCase.java
@@ -292,8 +292,9 @@ public class OAuth2ServiceSAML2BearerGrantTestCase extends OAuth2ServiceAbstract
         Assert.assertEquals(response.getStatusLine().getStatusCode(), 200, "HTTP 200 expected for request login page.");
         String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
         Assert.assertTrue(StringUtils.isNotBlank(sessionKey), "Session Key can't be empty.");
-        response = Utils.sendPOSTMessage(sessionKey, COMMON_AUTH_URL, USER_AGENT, ACS_URL, "travelocity.com",
-                userInfo.getUserName(), userInfo.getPassword(), client);
+        response = Utils.sendPOSTMessage(sessionKey, getTenantQualifiedURL(COMMON_AUTH_URL, userInfo.getUserDomain()),
+                USER_AGENT, ACS_URL, "travelocity.com", userInfo.getUserNameWithoutDomain(),
+                userInfo.getPassword(), client);
         EntityUtils.consume(response.getEntity());
 
         if (requestMissingClaims(response)) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/RegistryMountTestCase.java
@@ -195,11 +195,12 @@ public class RegistryMountTestCase extends ISIntegrationTest {
 
     private HttpResponse sendPOSTMessage(String sessionKey) throws Exception {
 
-        HttpPost post = new HttpPost(COMMON_AUTH_URL);
+        HttpPost post = new HttpPost(getTenantQualifiedURL(COMMON_AUTH_URL, TENANT_DOMAIN));
         post.setHeader("User-Agent", USER_AGENT);
         post.addHeader("Referer", String.format(ACS_URL, artifact));
         List<NameValuePair> urlParameters = new ArrayList<>();
-        urlParameters.add(new BasicNameValuePair("username", TENANT_ADMIN_USERNAME));
+        urlParameters.add(new BasicNameValuePair("username",
+                MultitenantUtils.getTenantAwareUsername(TENANT_ADMIN_USERNAME)));
         urlParameters.add(new BasicNameValuePair("password", TENANT_ADMIN_PASSWORD));
         urlParameters.add(new BasicNameValuePair("sessionDataKey", sessionKey));
         post.setEntity(new UrlEncodedFormEntity(urlParameters));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLIdPInitiatedSSOTestCase.java
@@ -138,10 +138,12 @@ public class SAMLIdPInitiatedSSOTestCase extends AbstractSAMLSSOTestCase {
 
         String sessionDataKey = getSessionDataKeyFromRedirectUrl(redirectUrl);
 
-        HttpResponse samlssoResponse = Utils.sendPOSTMessage(sessionDataKey, String.format(SAML_SSO_URL,
-                IS_DEFAULT_HTTPS_PORT), USER_AGENT, SP_ACS_URL, samlConfig.getApp()
-                        .getArtifact(), samlConfig.getUser().getUsername(), samlConfig.getUser().getPassword(),
-                httpClient);
+        HttpResponse samlssoResponse = Utils.sendPOSTMessage(sessionDataKey, getTenantQualifiedURL(String.format(
+                SAML_SSO_URL, IS_DEFAULT_HTTPS_PORT), samlConfig.getUser().getTenantDomain()), USER_AGENT, SP_ACS_URL,
+                samlConfig.getApp().getArtifact(), samlConfig.getUser().getTenantAwareUsername(),
+                samlConfig.getUser().getPassword(), httpClient,
+                getTenantQualifiedURL(String.format(SAML_SSO_URL, IS_DEFAULT_HTTPS_PORT),
+                        samlConfig.getUser().getTenantDomain()));
 
         List<NameValuePair> consentRequiredClaims = Utils.getConsentRequiredClaimsFromResponse(samlssoResponse);
         HttpResponse commonAuthResponse = setConsentForSP(sessionDataKey, consentRequiredClaims);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLQueryProfileTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLQueryProfileTestCase.java
@@ -198,8 +198,8 @@ public class SAMLQueryProfileTestCase extends AbstractSAMLSSOTestCase {
 
             String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
             response = Utils.sendPOSTMessage(sessionKey, tenantedSamlSSOUrl, USER_AGENT, ACS_URL, config.getApp()
-                            .getArtifact(), config.getUser().getUsername(), config.getUser().getPassword(), httpClient,
-                    tenantedSamlSSOUrl);
+                            .getArtifact(), config.getUser().getTenantAwareUsername(), config.getUser().getPassword(),
+                    httpClient, tenantedSamlSSOUrl);
 
 
             if (requestMissingClaims(response)) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLSSOTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/saml/SAMLSSOTestCase.java
@@ -143,8 +143,10 @@ public class SAMLSSOTestCase extends AbstractSAMLSSOTestCase {
             }
 
             String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
-            response = Utils.sendPOSTMessage(sessionKey, SAML_SSO_URL, USER_AGENT, ACS_URL, config.getApp()
-                    .getArtifact(), config.getUser().getUsername(), config.getUser().getPassword(), httpClient);
+            response = Utils.sendPOSTMessage(sessionKey, getTenantQualifiedURL(SAML_SSO_URL,
+                    config.getUser().getTenantDomain()), USER_AGENT, ACS_URL, config.getApp()
+                    .getArtifact(), config.getUser().getTenantAwareUsername(), config.getUser().getPassword(),
+                    httpClient, getTenantQualifiedURL(SAML_SSO_URL, config.getUser().getTenantDomain()));
 
 
             if (requestMissingClaims(response)) {
@@ -243,8 +245,8 @@ public class SAMLSSOTestCase extends AbstractSAMLSSOTestCase {
                         httpClient);
 
                 String sessionKey = Utils.extractDataFromResponse(response, CommonConstants.SESSION_DATA_KEY, 1);
-                response = Utils.sendPOSTMessage(sessionKey, COMMON_AUTH_URL, USER_AGENT, ACS_URL, config.getApp()
-                        .getArtifact(), config.getUser().getUsername(), config.getUser().getPassword(), httpClient);
+                response = Utils.sendPOSTMessage(sessionKey, getTenantQualifiedURL(COMMON_AUTH_URL, config.getUser().getTenantDomain()), USER_AGENT, ACS_URL, config.getApp()
+                        .getArtifact(), config.getUser().getTenantAwareUsername(), config.getUser().getPassword(), httpClient);
                 EntityUtils.consume(response.getEntity());
 
                 response = Utils.sendRedirectRequest(response, USER_AGENT, ACS_URL, config.getApp().getArtifact(),

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTS.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/sts/TestPassiveSTS.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.application.common.model.xsd.OutboundProvisionin
 import org.wso2.carbon.identity.application.common.model.xsd.Property;
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
 import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.wso2.identity.integration.common.clients.application.mgt.ApplicationManagementServiceClient;
 import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.util.Utils;
@@ -224,9 +225,9 @@ public class TestPassiveSTS extends ISIntegrationTest {
     public void testSendLoginRequestPost() throws Exception {
 
         cookieStore.clear();
-        HttpPost request = new HttpPost(COMMON_AUTH_URL);
+        HttpPost request = new HttpPost(getTenantQualifiedURL(COMMON_AUTH_URL, tenantDomain));
         List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
-        urlParameters.add(new BasicNameValuePair("username", username));
+        urlParameters.add(new BasicNameValuePair("username", MultitenantUtils.getTenantAwareUsername(username)));
         urlParameters.add(new BasicNameValuePair("password", userPassword));
         urlParameters.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
         request.setEntity(new UrlEncodedFormEntity(urlParameters));


### PR DESCRIPTION
This pull request updates several integration tests to improve multi-tenancy support and ensure tenant-aware authentication handling. 

**Multi-tenancy improvements:**

- Updated calls to authentication endpoints (such as `SAML_SSO_URL` and `COMMON_AUTH_URL`) to use tenant-qualified URLs by calling `getTenantQualifiedURL` with the appropriate tenant domain, ensuring requests are routed correctly in multi-tenant setups. 
- Modified username parameters in test requests to use tenant-aware usernames (via `getTenantAwareUsername` or similar methods) instead of plain usernames, so that authentication is performed for the correct user within the tenant context. 

**Test correctness and consistency:**

- Adjusted assertions and redirect URL checks to expect tenant-qualified URLs, improving the accuracy of test validations in multi-tenant scenarios.
- Updated OAuth2 and SAML tests to use tenant-aware usernames and tenant-qualified URLs, reducing the risk of cross-tenant test failures. 

### Related issue
- https://github.com/wso2/product-is/issues/26339

### Related pr
- https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to verify multi-tenant authentication flows across SAML SSO, OAuth2, and Email OTP methods, ensuring proper tenant-aware credential handling and URL routing in multi-tenant deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->