### PR TITLE
Update sub organization application creation with issuer as the sub organization

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2AuthorizationForSubOrganizationAppsTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2AuthorizationForSubOrganizationAppsTestCase.java
@@ -261,7 +261,8 @@ public class OAuth2AuthorizationForSubOrganizationAppsTestCase extends OAuth2Ser
          Create an application from the switched token in the created application and enable authorization
          grant types. The newly created API resource will be added via updateOrganizationAppAuthorizedAPIs
         */
-        organizationApplicationId = createOrganizationApplication(ORGANIZATION_MAIN_APP_NAME, switchedM2MToken);
+        organizationApplicationId = createOrganizationApplication(ORGANIZATION_MAIN_APP_NAME, switchedM2MToken,
+                organizationId);
 
         // Create a user in the organization to perform login
         createOrgUser();
@@ -564,7 +565,8 @@ public class OAuth2AuthorizationForSubOrganizationAppsTestCase extends OAuth2Ser
         shareApplication(applicationId);
     }
 
-    private String createOrganizationApplication(String applicationName, String accessToken) throws Exception {
+    private String createOrganizationApplication(String applicationName, String accessToken, String organizationId)
+            throws Exception {
 
         List<UserClaimConfig> userClaimConfigs = Collections.singletonList(
                 new UserClaimConfig.Builder().localClaimUri("http://wso2.org/claims/emailaddress")
@@ -584,7 +586,7 @@ public class OAuth2AuthorizationForSubOrganizationAppsTestCase extends OAuth2Ser
                 .build();
 
         ApplicationResponseModel applicationResponseModel = addOrganizationApplication(applicationName,
-                applicationConfig, accessToken);
+                applicationConfig, accessToken, organizationId);
         String organizationApplicationId = applicationResponseModel.getId();
 
         JSONObject orgAppAPIResources = new JSONObject(RESTTestBase.readResource(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2ServiceAbstractIntegrationTest.java
@@ -60,6 +60,7 @@ import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.
 import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.ScopeGetModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AccessTokenConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AllowedIssuer;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
@@ -299,7 +300,8 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
      */
     public ApplicationResponseModel addOrganizationApplication(String applicationName,
                                                                ApplicationConfig applicationConfig,
-                                                               String switchedAccessToken) throws Exception {
+                                                               String switchedAccessToken,
+                                                               String organizationId) throws Exception {
 
         if (applicationConfig == null) {
             return getBasicOAuthApplication(CALLBACK_URL);
@@ -311,6 +313,9 @@ public class OAuth2ServiceAbstractIntegrationTest extends ISIntegrationTest {
         OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
         oidcConfig.setGrantTypes(applicationConfig.getGrantTypes());
         oidcConfig.setCallbackURLs(Collections.singletonList(OAuth2Constant.CALLBACK_URL));
+        AllowedIssuer allowedIssuer = new AllowedIssuer();
+        allowedIssuer.organizationId(organizationId);
+        oidcConfig.setIssuer(allowedIssuer);
 
         AccessTokenConfiguration accessTokenConfiguration = new AccessTokenConfiguration();
         accessTokenConfiguration.type(applicationConfig.getTokenType().getTokenTypeProperty());


### PR DESCRIPTION
## Changes in this PR
- $subject
- Related to https://github.com/wso2/product-is/issues/26758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 supports organization-scoped issuer configuration for sub-organization applications.
  * Application creation and provisioning now correctly respect organization context for organization-scoped apps.

* **Bug Fixes**
  * Tokens issued for organization-scoped apps now use the correct organization-specific issuer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->