### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2736,7 +2736,7 @@
 
         <!-- OAuth2 Grant Type extensions -->
         <identity.oauth2.jwt.bearer.grant.version>2.3.11</identity.oauth2.jwt.bearer.grant.version>
-        <identity.oauth2.token.exchange.grant.version>1.1.24</identity.oauth2.token.exchange.grant.version>
+        <identity.oauth2.token.exchange.grant.version>1.1.25</identity.oauth2.token.exchange.grant.version>
 
         <identity.oauth.dpop.version>2.0.9</identity.oauth.dpop.version>
 


### PR DESCRIPTION
This pull request updates dependency versions in the `pom.xml` file to keep the project up to date with the latest patches for authentication components.

Dependency version updates:

* Bumped the `identity.outbound.auth.oidc` dependency version from `5.12.38` to `5.12.39` to include the latest fixes or improvements.
* Updated the `identity.oauth2.token.exchange.grant` version from `1.1.24` to `1.1.25` for enhanced OAuth2 grant type extension support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for outbound authentication and token exchange components to pull in latest compatible artifact versions during build.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Related Issue 
- https://github.com/wso2/product-is/issues/23582