### PR TITLE
Bump framework version and fix test failures

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/user/profile/mgt/SharedUserProfileClaimMgtTestCase.java
@@ -600,7 +600,14 @@ public class SharedUserProfileClaimMgtTestCase extends OAuth2ServiceAbstractInte
 
         org.json.simple.JSONObject sharedUser = scim2RestClient.getSubOrgUser(sharedUserId, null, switchedM2MToken);
         String givenNameOfSharedUser = (String) ((org.json.simple.JSONObject) sharedUser.get("name")).get("givenName");
-        String emailOfSharedUser = (String) ((org.json.simple.JSONArray) sharedUser.get("emails")).get(0);
+        org.json.simple.JSONArray emails = (org.json.simple.JSONArray) sharedUser.get("emails");
+        String emailOfSharedUser = "";
+        for (org.json.simple.JSONObject email : (Iterable<org.json.simple.JSONObject>) emails) {
+            if ((Boolean) email.get("primary")) {
+                emailOfSharedUser = (String) email.get("value");
+                break;
+            }
+        }
         Assert.assertEquals(givenNameOfSharedUser, ROOT_ORG_USER_GIVEN_NAME, "Unexpected given name.");
         Assert.assertEquals(emailOfSharedUser, ROOT_ORG_USER_EMAIL, "Unexpected email.");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2669,7 +2669,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.10.13</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.16</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared user profile email resolution to correctly identify and use the primary email address when multiple emails are present.

* **Chores**
  * Updated Carbon Identity Framework dependency to version 7.10.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->