### PR TITLE
Bump scim2 connector version to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2746,7 +2746,7 @@
         <provisioning.connector.google.version>5.2.8</provisioning.connector.google.version>
         <provisioning.connector.salesforce.version>5.2.10</provisioning.connector.salesforce.version>
         <provisioning.connector.scim.version>5.3.5</provisioning.connector.scim.version>
-        <provisioning.connector.scim2.version>2.1.2</provisioning.connector.scim2.version>
+        <provisioning.connector.scim2.version>2.1.3</provisioning.connector.scim2.version>
 
         <!-- Local Authenticator Versions -->
         <identity.local.auth.basicauth.version>6.11.1</identity.local.auth.basicauth.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated provisioning SCIM v2 connector dependency to version 2.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->