### PR TITLE
Downgrade identity-apps Console version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2799,7 +2799,7 @@
         <conditional.authentication.functions.version>1.2.88</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>2.89.0</identity.apps.console.version>
+        <identity.apps.console.version>2.87.1</identity.apps.console.version>
         <identity.apps.myaccount.version>2.25.21</identity.apps.myaccount.version>
         <identity.apps.core.version>3.3.34</identity.apps.core.version>
         <identity.apps.tests.version>1.6.383</identity.apps.tests.version>


### PR DESCRIPTION
This pull request makes a minor version change to the `identity.apps.console` dependency in the `pom.xml` file, downgrading it from version 2.89.0 to 2.87.1. This may be to address compatibility or stability issues with the newer version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Rolled back Identity Portal Console app version from 2.89.0 to 2.87.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->