### PR TITLE
Update email address extraction logic for shared user

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -600,7 +600,8 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
 
         org.json.simple.JSONObject sharedUser = scim2RestClient.getSubOrgUser(sharedUserId, null, switchedM2MToken);
         String givenNameOfSharedUser = (String) ((org.json.simple.JSONObject) sharedUser.get("name")).get("givenName");
-        String emailOfSharedUser = (String) ((org.json.simple.JSONArray) sharedUser.get("emails")).get(0);
+        String emailOfSharedUser = (String) ((org.json.simple.JSONObject)
+                ((org.json.simple.JSONArray) sharedUser.get("emails")).get(0)).get("value");
         Assert.assertEquals(givenNameOfSharedUser, ROOT_ORG_USER_GIVEN_NAME, "Unexpected given name.");
         Assert.assertEquals(emailOfSharedUser, ROOT_ORG_USER_EMAIL, "Unexpected email.");
     }


### PR DESCRIPTION
## Changes in this PR
- $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed email data parsing for shared user profiles to correctly retrieve email information from the updated response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->