### PR TITLE
Bump identity inbound OAuth version to 7.4.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2696,7 +2696,7 @@
         <identity.carbon.auth.rest.version>1.12.1</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.31</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.32</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.3</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>


### PR DESCRIPTION
Update pom.xml property identity.inbound.auth.oauth.version from 7.4.31 to 7.4.32 to pick up the latest patch fixes for the inbound OAuth component (JWKSEndpoint).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth module dependency version for enhanced compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->