### PR TITLE
Remove unused Stratos Identity Dashboard UI

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -641,7 +641,6 @@ com.google.guava.failureaccess_1.0.2.jar                                        
 org.wso2.carbon.registry.common_4.9.2.jar                                                           bundle         apache2
 org.wso2.carbon.crypto.api_1.1.16.jar                                                               bundle         apache2
 org.wso2.carbon.identity.user.store.configuration.ui_7.10.27.jar                                    bundle         apache2
-org.wso2.stratos.identity.dashboard.ui_2.2.1.jar                                                    bundle         apache2
 commons-cli_1.2.0.wso2v1.jar                                                                        bundle         apache2
 vertx-json-schema_4.5.11.wso2v1.jar                                                                 bundle         apache2 + epl1
 nimbus-jose-jwt_10.3.0.wso2v1.jar                                                                   bundle         apache2

--- a/modules/features/org.wso2.identity.ui.feature/pom.xml
+++ b/modules/features/org.wso2.identity.ui.feature/pom.xml
@@ -32,10 +32,6 @@
     <description>This feature contains the bundles required for Cloud Identity login UI and dashboard</description>
 
     <dependencies>
-        <dependency>
-            <groupId>org.wso2.identity</groupId>
-            <artifactId>org.wso2.stratos.identity.dashboard.ui</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -64,9 +60,6 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
-                                <bundleDef>
-                                    org.wso2.identity:org.wso2.stratos.identity.dashboard.ui
-                                </bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core.ui:${carbon.kernel.version}</importFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -1003,11 +1003,6 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.identity</groupId>
-                <artifactId>org.wso2.stratos.identity.dashboard.ui</artifactId>
-                <version>${stratos.version.221}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
@@ -2848,7 +2843,6 @@
         <securevault.wso2.version>1.1.13</securevault.wso2.version>
 
         <!-- Feature dependency Versions -->
-        <stratos.version.221>2.2.1</stratos.version.221>
         <ehcache.version>1.5.0.wso2v3</ehcache.version>
         <bcel.wso2.version>6.7.0.wso2v1</bcel.wso2.version>
         <asm-all.version>5.2</asm-all.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the legacy identity dashboard UI component from dependencies, build configuration, and the license list.
  * No functional or public API changes expected; this reduces packaged components and cleans up licensing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->