### PR TITLE
Bump inbound auth oauth version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2696,7 +2696,7 @@
         <identity.carbon.auth.rest.version>1.12.0</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.7</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.9</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.2</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.0</identity.inbound.auth.sts.version>


### PR DESCRIPTION
### Purpose

This pull request updates a dependency version in the `pom.xml` file to ensure the project uses the latest compatible library.

Dependency update:

* Bumped the version of `identity.inbound.auth.oauth` from `7.4.7` to `7.4.9` in `pom.xml` to incorporate the latest improvements and bug fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth identity component dependency to version 7.4.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->