### PR TITLE
fix: implement BasicAuthHandler#getAuthenticationInfo in tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/BasicAuthHandler.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/BasicAuthHandler.java
@@ -24,6 +24,7 @@ import org.wso2.charon.core.extensions.AuthenticationHandler;
 import org.wso2.charon.core.extensions.AuthenticationInfo;
 import org.wso2.charon.core.extensions.CharonManager;
 import org.wso2.charon.core.schema.SCIMConstants;
+import org.wso2.identity.integration.test.utils.BasicAuthInfo;
 
 import java.util.Map;
 
@@ -111,7 +112,12 @@ public class BasicAuthHandler implements AuthenticationHandler {
      * @return AuthenticationInfo
      */
     public AuthenticationInfo getAuthenticationInfo() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        BasicAuthInfo basicAuthInfo = new BasicAuthInfo();
+        basicAuthInfo.setUserName(USER_NAME);
+        basicAuthInfo.setPassword(PASSWORD);
+        basicAuthInfo.setAuthorizationHeader(
+                getBase64EncodedBasicAuthHeader(USER_NAME, PASSWORD));
+        return basicAuthInfo;
     }
 
 }

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/identity/ui/integration/test/utils/BasicAuthHandler.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/identity/ui/integration/test/utils/BasicAuthHandler.java
@@ -115,7 +115,12 @@ public class BasicAuthHandler implements AuthenticationHandler {
      * @return AuthenticationInfo
      */
     public AuthenticationInfo getAuthenticationInfo() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        BasicAuthInfo basicAuthInfo = new BasicAuthInfo();
+        basicAuthInfo.setUserName(USER_NAME);
+        basicAuthInfo.setPassword(PASSWORD);
+        basicAuthInfo.setAuthorizationHeader(
+                getBase64EncodedBasicAuthHeader(USER_NAME, PASSWORD));
+        return basicAuthInfo;
     }
 
 }


### PR DESCRIPTION
I noticed that getAuthenticationInfo() was essentially a dead end—it always returned null, even though the class had all the credentials it needed. This was a bit of a landmine for anyone calling the method, as it could lead to unexpected crashes or authentication silent-fails. I’ve updated it to actually 'speak up' and return a fully formed BasicAuthInfo object. Now, the method does exactly what it says on the tin, making it much safer for the rest of the team to use.

    public AuthenticationInfo getAuthenticationInfo() {
        BasicAuthInfo authInfo = new BasicAuthInfo();
        authInfo.setUserName(USER_NAME);
        authInfo.setPassword(PASSWORD);
        authInfo.setAuthorizationHeader(getBase64EncodedBasicAuthHeader(USER_NAME, PASSWORD));
        return authInfo;
    }
    
        public AuthenticationInfo getAuthenticationInfo() {
        BasicAuthInfo authInfo = new BasicAuthInfo();
        authInfo.setUserName(USER_NAME);
        authInfo.setPassword(PASSWORD);
        authInfo.setAuthorizationHeader(getBase64EncodedBasicAuthHeader(USER_NAME, PASSWORD));
        return authInfo;
    }
    
    full Git link - https://github.com/Mihix/Fix-BasicAuthHandler-getAuthenticationInfo-returning-null-in-integration-tests-in-PRODUCT-IS-WS02.git
