### PR TITLE
Remove scim-password assertion since the values are masked by default

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java
@@ -811,7 +811,8 @@ public class IdPSuccessTest extends IdPTestBase {
                 .body("rulesEnabled", equalTo(false))
                 .body("properties", notNullValue())
                 .body("properties.find{ it.key == 'scim-enable-pwd-provisioning' }.value", equalTo("true"))
-                .body("properties.find{ it.key == 'scim-password' }.value", equalTo("admin"))
+                // Secret properties are masked in the response, hence the value assertion is not removed.
+                //.body("properties.find{ it.key == 'scim-password' }.value", equalTo("admin"))
                 .body("properties.find{ it.key == 'scim-user-ep' }.value", equalTo("https://localhost:9445/userinfo"))
                 .body("properties.find{ it.key == 'scim-username' }.value", equalTo("admin"));
     }


### PR DESCRIPTION
This pull request makes a minor adjustment to the `testGetIdPOutboundConnector` test to reflect that secret properties are now masked in the API response. The assertion that checked the value of the `scim-password` property has been commented out, with a note explaining the reason.

* Commented out the assertion for the `scim-password` property in the `testGetIdPOutboundConnector` test, since secret properties are now masked in the response. Added a comment to clarify this behavior. (`modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/IdPSuccessTest.java`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated identity provider outbound connector test to account for secret masking in API responses. The test no longer asserts specific secret values and continues to validate non-sensitive connector properties (e.g., enablement and endpoints), ensuring tests reflect that secret properties are present but masked in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->