### PR TITLE
Add integration test for sharing parameters in initial /authorize request with custom authenticator

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/model/Endpoint.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/model/Endpoint.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.authenticators.v1.model.AuthenticationType;
 import javax.validation.constraints.*;
 
@@ -35,6 +37,8 @@ public class Endpoint  {
   
     private String uri;
     private AuthenticationType authentication;
+    private List<String> allowedHeaders = null;
+    private List<String> allowedParameters = null;
 
     /**
     **/
@@ -72,6 +76,60 @@ public class Endpoint  {
         this.authentication = authentication;
     }
 
+    /**
+     * List of HTTP headers to forward to the extension.
+     **/
+    public Endpoint allowedHeaders(List<String> allowedHeaders) {
+
+        this.allowedHeaders = allowedHeaders;
+        return this;
+    }
+
+    @ApiModelProperty(example = "[\"x-geo-location\",\"host\"]", value = "List of HTTP headers to forward to the extension.")
+    @JsonProperty("allowedHeaders")
+    @Valid
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+
+    public Endpoint addAllowedHeadersItem(String allowedHeadersItem) {
+        if (this.allowedHeaders == null) {
+            this.allowedHeaders = new ArrayList<>();
+        }
+        this.allowedHeaders.add(allowedHeadersItem);
+        return this;
+    }
+
+    /**
+     * List of parameters to forward to the extension.
+     **/
+    public Endpoint allowedParameters(List<String> allowedParameters) {
+
+        this.allowedParameters = allowedParameters;
+        return this;
+    }
+
+    @ApiModelProperty(example = "[\"device-id\"]", value = "List of parameters to forward to the extension.")
+    @JsonProperty("allowedParameters")
+    @Valid
+    public List<String> getAllowedParameters() {
+        return allowedParameters;
+    }
+    public void setAllowedParameters(List<String> allowedParameters) {
+        this.allowedParameters = allowedParameters;
+    }
+
+    public Endpoint addAllowedParametersItem(String allowedParametersItem) {
+        if (this.allowedParameters == null) {
+            this.allowedParameters = new ArrayList<>();
+        }
+        this.allowedParameters.add(allowedParametersItem);
+        return this;
+    }
+
 
 
     @Override
@@ -85,12 +143,14 @@ public class Endpoint  {
         }
         Endpoint endpoint = (Endpoint) o;
         return Objects.equals(this.uri, endpoint.uri) &&
-            Objects.equals(this.authentication, endpoint.authentication);
+                Objects.equals(this.authentication, endpoint.authentication) &&
+                Objects.equals(this.allowedHeaders, endpoint.allowedHeaders) &&
+                Objects.equals(this.allowedParameters, endpoint.allowedParameters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri, authentication);
+        return Objects.hash(uri, authentication, allowedHeaders, allowedParameters);
     }
 
     @Override
@@ -101,6 +161,8 @@ public class Endpoint  {
         
         sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
         sb.append("    authentication: ").append(toIndentedString(authentication)).append("\n");
+        sb.append("    allowedHeaders: ").append(toIndentedString(allowedHeaders)).append("\n");
+        sb.append("    allowedParameters: ").append(toIndentedString(allowedParameters)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/util/UserDefinedLocalAuthenticatorPayload.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/authenticator/management/v1/util/UserDefinedLocalAuthenticatorPayload.java
@@ -103,6 +103,7 @@ public class UserDefinedLocalAuthenticatorPayload {
         authenticationConfig.setProperties(propertyMap);
         authenticationConfig.setProperties(propertyMap);
         endpoint.setAuthentication(authenticationConfig);
+        endpoint.setAllowedParameters(endpointConfig.getEndpointConfig().getAllowedParameters());
         return endpoint;
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/CustomAuthenticatorManagementClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/CustomAuthenticatorManagementClient.java
@@ -34,6 +34,9 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.identity.integration.test.rest.api.server.authenticator.management.v1.util.UserDefinedLocalAuthenticatorPayload;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
 /**
@@ -120,6 +123,7 @@ public class CustomAuthenticatorManagementClient extends RestBaseClient {
             put("username", username);
             put("password", password);
         }});
+        endpointConfig.allowedParameters((new ArrayList<>(Collections.singletonList("testParam"))));
         config.setEndpointConfig(endpointConfig.build());
 
         return config;

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -149,7 +149,7 @@
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdatepassword.PreUpdatePasswordActionSmsOtpFailureTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdateprofile.PreUpdateProfileActionSuccessTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdateprofile.PreUpdateProfileActionFailureTestCase"/>
-            <!--        <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomInternalUserAuthenticatorTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomInternalUserAuthenticatorTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCHybridFlowIntegrationTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsGrantTypesTestCase"/>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/26605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable allowed headers and allowed parameters in endpoint authentication configuration for custom authenticators.

* **Tests**
  * Enhanced test coverage for custom internal user authenticators with improved verification of mock service requests and payload validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->