### PR TITLE
Add tests for preserveCurrentSessionAtPasswordUpdate config

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/ConfigSuccessTest.java
@@ -203,6 +203,44 @@ public class ConfigSuccessTest extends ConfigTestBase {
     }
 
     @Test(dependsOnMethods = {"testPatchConfigs"})
+    public void testGetPreserveCurrentSessionAtPasswordUpdateConfig() throws Exception {
+
+        Response response = getResponseOfGet(CONFIGS_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("preserveCurrentSessionAtPasswordUpdate", equalTo(false));
+    }
+
+    @Test(dependsOnMethods = {"testGetPreserveCurrentSessionAtPasswordUpdateConfig"})
+    public void testPatchPreserveCurrentSessionAtPasswordUpdateConfig() throws Exception {
+
+        String body = readResource("patch-modify-preserve-session-at-password-update-config.json");
+        Response response = getResponseOfPatch(CONFIGS_API_BASE_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+
+        response = getResponseOfGet(CONFIGS_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("preserveCurrentSessionAtPasswordUpdate", equalTo(true));
+
+        String defaultBody = readResource("default-preserve-session-at-password-update-config.json");
+        getResponseOfPatch(CONFIGS_API_BASE_PATH, defaultBody);
+        response = getResponseOfGet(CONFIGS_API_BASE_PATH);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("preserveCurrentSessionAtPasswordUpdate", equalTo(false));
+    }
+
+    @Test(dependsOnMethods = {"testPatchConfigs"})
     public void testUpdateScimConfigs() throws Exception {
 
         String body = readResource("update-scim-configs.json");

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/default-preserve-session-at-password-update-config.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/default-preserve-session-at-password-update-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "operation": "REPLACE",
+    "path": "/preserveCurrentSessionAtPasswordUpdate",
+    "value": "false"
+  }
+]

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/patch-modify-preserve-session-at-password-update-config.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/configs/v1/patch-modify-preserve-session-at-password-update-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "operation": "REPLACE",
+    "path": "/preserveCurrentSessionAtPasswordUpdate",
+    "value": "true"
+  }
+]


### PR DESCRIPTION
Related issue https://github.com/wso2/product-is/issues/26832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for session preservation behavior during password updates.
  * Added validation tests for retrieving and modifying session preservation configuration settings.
  * Includes test scenarios for default values, configuration updates, and reverting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->