### PR TITLE
Bump OAuth version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2671,7 +2671,7 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.0.417</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.418</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.11.64</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.10.3</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.13.2</identity.inbound.auth.sts.version>


### PR DESCRIPTION
This pull request makes a minor update to the project dependencies by bumping the version of the `identity.inbound.auth.oauth` library.

- Upgraded the `identity.inbound.auth.oauth` dependency version from `7.0.417` to `7.0.418` in `pom.xml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth authentication dependency to the latest patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->