### PR TITLE
Add support for ciba configs in integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/CIBAAuthenticationRequestConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/CIBAAuthenticationRequestConfiguration.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.validation.Valid;
+
+public class CIBAAuthenticationRequestConfiguration {
+  
+    private Long authReqExpiryTime;
+    private List<String> notificationChannels = null;
+
+
+    /**
+    * CIBA authentication request expiry time in seconds.
+    **/
+    public CIBAAuthenticationRequestConfiguration authReqExpiryTime(Long authReqExpiryTime) {
+
+        this.authReqExpiryTime = authReqExpiryTime;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "600", value = "CIBA authentication request expiry time in seconds.")
+    @JsonProperty("authReqExpiryTime")
+    @Valid
+    public Long getAuthReqExpiryTime() {
+        return authReqExpiryTime;
+    }
+    public void setAuthReqExpiryTime(Long authReqExpiryTime) {
+        this.authReqExpiryTime = authReqExpiryTime;
+    }
+
+    /**
+    * List of allowed notification channels.
+    **/
+    public CIBAAuthenticationRequestConfiguration notificationChannels(List<String> notificationChannels) {
+
+        this.notificationChannels = notificationChannels;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"email\",\"sms\"]", value = "List of allowed notification channels.")
+    @JsonProperty("notificationChannels")
+    @Valid
+    public List<String> getNotificationChannels() {
+        return notificationChannels;
+    }
+    public void setNotificationChannels(List<String> notificationChannels) {
+        this.notificationChannels = notificationChannels;
+    }
+
+    public CIBAAuthenticationRequestConfiguration addNotificationChannelsItem(String notificationChannelsItem) {
+        if (this.notificationChannels == null) {
+            this.notificationChannels = new ArrayList<>();
+        }
+        this.notificationChannels.add(notificationChannelsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CIBAAuthenticationRequestConfiguration ciBAAuthenticationRequestConfiguration = (CIBAAuthenticationRequestConfiguration) o;
+        return Objects.equals(this.authReqExpiryTime, ciBAAuthenticationRequestConfiguration.authReqExpiryTime) &&
+            Objects.equals(this.notificationChannels, ciBAAuthenticationRequestConfiguration.notificationChannels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authReqExpiryTime, notificationChannels);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class CIBAAuthenticationRequestConfiguration {\n");
+        
+        sb.append("    authReqExpiryTime: ").append(toIndentedString(authReqExpiryTime)).append("\n");
+        sb.append("    notificationChannels: ").append(toIndentedString(notificationChannels)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/CIBAMetadata.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/CIBAMetadata.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.validation.Valid;
+
+public class CIBAMetadata {
+  
+    private List<CIBANotificationChannel> supportedNotificationChannels = null;
+
+
+    /**
+    **/
+    public CIBAMetadata supportedNotificationChannels(List<CIBANotificationChannel> supportedNotificationChannels) {
+
+        this.supportedNotificationChannels = supportedNotificationChannels;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("supportedNotificationChannels")
+    @Valid
+    public List<CIBANotificationChannel> getSupportedNotificationChannels() {
+        return supportedNotificationChannels;
+    }
+    public void setSupportedNotificationChannels(List<CIBANotificationChannel> supportedNotificationChannels) {
+        this.supportedNotificationChannels = supportedNotificationChannels;
+    }
+
+    public CIBAMetadata addSupportedNotificationChannelsItem(CIBANotificationChannel supportedNotificationChannelsItem) {
+        if (this.supportedNotificationChannels == null) {
+            this.supportedNotificationChannels = new ArrayList<>();
+        }
+        this.supportedNotificationChannels.add(supportedNotificationChannelsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CIBAMetadata ciBAMetadata = (CIBAMetadata) o;
+        return Objects.equals(this.supportedNotificationChannels, ciBAMetadata.supportedNotificationChannels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(supportedNotificationChannels);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class CIBAMetadata {\n");
+        
+        sb.append("    supportedNotificationChannels: ").append(toIndentedString(supportedNotificationChannels)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/CIBANotificationChannel.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/CIBANotificationChannel.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+import javax.validation.Valid;
+
+public class CIBANotificationChannel {
+  
+    private String name;
+    private String displayName;
+
+    /**
+    **/
+    public CIBANotificationChannel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "email", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public CIBANotificationChannel displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Email", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CIBANotificationChannel ciBANotificationChannel = (CIBANotificationChannel) o;
+        return Objects.equals(this.name, ciBANotificationChannel.name) &&
+            Objects.equals(this.displayName, ciBANotificationChannel.displayName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, displayName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class CIBANotificationChannel {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OIDCMetaData.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OIDCMetaData.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
@@ -45,6 +47,7 @@ public class OIDCMetaData  {
     private MetadataProperty requestObjectEncryptionMethod;
     private MetadataProperty subjectType;
     private FapiMetadata fapiMetadata;
+    private CIBAMetadata cibaMetadata;
 
     /**
      **/
@@ -391,6 +394,24 @@ public class OIDCMetaData  {
         this.fapiMetadata = fapiMetadata;
     }
 
+    /**
+     **/
+    public OIDCMetaData cibaMetadata(CIBAMetadata cibaMetadata) {
+
+        this.cibaMetadata = cibaMetadata;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("cibaMetadata")
+    @Valid
+    public CIBAMetadata getCibaMetadata() {
+        return cibaMetadata;
+    }
+    public void setCibaMetadata(CIBAMetadata cibaMetadata) {
+        this.cibaMetadata = cibaMetadata;
+    }
+
 
 
     @Override
@@ -421,7 +442,8 @@ public class OIDCMetaData  {
                 Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.requestObjectEncryptionAlgorithm) &&
                 Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.requestObjectEncryptionMethod) &&
                 Objects.equals(this.subjectType, oiDCMetaData.subjectType) &&
-                Objects.equals(this.fapiMetadata, oiDCMetaData.fapiMetadata);
+                Objects.equals(this.fapiMetadata, oiDCMetaData.fapiMetadata) &&
+                Objects.equals(this.cibaMetadata, oiDCMetaData.cibaMetadata);
     }
 
     @Override
@@ -431,7 +453,8 @@ public class OIDCMetaData  {
                 idTokenEncryptionAlgorithm, idTokenEncryptionMethod, scopeValidators, accessTokenType,
                 accessTokenBindingType, tokenEndpointAuthMethod, tokenEndpointAllowReusePvtKeyJwt,
                 tokenEndpointSignatureAlgorithm, idTokenSignatureAlgorithm, requestObjectSignatureAlgorithm,
-                requestObjectEncryptionAlgorithm, requestObjectEncryptionMethod, subjectType, fapiMetadata);
+                requestObjectEncryptionAlgorithm, requestObjectEncryptionMethod, subjectType, fapiMetadata,
+                cibaMetadata);
     }
 
     @Override
@@ -461,6 +484,7 @@ public class OIDCMetaData  {
         sb.append("    requestObjectEncryptionMethod: ").append(toIndentedString(requestObjectEncryptionMethod)).append("\n");
         sb.append("    subjectType: ").append(toIndentedString(subjectType)).append("\n");
         sb.append("    fapiMetadata: ").append(toIndentedString(fapiMetadata)).append("\n");
+        sb.append("    cibaMetadata: ").append(toIndentedString(cibaMetadata)).append("\n");
         sb.append("}");
         return sb.toString();
     }
@@ -498,5 +522,8 @@ public class OIDCMetaData  {
         Collections.sort(subjectType.getOptions());
         Collections.sort(fapiMetadata.getAllowedSignatureAlgorithms().getOptions());
         Collections.sort(fapiMetadata.getAllowedEncryptionAlgorithms().getOptions());
+        Comparator<CIBANotificationChannel> cibaNotificationChannelComparator = Comparator.comparing(
+                CIBANotificationChannel::getName);
+        cibaMetadata.getSupportedNotificationChannels().sort(cibaNotificationChannelComparator);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OpenIDConnectConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OpenIDConnectConfiguration.java
@@ -88,6 +88,7 @@ public enum StateEnum {
     private SubjectConfiguration subject;
     private Boolean isFAPIApplication = false;
     private FapiMetadata fapiMetadata;
+    private CIBAAuthenticationRequestConfiguration cibaAuthenticationRequest;
 
     /**
     **/
@@ -518,6 +519,16 @@ public enum StateEnum {
     }
     public void setFapiMetadata(FapiMetadata fapiMetadata) {
         this.fapiMetadata = fapiMetadata;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("cibaAuthenticationRequest")
+    @Valid
+    public CIBAAuthenticationRequestConfiguration getCibaAuthenticationRequest() {
+        return cibaAuthenticationRequest;
+    }
+    public void setCibaAuthenticationRequest(CIBAAuthenticationRequestConfiguration cibaAuthenticationRequest) {
+        this.cibaAuthenticationRequest = cibaAuthenticationRequest;
     }
 
     @Override

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
@@ -206,5 +206,21 @@
           }
         ]
       }
+  },
+  "cibaMetadata": {
+    "supportedNotificationChannels": [
+      {
+        "name": "external",
+        "displayName": "External"
+      },
+      {
+        "name": "email",
+        "displayName": "Email"
+      },
+      {
+        "name": "sms",
+        "displayName": "SMS"
+      }
+    ]
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2800,7 +2800,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.5.6</identity.server.api.version>
+        <identity.server.api.version>1.5.7</identity.server.api.version>
         <identity.user.api.version>1.3.71</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
## Purpose
- Provide support for ciba configs in integration tests
- Bump api.server.version

### Related Issue(s)
- https://github.com/wso2/product-is/issues/23153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CIBA authentication request configuration (expiry and selectable notification channels).
  * Introduced CIBA metadata and notification channel definitions for richer CIBA behavior and display.
  * Extended OpenID Connect settings to include CIBA-related configuration.
  * 

* **Chores**
  * Bumped Identity REST API version to 1.5.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->