### PR TITLE
Version Bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2643,7 +2643,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.8.669</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.670</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2671,7 +2671,7 @@
 
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.0.418</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.0.419</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.11.64</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.10.3</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.13.2</identity.inbound.auth.sts.version>
@@ -2703,7 +2703,7 @@
         <!--<identity.agent-entitlement-filter.version>5.1.1</identity.agent-entitlement-filter.version>-->
 
         <!-- Authenticator Versions -->
-        <identity.outbound.auth.oidc.version>5.12.39</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.12.40</identity.outbound.auth.oidc.version>
         <identity.outbound.auth.oauth2.version>1.0.13</identity.outbound.auth.oauth2.version>
         <identity.outbound.auth.passive.sts.version>5.5.3</identity.outbound.auth.passive.sts.version>
         <identity.outbound.auth.samlsso.version>5.9.10</identity.outbound.auth.samlsso.version>


### PR DESCRIPTION
### Purpose
 - Update dependency versions for framework components and authenticators to latest releases.

### Description 
This pull request updates several dependency versions in the `pom.xml` file to ensure the project uses the latest compatible releases. These changes are minor version bumps and help keep the project up to date with bug fixes and improvements from upstream dependencies.

Dependency version updates:

* Bumped `carbon.identity.framework.version` from `7.8.669` to `7.8.670` to use the latest Carbon Identity Framework.
* Updated `identity.inbound.auth.oauth.version` from `7.0.418` to `7.0.419`.
* Updated `identity.outbound.auth.oidc.version` from `5.12.39` to `5.12.40`.