### PR TITLE
Bump versions for CDS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2790,7 +2790,7 @@
         <!-- Identity Portal Versions -->
         <identity.apps.console.version>2.85.10</identity.apps.console.version>
         <identity.apps.myaccount.version>2.25.19</identity.apps.myaccount.version>
-        <identity.apps.core.version>3.3.34</identity.apps.core.version>
+        <identity.apps.core.version>3.3.33</identity.apps.core.version>
         <identity.apps.tests.version>1.6.383</identity.apps.tests.version>
 
         <!-- Charon -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Carbon Identity Framework dependency to patch release 7.8.664; this is a version-only update with no observable structural or behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->