### PR TITLE
Add fix for failing JwtAccessTokenScopeAsArrayTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/JwtAccessTokenScopeAsArrayTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/JwtAccessTokenScopeAsArrayTestCase.java
@@ -137,6 +137,9 @@ public class JwtAccessTokenScopeAsArrayTestCase extends OAuth2ServiceAbstractInt
         // Initialize OrgMgtRestClient for sub-org testing.
         orgMgtRestClient = new OrgMgtRestClient(context, tenantInfo, serverURL,
                 new JSONObject(RESTTestBase.readResource(AUTHORIZED_APIS_JSON, this.getClass())));
+
+        // Set organization version to v1.0.0 to enable inheritance for inheritance tests.
+        orgMgtRestClient.updateOrganizationVersion("v1.0.0");
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/oauth2/jwt-scope-array-authorized-apis.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/oauth2/jwt-scope-array-authorized-apis.json
@@ -2,6 +2,7 @@
   "/api/server/v1/organizations": [
     "internal_organization_view",
     "internal_organization_create",
+    "internal_organization_update",
     "internal_organization_delete"
   ],
   "/o/api/server/v1/configs": [

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -93,8 +93,7 @@
 
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>
-<!--            Temporarily disable the failing test case -->
-<!--            <class name="org.wso2.identity.integration.test.oauth2.JwtAccessTokenScopeAsArrayTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.oauth2.JwtAccessTokenScopeAsArrayTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2ApplicationAccessTokenIntrospectionTestCase"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled JWT access token scope testing with enhanced organization version inheritance support and expanded authorization scopes for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->