### PR TITLE
Bump carbon identity framework version to 7.10.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2669,7 +2669,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.10.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.23</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
resolves https://github.com/wso2/product-is/issues/27001

This pull request updates the dependency version for the Carbon Identity Framework.

* Dependency version update:
  * Updated the `carbon.identity.framework.version` property from `7.10.21` to `7.10.23` in `pom.xml` to use the latest stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Carbon Identity Framework dependency to version 7.10.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->