### PR TITLE
Bump xalan from 2.7.2 to 2.7.3 to fix CVE-2022-34169

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2892,7 +2892,7 @@
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <wss4j.wso2.version>1.6.0-wso2v8</wss4j.wso2.version>
         <openws.version>1.5.4</openws.version>
-        <xalan.version>2.7.2</xalan.version>
+        <xalan.version>2.7.3</xalan.version>
         <xalan.wso2.version>2.7.0.wso2v1</xalan.wso2.version>
         <rampart.wso2.version>1.6.1-wso2v43</rampart.wso2.version>
         <orbit.version.commons.httpclient>4.5.13.wso2v1</orbit.version.commons.httpclient>


### PR DESCRIPTION
### Description

- This PR upgrades the xalan dependency from version 2.7.2 to 2.7.3 to address the critical RCE vulnerability identified as CVE-2022-34169.

### Vulnerability Details

- CVE-2022-34169 allows attackers to bypass protections and execute arbitrary code via XSLT transformations. Version 2.7.3 patches this issue.

### Changes

- Updated pom.xml version property for Xalan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external library versions for maintenance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->