### PR TITLE
Add support for allowed issuer OIDC configuration in integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/AllowedIssuer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/AllowedIssuer.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.application.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.Objects;
+
+public class AllowedIssuer {
+  
+    private String value;
+    private String organizationId;
+    private String tenantDomain;
+
+    /**
+    * Issuer detail that can be used for tokens.
+    **/
+    public AllowedIssuer value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9443/oauth2/token", value = "Issuer detail that can be used for tokens.")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+    * Organization ID of the allowed issuer.
+    **/
+    public AllowedIssuer organizationId(String organizationId) {
+
+        this.organizationId = organizationId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "bdece142-646b-45c0-9385-a4159f1ea219", value = "Organization ID of the allowed issuer.")
+    @JsonProperty("organizationId")
+    @Valid
+    public String getOrganizationId() {
+        return organizationId;
+    }
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    /**
+    * Tenant domain of the allowed issuer.
+    **/
+    public AllowedIssuer tenantDomain(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "wso2.com", value = "Tenant domain of the allowed issuer.")
+    @JsonProperty("tenantDomain")
+    @Valid
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AllowedIssuer allowedIssuer = (AllowedIssuer) o;
+        return Objects.equals(this.value, allowedIssuer.value) &&
+            Objects.equals(this.organizationId, allowedIssuer.organizationId) &&
+            Objects.equals(this.tenantDomain, allowedIssuer.tenantDomain);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, organizationId, tenantDomain);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AllowedIssuer {\n");
+        
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("    organizationId: ").append(toIndentedString(organizationId)).append("\n");
+        sb.append("    tenantDomain: ").append(toIndentedString(tenantDomain)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OIDCMetaData.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OIDCMetaData.java
@@ -21,9 +21,7 @@ package org.wso2.identity.integration.test.rest.api.server.application.managemen
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Objects;
+import java.util.*;
 import javax.validation.Valid;
 
 public class OIDCMetaData  {
@@ -48,6 +46,7 @@ public class OIDCMetaData  {
     private MetadataProperty subjectType;
     private FapiMetadata fapiMetadata;
     private CIBAMetadata cibaMetadata;
+    private List<AllowedIssuer> allowedIssuers = null;
 
     /**
      **/
@@ -412,7 +411,29 @@ public class OIDCMetaData  {
         this.cibaMetadata = cibaMetadata;
     }
 
+    public OIDCMetaData allowedIssuers(List<AllowedIssuer> allowedIssuers) {
 
+        this.allowedIssuers = allowedIssuers;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("allowedIssuers")
+    @Valid
+    public List<AllowedIssuer> getAllowedIssuers() {
+        return allowedIssuers;
+    }
+    public void setAllowedIssuers(List<AllowedIssuer> allowedIssuers) {
+        this.allowedIssuers = allowedIssuers;
+    }
+
+    public OIDCMetaData addAllowedIssuersItem(AllowedIssuer allowedIssuersItem) {
+        if (this.allowedIssuers == null) {
+            this.allowedIssuers = new ArrayList<>();
+        }
+        this.allowedIssuers.add(allowedIssuersItem);
+        return this;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -443,7 +464,8 @@ public class OIDCMetaData  {
                 Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.requestObjectEncryptionMethod) &&
                 Objects.equals(this.subjectType, oiDCMetaData.subjectType) &&
                 Objects.equals(this.fapiMetadata, oiDCMetaData.fapiMetadata) &&
-                Objects.equals(this.cibaMetadata, oiDCMetaData.cibaMetadata);
+                Objects.equals(this.cibaMetadata, oiDCMetaData.cibaMetadata) &&
+                Objects.equals(this.allowedIssuers, oiDCMetaData.allowedIssuers);
     }
 
     @Override
@@ -454,7 +476,7 @@ public class OIDCMetaData  {
                 accessTokenBindingType, tokenEndpointAuthMethod, tokenEndpointAllowReusePvtKeyJwt,
                 tokenEndpointSignatureAlgorithm, idTokenSignatureAlgorithm, requestObjectSignatureAlgorithm,
                 requestObjectEncryptionAlgorithm, requestObjectEncryptionMethod, subjectType, fapiMetadata,
-                cibaMetadata);
+                cibaMetadata, allowedIssuers);
     }
 
     @Override
@@ -485,6 +507,7 @@ public class OIDCMetaData  {
         sb.append("    subjectType: ").append(toIndentedString(subjectType)).append("\n");
         sb.append("    fapiMetadata: ").append(toIndentedString(fapiMetadata)).append("\n");
         sb.append("    cibaMetadata: ").append(toIndentedString(cibaMetadata)).append("\n");
+        sb.append("    allowedIssuers: ").append(toIndentedString(allowedIssuers)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OpenIDConnectConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OpenIDConnectConfiguration.java
@@ -89,6 +89,7 @@ public enum StateEnum {
     private Boolean isFAPIApplication = false;
     private FapiMetadata fapiMetadata;
     private CIBAAuthenticationRequestConfiguration cibaAuthenticationRequest;
+    private AllowedIssuer issuer;
 
     /**
     **/
@@ -531,6 +532,25 @@ public enum StateEnum {
         this.cibaAuthenticationRequest = cibaAuthenticationRequest;
     }
 
+    /**
+     * Issuer of the application which will be used in the tokens.
+     **/
+    public OpenIDConnectConfiguration issuer(AllowedIssuer issuer) {
+
+        this.issuer = issuer;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("issuer")
+    @Valid
+    public AllowedIssuer getIssuer() {
+        return issuer;
+    }
+    public void setIssuer(AllowedIssuer issuer) {
+        this.issuer = issuer;
+    }
+
     @Override
     public boolean equals(Object o) {
 
@@ -562,12 +582,13 @@ public enum StateEnum {
             Objects.equals(this.pushAuthorizationRequest, openIDConnectConfiguration.pushAuthorizationRequest) &&
             Objects.equals(this.subject, openIDConnectConfiguration.subject) &&
             Objects.equals(this.isFAPIApplication, openIDConnectConfiguration.isFAPIApplication) &&
-            Objects.equals(this.fapiMetadata, openIDConnectConfiguration.fapiMetadata);
+            Objects.equals(this.fapiMetadata, openIDConnectConfiguration.fapiMetadata) &&
+            Objects.equals(this.issuer, openIDConnectConfiguration.issuer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, hybridFlow, accessToken, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata);
+        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, hybridFlow, accessToken, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata, issuer);
     }
 
     @Override
@@ -598,6 +619,7 @@ public enum StateEnum {
         sb.append("    subject: ").append(toIndentedString(subject)).append("\n");
         sb.append("    isFAPIApplication: ").append(toIndentedString(isFAPIApplication)).append("\n");
         sb.append("    fapiMetadata: ").append(toIndentedString(fapiMetadata)).append("\n");
+        sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
@@ -222,5 +222,6 @@
         "displayName": "SMS"
       }
     ]
-  }
+  },
+  "allowedIssuers": null
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2696,7 +2696,7 @@
         <identity.carbon.auth.rest.version>1.12.0</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.10</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.11</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.2</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.0</identity.inbound.auth.sts.version>
@@ -2800,7 +2800,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.5.8</identity.server.api.version>
+        <identity.server.api.version>1.5.9</identity.server.api.version>
         <identity.user.api.version>1.3.71</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
## Changes in this PR
- $subject for the PR[1]
- API Server Version : https://github.com/wso2/identity-api-server/commits/v1.5.9
- OAuth2 version : https://github.com/wso2-extensions/identity-inbound-auth-oauth/commits/v7.4.11

[1] https://github.com/wso2/identity-api-server/pull/1055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicit allowed issuers plus a configurable issuer entry in OIDC configuration and metadata for finer issuer validation.

* **Bug Fixes / Data**
  * OIDC metadata sample updated to include the new allowedIssuers placeholder.

* **Chores**
  * Bumped OAuth inbound auth and identity server API component versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->