### PR TITLE
Bump identity.organization.login.version to v1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2782,7 +2782,7 @@
 
         <identity.org.mgt.version>2.2.0</identity.org.mgt.version>
         <identity.org.mgt.core.version>1.3.0</identity.org.mgt.core.version>
-        <identity.organization.login.version>1.2.0</identity.organization.login.version>
+        <identity.organization.login.version>1.2.1</identity.organization.login.version>
         <identity.oauth2.grant.organizationswitch.version>1.1.32</identity.oauth2.grant.organizationswitch.version>
 
         <!-- Hash Provider Versions-->


### PR DESCRIPTION
$subject

related: https://github.com/wso2-extensions/identity-auth-organization-login/pull/71



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the identity organization login server feature version from 1.2.0 to 1.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->