### PR TITLE
Bump the kernel version.

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.10.115" useFeatures="true" includeLaunchers="true">
+version="4.10.118" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.10.115" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.10.115"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.10.118"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2797,7 +2797,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.10.115</carbon.kernel.version>
+        <carbon.kernel.version>4.10.118</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.0.16</identity.verification.version>


### PR DESCRIPTION
### Description
- $subject

This pull request updates the Carbon Kernel version used across the project from 4.10.115 to 4.10.118 to ensure compatibility with the latest features and bug fixes. The changes are minor and focused solely on version bumps.

**Version updates:**

* Updated the `carbon.kernel.version` property in `pom.xml` from `4.10.115` to `4.10.118` to use the latest Carbon Kernel version.
* Updated the `version` attribute and the `org.wso2.carbon.core.runtime` feature version in `modules/p2-profile-gen/carbon.product` from `4.10.115` to `4.10.118`. [[1]](diffhunk://#diff-fb626faa6458db1bcdb52bd7f2017cc2af23109ee2bb9b3644b2a0bece19af57L5-R5) [[2]](diffhunk://#diff-fb626faa6458db1bcdb52bd7f2017cc2af23109ee2bb9b3644b2a0bece19af57L17-R17)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated internal dependencies to version 4.10.118 for enhanced stability and improved compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->