### PR TITLE
Add wso2.com_ed option to SAML metadata test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/saml-metadata-tenant.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/saml-metadata-tenant.json
@@ -2,6 +2,7 @@
   "defaultNameIdFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
   "certificateAlias": {
     "options": [
+      "wso2.com_ed",
       "wso2.com"
     ],
     "defaultValue": "wso2carbon"


### PR DESCRIPTION
Include the "wso2.com_ed" certificate alias in the certificateAlias.options array of the tenant SAML metadata test resource. This updates the test JSON (modules/integration/tests-integration/.../saml-metadata-tenant.json) to include an additional certificate alias option used by integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated test resources to include additional certificate alias configuration options for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->