### PR TITLE
Add git action to run tests with java 25

### DIFF
--- a/.github/workflows/integration-test-runner-jdk25.yml
+++ b/.github/workflows/integration-test-runner-jdk25.yml
@@ -1,4 +1,4 @@
-name: Integration Test Runner JDK21
+name: Integration Test Runner JDK25
 
 on:
   workflow_dispatch:
@@ -21,12 +21,12 @@ jobs:
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v4
-      - name: Set up Adopt JDK 21
+      - name: Set up Adopt JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: "adopt"
-      - name: Product-IS build with JDK 21 with Integration Tests
+      - name: Product-IS build with JDK 25 with Integration Tests
         run: |
           mvn clean install --batch-mode | tee mvn-build.log
           


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java version compatibility testing from JDK 21 to JDK 25 in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->