### PR TITLE
EdDSA kernel bump

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.4" useFeatures="true" includeLaunchers="true">
+version="4.12.5" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.4" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.4"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.5"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2822,7 +2822,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.4</carbon.kernel.version>
+        <carbon.kernel.version>4.12.5</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.0</identity.verification.version>


### PR DESCRIPTION
This pull request updates the Carbon Kernel version across the project from 4.12.3 to 4.12.5 to ensure consistency and to incorporate the latest improvements and fixes.

Version upgrade:

* Updated the `carbon.kernel.version` property in `pom.xml` from 4.12.3 to 4.12.5 to use the latest Carbon Kernel version.
* Updated the `version` attribute and the `org.wso2.carbon.core.runtime` feature version in `modules/p2-profile-gen/carbon.product` from 4.12.3 to 4.12.5. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product and feature metadata versions to 4.12.5, ensuring all components are synchronized with the latest kernel release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->