### PR TITLE
Add Adaptive Script Based Resend/Retry Integration Tests.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/AbstractOTPLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/AbstractOTPLimitNativeAuthTestCase.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.applicationNativeAuthentication;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.testng.Assert;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.application.common.model.idp.xsd.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvider;
+import org.wso2.identity.integration.common.clients.Idp.IdentityProviderMgtServiceClient;
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+import org.wso2.identity.integration.test.oidc.OIDCUtilTest;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.PhoneNumbers;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.AUTHENTICATOR_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.AUTHENTICATORS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.CODE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.DESCRIPTION;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FAIL_INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_STATUS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_TYPE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.HREF;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.LINKS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.MESSAGE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.MESSAGE_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.MESSAGES;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.METADATA;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.NEXT_STEP;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.PARAMS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.PROMPT_TYPE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.REQUIRED_PARAMS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.RESPONSE_MODE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.STEP_TYPE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.TRACE_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.USERNAME_PARAM;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.UTF_8;
+
+/**
+ * Abstract base class for Email-OTP and SMS-OTP OTP limit (retry + resend) integration tests.
+ */
+public abstract class AbstractOTPLimitNativeAuthTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    protected static final String TEST_USER_NAME     = "it_user_otp_limits";
+    protected static final String TEST_USER_PASSWORD = "User@123Otp!";
+    protected static final String TEST_USER_EMAIL    = "it_user_otp_limits@example.com";
+    protected static final String TEST_USER_MOBILE   = "+94771234567";
+
+    protected static final String WRONG_OTP = "000000";
+    protected static final String ADAPTIVE_SCRIPT_TEMPLATE =
+            "var onLoginRequest = function(context) {\n" +
+            "  executeStep(1, {\n" +
+            "    authenticatorParams: {\n" +
+            "      local: {\n" +
+            "        \"%s\": {\n" +
+            "          \"enableRetryFromAuthenticator\": \"true\",\n" +
+            "          \"maximumAllowedFailureAttempts\": \"2\",\n" +
+            "          \"maximumAllowedResendAttempts\": \"1\",\n" +
+            "          \"terminateOnResendLimitExceeded\": \"true\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }, {});\n" +
+            "};\n";
+
+    protected static final String ADAPTIVE_SCRIPT_SOFT_RESEND_TEMPLATE =
+            "var onLoginRequest = function(context) {\n" +
+            "  executeStep(1, {\n" +
+            "    authenticatorParams: {\n" +
+            "      local: {\n" +
+            "        \"%s\": {\n" +
+            "          \"enableRetryFromAuthenticator\": \"true\",\n" +
+            "          \"maximumAllowedFailureAttempts\": \"2\",\n" +
+            "          \"maximumAllowedResendAttempts\": \"1\",\n" +
+            "          \"terminateOnResendLimitExceeded\": \"false\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }, {});\n" +
+            "};\n";
+
+    protected CloseableHttpClient client;
+    protected SCIM2RestClient scim2RestClient;
+    protected String userId;
+    protected String soapBackendURL;
+    protected String authorizeEndpointURL;
+    protected String flowId;
+    protected String authenticatorId;
+    protected String href;
+
+    /**
+     * Initializes common resources for OTP limit tests.
+     *
+     * @param userMode the user mode to initialize for (SUPER_TENANT or TENANT).
+     */
+    protected void commonInit(TestUserMode userMode) throws Exception {
+
+        soapBackendURL = backendURL;
+        backendURL = backendURL.replace("services/", "");
+
+        authorizeEndpointURL = getTenantQualifiedURL(
+                OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain());
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+
+        setSystemproperties();
+
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        userId = scim2RestClient.createUser(buildTestUser());
+
+        resetResidentIDPCache();
+    }
+
+    /**
+     * Tears down the common resources created.
+     */
+    protected void commonTearDown() throws Exception {
+
+        if (userId != null) {
+            scim2RestClient.deleteUser(userId);
+        }
+        if (scim2RestClient != null) {
+            scim2RestClient.closeHttpClient();
+        }
+        if (restClient != null) {
+            restClient.closeHttpClient();
+        }
+        if (client != null) {
+            client.close();
+        }
+
+        // Nullify framework-level state.
+        consumerKey = null;
+        consumerSecret = null;
+        flowId = null;
+        authenticatorId = null;
+        href = null;
+        userId = null;
+    }
+
+    /**
+     * Initiates a fresh API-based auth flow then completes the mandatory IDF step.
+     *
+     * @param consumerKey OAuth2 client id of the target application.
+     */
+    protected void initiateAuthFlow(String consumerKey) throws Exception {
+
+        // Step 1 – POST /oauth2/authorize → IDF challenge.
+        HttpResponse response = sendPostRequestWithParameters(
+                client,
+                buildOAuth2Parameters(consumerKey),
+                authorizeEndpointURL);
+        Assert.assertNotNull(response, "Auth flow initiation returned null response.");
+
+        String bodyStr = EntityUtils.toString(response.getEntity(), UTF_8);
+        EntityUtils.consume(response.getEntity());
+
+        JSONParser parser = new JSONParser();
+        JSONObject initJson = (JSONObject) parser.parse(bodyStr);
+        Assert.assertNotNull(initJson, "Auth flow init response JSON is null.");
+
+        extractFlowState(initJson);
+
+        // Step 2 – submit username through IDF → OTP is triggered and sent.
+        submitUsernameForIDF();
+    }
+
+    /**
+     * Submits the test username through the IDF (Identifier-First) step.
+     */
+    private void submitUsernameForIDF() {
+
+        String idfBody = buildIDFSubmitBody(flowId, authenticatorId, TEST_USER_NAME);
+        ExtractableResponse<Response> resp = postAndAssertStatus(href, idfBody, HttpStatus.SC_OK);
+
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertNotEquals(status, FAIL_INCOMPLETE,
+                "IDF step failed unexpectedly. Username '" + TEST_USER_NAME + "' may not exist.");
+
+        refreshFlowState(resp);
+    }
+
+    /**
+     * Submits an OTP code against the current flow, asserts the expected HTTP status,
+     * and returns the response for further assertion.
+     *
+     * @param otpCode        OTP to submit.
+     * @param expectedStatus expected HTTP status code.
+     */
+    protected ExtractableResponse<Response> submitOTPCode(String otpCode, int expectedStatus) {
+
+        return postAndAssertStatus(href, buildOTPSubmitBody(flowId, authenticatorId, otpCode), expectedStatus);
+    }
+
+    /**
+     * Triggers an OTP resend against the current flow, asserts the expected HTTP status,
+     * and returns the response for further assertion.
+     *
+     * @param expectedStatus expected HTTP status code.
+     */
+    protected ExtractableResponse<Response> triggerResend(int expectedStatus) {
+
+        return postAndAssertStatus(href, buildResendBody(flowId, authenticatorId), expectedStatus);
+    }
+
+    /**
+     * POSTs a JSON body to {@code url}, asserts the HTTP status, and returns
+     * the extractable response.
+     */
+    protected ExtractableResponse<Response> postAndAssertStatus(
+            String url, String requestBody, int expectedStatus) {
+
+        return given()
+                .contentType(ContentType.JSON)
+                .headers(new HashMap<>())
+                .body(requestBody)
+                .when()
+                .post(url)
+                .then()
+                .assertThat()
+                .statusCode(expectedStatus)
+                .extract();
+    }
+
+    /**
+     * Asserts that an HTTP 400 error response body exactly matches the expected error.
+     *
+     * @param resp     the 400 response to inspect.
+     * @param expected the {@link Constants.OtpLimitExceededError} enum entry to assert against.
+     */
+    protected void assertOTPLimitExceededPayload(
+            ExtractableResponse<Response> resp,
+            Constants.OtpLimitExceededError expected) {
+
+        String actualCode = resp.jsonPath().getString(CODE);
+        String actualMessage = resp.jsonPath().getString(MESSAGE);
+        String actualDescription = resp.jsonPath().getString(DESCRIPTION);
+        String actualTraceId = resp.jsonPath().getString(TRACE_ID);
+
+        Assert.assertEquals(actualCode, expected.getCode(),
+                "Error code mismatch. Expected: " + expected.getCode() + ", got: " + actualCode);
+        Assert.assertEquals(actualMessage, expected.getMessage(),
+                "Error message mismatch. Expected: " + expected.getMessage() + ", got: " + actualMessage);
+        Assert.assertEquals(actualDescription, expected.getDescription(),
+                "Error description mismatch. Expected: " + expected.getDescription()
+                        + ", got: " + actualDescription);
+
+        Assert.assertNotNull(actualTraceId, "traceId must be present in the error response.");
+        Assert.assertFalse(actualTraceId.trim().isEmpty(), "traceId must not be blank in the error response.");
+    }
+
+    /**
+     * Parses the init-response JSON and stores flowId, and authenticatorId.
+     * and href(URL that should be called on next request) into instance fields.
+     */
+    protected void extractFlowState(JSONObject json) {
+
+        Assert.assertTrue(json.containsKey(FLOW_ID), "flowId missing from init response.");
+        Assert.assertTrue(json.containsKey(FLOW_STATUS), "flowStatus missing from init response.");
+        Assert.assertTrue(json.containsKey(FLOW_TYPE), "flowType missing from init response.");
+        Assert.assertTrue(json.containsKey(NEXT_STEP), "nextStep missing from init response.");
+        Assert.assertTrue(json.containsKey(LINKS), "links missing from init response.");
+
+        flowId = (String) json.get(FLOW_ID);
+
+        JSONObject nextStep = (JSONObject) json.get(NEXT_STEP);
+        Assert.assertTrue(nextStep.containsKey(STEP_TYPE), "stepType missing from nextStep.");
+        Assert.assertTrue(nextStep.containsKey(AUTHENTICATORS), "authenticators missing from nextStep.");
+
+        JSONArray authenticatorsArray = (JSONArray) nextStep.get(AUTHENTICATORS);
+        Assert.assertFalse(authenticatorsArray.isEmpty(), "authenticators list must not be empty.");
+
+        JSONObject authenticator = (JSONObject) authenticatorsArray.get(0);
+        Assert.assertTrue(authenticator.containsKey(AUTHENTICATOR_ID), "authenticatorId missing.");
+        Assert.assertTrue(authenticator.containsKey(METADATA), "metadata missing.");
+        Assert.assertTrue(authenticator.containsKey(REQUIRED_PARAMS), "requiredParams missing.");
+
+        authenticatorId = (String) authenticator.get(AUTHENTICATOR_ID);
+
+        JSONObject metadata = (JSONObject) authenticator.get(METADATA);
+        Assert.assertTrue(metadata.containsKey(PROMPT_TYPE), "promptType missing from metadata.");
+        Assert.assertTrue(metadata.containsKey(PARAMS), "params missing from metadata.");
+
+        JSONArray linksArray = (JSONArray) json.get(LINKS);
+        Assert.assertFalse(linksArray.isEmpty(), "links list must not be empty.");
+        JSONObject link = (JSONObject) linksArray.get(0);
+        Assert.assertTrue(link.containsKey(HREF), "href missing from links.");
+        href = link.get(HREF).toString();
+    }
+
+    /**
+     * Fully refreshes flowId, authenticatorId, and href instance fields from the given response.
+     * from success response.  All three fields are asserted to
+     * be present (used after the IDF step where the OTP challenge must supply them).
+     */
+    protected void refreshFlowState(ExtractableResponse<Response> resp) {
+
+        String newFlowId = resp.jsonPath().getString(FLOW_ID);
+        Assert.assertNotNull(newFlowId, "flowId must be present in the IDF step response.");
+        flowId = newFlowId;
+
+        List<Map<String, Object>> links = resp.jsonPath().getList(LINKS);
+        Assert.assertNotNull(links, "links must be present in the IDF step response.");
+        Assert.assertFalse(links.isEmpty(), "links must not be empty in the IDF step response.");
+        Object hrefObj = links.get(0).get(HREF);
+        Assert.assertNotNull(hrefObj, "href must be present in the IDF step response links.");
+        href = hrefObj.toString();
+
+        String nextStepPrefix = NEXT_STEP + "." + AUTHENTICATORS;
+        List<Map<String, Object>> auths = resp.jsonPath().getList(nextStepPrefix);
+        Assert.assertNotNull(auths, "authenticators must be present in the IDF step nextStep.");
+        Assert.assertFalse(auths.isEmpty(), "authenticators must not be empty in the IDF step nextStep.");
+        Object idObj = auths.get(0).get(AUTHENTICATOR_ID);
+        Assert.assertNotNull(idObj, "authenticatorId must be present in the IDF step authenticator.");
+        authenticatorId = idObj.toString();
+    }
+
+    /**
+     * Refreshes flowId, authenticatorId, and href instance fields from the given response if present.
+     * that keeps the flow alive (FAIL_INCOMPLETE / INCOMPLETE).
+     */
+    protected void refreshHrefAndAuthenticatorId(ExtractableResponse<Response> resp) {
+
+        List<Map<String, Object>> links = resp.jsonPath().getList(LINKS);
+        if (links != null && !links.isEmpty()) {
+            Object hrefObj = links.get(0).get(HREF);
+            if (hrefObj != null) {
+                href = hrefObj.toString();
+            }
+        }
+
+        String nextStepPrefix = NEXT_STEP + "." + AUTHENTICATORS;
+        List<Map<String, Object>> auths = resp.jsonPath().getList(nextStepPrefix);
+        if (auths != null && !auths.isEmpty()) {
+            Object idObj = auths.get(0).get(AUTHENTICATOR_ID);
+            if (idObj != null) {
+                authenticatorId = idObj.toString();
+            }
+        }
+    }
+
+    private String buildOTPSubmitBody(String flowId, String authenticatorId, String otpCode) {
+
+        return "{\n" +
+               "  \"flowId\": \"" + flowId + "\",\n" +
+               "  \"selectedAuthenticator\": {\n" +
+               "    \"authenticatorId\": \"" + authenticatorId + "\",\n" +
+               "    \"params\": {\n" +
+               "      \"OTPcode\": \"" + otpCode + "\"\n" +
+               "    }\n" +
+               "  }\n" +
+               "}";
+    }
+
+    private String buildIDFSubmitBody(String flowId, String authenticatorId, String username) {
+
+        return "{\n" +
+               "  \"flowId\": \"" + flowId + "\",\n" +
+               "  \"selectedAuthenticator\": {\n" +
+               "    \"authenticatorId\": \"" + authenticatorId + "\",\n" +
+               "    \"params\": {\n" +
+               "      \"" + USERNAME_PARAM + "\": \"" + username + "\"\n" +
+               "    }\n" +
+               "  }\n" +
+               "}";
+    }
+
+    private String buildResendBody(String flowId, String authenticatorId) {
+
+        return "{\n" +
+               "  \"flowId\": \"" + flowId + "\",\n" +
+               "  \"selectedAuthenticator\": {\n" +
+               "    \"authenticatorId\": \"" + authenticatorId + "\",\n" +
+               "    \"params\": {\n" +
+               "      \"resendCode\": \"true\"\n" +
+               "    }\n" +
+               "  }\n" +
+               "}";
+    }
+
+    private List<NameValuePair> buildOAuth2Parameters(String consumerKey) {
+
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_RESPONSE_TYPE,
+                OAuth2Constant.AUTHORIZATION_CODE_NAME));
+        params.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_RESPONSE_MODE, RESPONSE_MODE));
+        params.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_CLIENT_ID, consumerKey));
+        params.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_REDIRECT_URI, OAuth2Constant.CALLBACK_URL));
+        params.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_SCOPE,
+                OAuth2Constant.OAUTH2_SCOPE_OPENID_WITH_INTERNAL_LOGIN));
+        params.add(new BasicNameValuePair(OAuth2Constant.OAUTH2_NONCE, UUID.randomUUID().toString()));
+        return params;
+    }
+
+    /**
+     * Creates an OIDC application with API-based authentication enabled, a single
+     * authentication step for authenticatorName, and the adaptive-auth script
+     * that enforces the OTP retry/resend limits.
+     *
+     * @param appName           display name for the application.
+     * @param authenticatorName authenticator key.
+     * @return the created {@link ApplicationResponseModel}.
+     */
+    protected ApplicationResponseModel createOTPApp(String appName, String authenticatorName)
+            throws Exception {
+
+        return createOTPAppWithAdaptiveScript(appName, authenticatorName,
+                String.format(ADAPTIVE_SCRIPT_TEMPLATE, authenticatorName));
+    }
+
+    /**
+     * Creates an OIDC application with soft resend limit enabled.
+     *
+     * @param appName           display name for the application.
+     * @param authenticatorName authenticator key.
+     * @return the created {@link ApplicationResponseModel}.
+     */
+    protected ApplicationResponseModel createOTPAppWithSoftResendLimit(String appName, String authenticatorName)
+            throws Exception {
+
+        return createOTPAppWithAdaptiveScript(appName, authenticatorName,
+                String.format(ADAPTIVE_SCRIPT_SOFT_RESEND_TEMPLATE, authenticatorName));
+    }
+
+    /**
+     * Creates an OIDC application with API-based authentication enabled, a single
+     * authentication step for authenticatorName, and the adaptive-auth script
+     * that enforces the OTP retry/resend limits with the option to terminate or not
+     * on resend limit exceeded.
+     *
+     * @param appName           display name for the application.
+     * @param authenticatorName authenticator key.
+     * @param adaptiveScript    adaptive auth script content to set in the application.
+     * @return the created {@link ApplicationResponseModel}.
+     */
+    private ApplicationResponseModel createOTPAppWithAdaptiveScript(String appName, String authenticatorName,
+                                                                    String adaptiveScript)
+            throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+
+        List<String> grantTypes = new ArrayList<>();
+        Collections.addAll(grantTypes, OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
+
+        List<String> callBackUrls = new ArrayList<>();
+        Collections.addAll(callBackUrls, OAuth2Constant.CALLBACK_URL);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(grantTypes);
+        oidcConfig.setCallbackURLs(callBackUrls);
+        oidcConfig.setPublicClient(true);
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+        application.setName(appName);
+
+        application.advancedConfigurations(new AdvancedApplicationConfiguration());
+        application.getAdvancedConfigurations().setEnableAPIBasedAuthentication(true);
+
+        AuthenticationStep step = new AuthenticationStep();
+        step.setId(1);
+        step.addOptionsItem(new Authenticator().idp("LOCAL").authenticator(authenticatorName));
+
+        AuthenticationSequence authSequence = new AuthenticationSequence();
+        authSequence.setType(AuthenticationSequence.TypeEnum.USER_DEFINED);
+        authSequence.addStepsItem(step);
+        authSequence.setSubjectStepId(1);
+        authSequence.setScript(adaptiveScript);
+
+        application.setAuthenticationSequence(authSequence);
+
+        String newAppId = addApplication(application);
+        return getApplication(newAppId);
+    }
+
+    /**
+     * Asserts the response when the resend limit is exceeded and
+     *
+     * @param resp the HTTP 200 response to assert.
+     */
+    protected void assertSoftResendLimitExceededPayload(ExtractableResponse<Response> resp) {
+
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, FAIL_INCOMPLETE,
+                "Soft resend limit: expected FAIL_INCOMPLETE but got: " + status);
+
+        Constants.OtpLimitExceededMessage expected = Constants.OtpLimitExceededMessage.RESEND_LIMIT_EXCEEDED;
+        String messagesPrefix = NEXT_STEP + "." + MESSAGES + "[0]";
+        String actualType = resp.jsonPath().getString(messagesPrefix + ".type");
+        String actualMessageId = resp.jsonPath().getString(messagesPrefix + "." + MESSAGE_ID);
+        String actualMessage = resp.jsonPath().getString(messagesPrefix + "." + MESSAGE);
+
+        Assert.assertEquals(actualType, expected.getType(),
+                "Soft resend limit: expected message type " + expected.getType() + " but got: " + actualType);
+        Assert.assertEquals(actualMessageId, expected.getMessageId(),
+                "Soft resend limit: expected messageId " + expected.getMessageId()
+                        + " but got: " + actualMessageId);
+        Assert.assertEquals(actualMessage, expected.getMessage(),
+                "Soft resend limit: expected message '" + expected.getMessage()
+                        + "' but got: " + actualMessage);
+    }
+
+    /**
+     * Builds the test user with both an email address (for Email-OTP) and a mobile
+     * number (for SMS-OTP).
+     */
+    protected UserObject buildTestUser() {
+
+        UserObject user = new UserObject();
+        user.setUserName(TEST_USER_NAME);
+        user.setPassword(TEST_USER_PASSWORD);
+        user.setName(new Name()
+                .givenName(OIDCUtilTest.firstName)
+                .familyName(OIDCUtilTest.lastName));
+        // Email claim (http://wso2.org/claims/emailaddress) – required by email-otp-authenticator.
+        user.addEmail(new Email().value(TEST_USER_EMAIL));
+        // Mobile claim (http://wso2.org/claims/mobile) – required by sms-otp-authenticator.
+        // SCIM2 maps phoneNumbers[type eq "mobile"].value → http://wso2.org/claims/mobile.
+        user.addPhoneNumbers(new PhoneNumbers().type("mobile").value(TEST_USER_MOBILE));
+        return user;
+    }
+
+    /**
+     * Resets the resident IDP cache to ensure that any changes to the IDP (e.g. enabling
+     * just the SAML SSO federated authenticator) are reflected in the test execution.
+     */
+    protected void resetResidentIDPCache() throws Exception {
+
+        IdentityProviderMgtServiceClient idpMgtClient =
+                new IdentityProviderMgtServiceClient(sessionCookie, soapBackendURL);
+        IdentityProvider residentIdp = idpMgtClient.getResidentIdP();
+
+        FederatedAuthenticatorConfig[] configs = residentIdp.getFederatedAuthenticatorConfigs();
+        for (FederatedAuthenticatorConfig cfg : configs) {
+            if (!cfg.getName().equalsIgnoreCase("samlsso")) {
+                configs = (FederatedAuthenticatorConfig[]) ArrayUtils.removeElement(configs, cfg);
+            }
+        }
+        residentIdp.setFederatedAuthenticatorConfigs(configs);
+        idpMgtClient.updateResidentIdP(residentIdp);
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/AbstractOTPLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/AbstractOTPLimitNativeAuthTestCase.java
@@ -97,10 +97,10 @@ import static org.wso2.identity.integration.test.applicationNativeAuthentication
  */
 public abstract class AbstractOTPLimitNativeAuthTestCase extends OAuth2ServiceAbstractIntegrationTest {
 
-    protected static final String TEST_USER_NAME     = "it_user_otp_limits";
+    protected static final String TEST_USER_NAME = "it_user_otp_limits";
     protected static final String TEST_USER_PASSWORD = "User@123Otp!";
-    protected static final String TEST_USER_EMAIL    = "it_user_otp_limits@example.com";
-    protected static final String TEST_USER_MOBILE   = "+94771234567";
+    protected static final String TEST_USER_EMAIL = "it_user_otp_limits@example.com";
+    protected static final String TEST_USER_MOBILE = "+94771234567";
 
     protected static final String WRONG_OTP = "000000";
     protected static final String ADAPTIVE_SCRIPT_TEMPLATE =

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/Constants.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/Constants.java
@@ -74,4 +74,100 @@ public class Constants {
     public static final String MESSAGE_ID = "messageId";
     public static final String MESSAGES = "messages";
     public static final String FAIL_INCOMPLETE = "FAIL_INCOMPLETE";
+    public static final String INCOMPLETE = "INCOMPLETE";
+
+    // IDF (Identifier-First) step param keys.
+    public static final String USERNAME_PARAM = "username";
+
+    /**
+     * Error codes for OTP retry and resend limits when {@code terminateOnResendLimitExceeded = true}.
+     */
+    public enum OtpLimitExceededError {
+
+        RETRY_LIMIT_EXCEEDED(
+                "ABA-60013",
+                "Maximum retry attempts exceeded.",
+                "Authentication failed. The maximum number of retry attempts has been exceeded."),
+
+        RESEND_LIMIT_EXCEEDED(
+                "ABA-60014",
+                "Maximum resend attempts exceeded.",
+                "Authentication failed. The maximum number of OTP resend attempts has been exceeded.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        OtpLimitExceededError(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " - " + message;
+        }
+    }
+
+    /**
+     * Message fields for OTP resend limit exceeded when {@code terminateOnResendLimitExceeded = false}.
+     *
+     */
+    public enum OtpLimitExceededMessage {
+
+        RESEND_LIMIT_EXCEEDED(
+                "ERROR",
+                "ABA-60003",
+                "resent.count.exceeded");
+
+        private final String type;
+        private final String messageId;
+        private final String message;
+
+        OtpLimitExceededMessage(String type, String messageId, String message) {
+
+            this.type = type;
+            this.messageId = messageId;
+            this.message = message;
+        }
+
+        public String getType() {
+
+            return type;
+        }
+
+        public String getMessageId() {
+
+            return messageId;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        @Override
+        public String toString() {
+
+            return messageId + " - " + message;
+        }
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPLimitNativeAuthTestCase.java
@@ -50,7 +50,7 @@ import static org.wso2.identity.integration.test.applicationNativeAuthentication
  */
 public class EmailOTPLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
 
-    private static final String APP_NAME          = "it-email-otp-first-factor";
+    private static final String APP_NAME = "it-email-otp-first-factor";
     private static final String OTP_AUTHENTICATOR = "email-otp-authenticator";
 
     private final TestUserMode userMode;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPLimitNativeAuthTestCase.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.applicationNativeAuthentication;
+
+import com.icegreen.greenmail.util.GreenMailUtil;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import jakarta.mail.Message;
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.OtpLimitExceededError;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.util.Utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.AUTH_DATA_CODE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FAIL_INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_STATUS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.SUCCESS_COMPLETED;
+
+/**
+ * Integration tests that validate Email-OTP retry and resend limit enforcement via
+ * adaptive-auth runtime params, using the API-based (native) authentication flow.
+ */
+public class EmailOTPLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
+
+    private static final String APP_NAME          = "it-email-otp-first-factor";
+    private static final String OTP_AUTHENTICATOR = "email-otp-authenticator";
+
+    private final TestUserMode userMode;
+    private String appId;
+    private String appConsumerKey;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public EmailOTPLimitNativeAuthTestCase(TestUserMode userMode) {
+
+        this.userMode = userMode;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER},
+                {TestUserMode.TENANT_USER}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        super.init(userMode);
+        commonInit(userMode);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        try {
+            if (appId != null) {
+                deleteApp(appId);
+            }
+            Utils.getMailServer().purgeEmailFromAllMailboxes();
+        } finally {
+            commonTearDown();
+        }
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Register the Email-OTP first-factor application with retry/resend "
+                  + "limit adaptive script.")
+    public void testRegisterEmailOTPApplication() throws Exception {
+
+        ApplicationResponseModel app = createOTPApp(APP_NAME, OTP_AUTHENTICATOR);
+        Assert.assertNotNull(app, "Email-OTP app creation failed.");
+        Assert.assertTrue(
+                app.getAdvancedConfigurations().getEnableAPIBasedAuthentication(),
+                "API-based authentication must be enabled on the Email-OTP app.");
+
+        appId = app.getId();
+        appConsumerKey = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        Assert.assertNotNull(appConsumerKey, "Email-OTP app client-id must not be null.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – first wrong OTP submit returns HTTP 200 + FAIL_INCOMPLETE.",
+          dependsOnMethods = "testRegisterEmailOTPApplication")
+    public void testEmailOTPFirstWrongOTPReturnsFAIL_INCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, FAIL_INCOMPLETE,
+                "Email OTP retry #1: expected FAIL_INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "Email OTP retry #1: flowId must remain the same after a failed attempt.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – second wrong OTP submit returns HTTP 400 + ABA-60013 payload.",
+          dependsOnMethods = "testEmailOTPFirstWrongOTPReturnsFAIL_INCOMPLETE")
+    public void testEmailOTPSecondWrongOTPReturnsABA60013() {
+
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_BAD_REQUEST);
+        assertOTPLimitExceededPayload(resp, OtpLimitExceededError.RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – first OTP resend returns HTTP 200 + INCOMPLETE.",
+          dependsOnMethods = "testEmailOTPSecondWrongOTPReturnsABA60013")
+    public void testEmailOTPFirstResendReturnsINCOMPLETE() throws Exception {
+
+        // Fresh flow for the resend scenario (independent of retry tests above).
+        initiateAuthFlow(appConsumerKey);
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, INCOMPLETE,
+                "Email OTP resend #1: expected INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "Email OTP resend #1: flowId must remain unchanged after a resend.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – second OTP resend returns HTTP 400 + ABA-60014 payload.",
+          dependsOnMethods = "testEmailOTPFirstResendReturnsINCOMPLETE")
+    public void testEmailOTPSecondResendReturnsABA60014() {
+
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_BAD_REQUEST);
+        assertOTPLimitExceededPayload(resp, OtpLimitExceededError.RESEND_LIMIT_EXCEEDED);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – submitting the correct OTP on first attempt completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testEmailOTPSecondResendReturnsABA60014")
+    public void testEmailOTPSuccessfulAuthOnFirstAttempt() throws Exception {
+
+        // Clean the mailbox to ensure we read the correct OTP email for this test, independent of previous tests.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = getOTPFromEmail();
+        Assert.assertNotNull(realOtp, "GreenMail did not capture an OTP – check email sender config.");
+        ExtractableResponse<Response> resp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, SUCCESS_COMPLETED,
+                "Email OTP success (1st attempt): expected SUCCESS_COMPLETED but got: " + status);
+        String authCode = resp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "Email OTP success (1st attempt): authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "Email OTP success (1st attempt): authData.code must not be blank.");
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – submitting the correct OTP after one wrong attempt "
+                  + "completes authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testEmailOTPSuccessfulAuthOnFirstAttempt")
+    public void testEmailOTPSuccessfulAuthAfterOneRetry() throws Exception {
+
+        // Clean the mailbox to ensure we read the correct OTP email for this test, independent of previous tests.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = getOTPFromEmail();
+        Assert.assertNotNull(realOtp, "GreenMail did not capture an OTP.");
+        ExtractableResponse<Response> failResp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        String failStatus = failResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(failStatus, FAIL_INCOMPLETE,
+                "Email OTP retry: expected FAIL_INCOMPLETE after wrong OTP but got: " + failStatus);
+        refreshHrefAndAuthenticatorId(failResp);
+        ExtractableResponse<Response> successResp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        String successStatus = successResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(successStatus, SUCCESS_COMPLETED,
+                "Email OTP retry: expected SUCCESS_COMPLETED after correct OTP but got: " + successStatus);
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "Email OTP retry: authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "Email OTP retry: authData.code must not be blank.");
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP – submitting the OTP received after a resend completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testEmailOTPSuccessfulAuthAfterOneRetry")
+    public void testEmailOTPSuccessfulAuthAfterResend() throws Exception {
+
+        // Clean the mailbox to ensure we read the correct OTP email for this test, independent of previous tests.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        initiateAuthFlow(appConsumerKey);
+        String ignoredOTP = getOTPFromEmail();
+        // Clean the mailbox to get rid of the OTP email sent during initiation.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        ExtractableResponse<Response> resendResp = triggerResend(HttpStatus.SC_OK);
+        String resendStatus = resendResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(resendStatus, INCOMPLETE,
+                "Email OTP resend: expected INCOMPLETE after resend but got: " + resendStatus);
+        refreshHrefAndAuthenticatorId(resendResp);
+        String newOtp = getOTPFromEmail();
+        Assert.assertNotNull(newOtp, "GreenMail did not capture an OTP after resend.");
+        ExtractableResponse<Response> successResp = submitOTPCode(newOtp, HttpStatus.SC_OK);
+        String successStatus = successResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(successStatus, SUCCESS_COMPLETED,
+                "Email OTP resend: expected SUCCESS_COMPLETED after submitting resent OTP but got: "
+                        + successStatus);
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "Email OTP resend: authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "Email OTP resend: authData.code must not be blank.");
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    /**
+     * Waits for exactly one incoming email on GreenMail (up to 10 s), then extracts
+     */
+    private String getOTPFromEmail() {
+
+        Assert.assertTrue(Utils.getMailServer().waitForIncomingEmail(10000, 1),
+                "Timed out waiting for OTP email from GreenMail.");
+        Message[] messages = Utils.getMailServer().getReceivedMessages();
+        String body = GreenMailUtil.getBody(messages[0]).replaceAll("=\r?\n", "");
+        Pattern pattern = Pattern.compile("\\s*<b>(\\d+)</b>");
+        Matcher matcher = pattern.matcher(body);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPSoftResendLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPSoftResendLimitNativeAuthTestCase.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.applicationNativeAuthentication;
+
+import com.icegreen.greenmail.util.GreenMailUtil;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import jakarta.mail.Message;
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.OtpLimitExceededError;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.util.Utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.AUTH_DATA_CODE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FAIL_INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_STATUS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.MESSAGE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.MESSAGES;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.MESSAGE_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.NEXT_STEP;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.SUCCESS_COMPLETED;
+
+/**
+ * Integration tests for Email-OTP where Soft resend limits are enforced via adaptive auth script.
+ */
+public class EmailOTPSoftResendLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
+
+    private static final String APP_NAME          = "it-email-otp-soft-resend-limit";
+    private static final String OTP_AUTHENTICATOR = "email-otp-authenticator";
+
+    private final TestUserMode userMode;
+    private String appId;
+    private String appConsumerKey;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public EmailOTPSoftResendLimitNativeAuthTestCase(TestUserMode userMode) {
+
+        this.userMode = userMode;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER},
+                {TestUserMode.TENANT_USER}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        super.init(userMode);
+        commonInit(userMode);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        try {
+            if (appId != null) {
+                deleteApp(appId);
+            }
+        } finally {
+            Utils.getMailServer().purgeEmailFromAllMailboxes();
+            commonTearDown();
+        }
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Register the Email-OTP application with terminateOnResendLimitExceeded=false "
+                  + "adaptive script.")
+    public void testRegisterEmailOTPSoftResendApp() throws Exception {
+
+        ApplicationResponseModel app = createOTPAppWithSoftResendLimit(APP_NAME, OTP_AUTHENTICATOR);
+        Assert.assertNotNull(app, "Email-OTP soft-resend app creation failed.");
+        Assert.assertTrue(
+                app.getAdvancedConfigurations().getEnableAPIBasedAuthentication(),
+                "API-based authentication must be enabled on the app.");
+
+        appId = app.getId();
+        appConsumerKey = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        Assert.assertNotNull(appConsumerKey, "Email-OTP soft-resend app client-id must not be null.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – first wrong OTP returns HTTP 200 + FAIL_INCOMPLETE.",
+          dependsOnMethods = "testRegisterEmailOTPSoftResendApp")
+    public void testEmailOTPSoftResendFirstWrongOTPReturnsFAIL_INCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, FAIL_INCOMPLETE,
+                "Email OTP soft-resend retry #1: expected FAIL_INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "Email OTP soft-resend retry #1: flowId must remain the same after a failed attempt.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – second wrong OTP returns HTTP 400 + ABA-60013.",
+          dependsOnMethods = "testEmailOTPSoftResendFirstWrongOTPReturnsFAIL_INCOMPLETE")
+    public void testEmailOTPSoftResendSecondWrongOTPReturnsABA60013() {
+
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_BAD_REQUEST);
+        assertOTPLimitExceededPayload(resp, OtpLimitExceededError.RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – first resend returns HTTP 200 + INCOMPLETE.",
+          dependsOnMethods = "testEmailOTPSoftResendSecondWrongOTPReturnsABA60013")
+    public void testEmailOTPSoftResendFirstResendReturnsINCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, INCOMPLETE,
+                "Email OTP soft-resend resend #1: expected INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "Email OTP soft-resend resend #1: flowId must remain unchanged after a resend.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – second resend returns HTTP 200 + FAIL_INCOMPLETE "
+                  + "with ABA-60003 in nextStep.messages.",
+          dependsOnMethods = "testEmailOTPSoftResendFirstResendReturnsINCOMPLETE")
+    public void testEmailOTPSoftResendSecondResendReturnsFAIL_INCOMPLETEWithABA60003() {
+
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_OK);
+        assertSoftResendLimitExceededPayload(resp);
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – correct OTP on first attempt completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testEmailOTPSoftResendSecondResendReturnsFAIL_INCOMPLETEWithABA60003")
+    public void testEmailOTPSoftResendSuccessfulAuthOnFirstAttempt() throws Exception {
+
+        // Clean the mailbox to ensure we read the correct OTP email for this test, independent of previous tests.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = getOTPFromEmail();
+        Assert.assertNotNull(realOtp, "GreenMail did not capture an OTP – check email sender config.");
+        ExtractableResponse<Response> resp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, SUCCESS_COMPLETED,
+                "Email OTP soft-resend success (1st attempt): expected SUCCESS_COMPLETED but got: " + status);
+        String authCode = resp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "Email OTP soft-resend: authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "Email OTP soft-resend: authData.code must not be blank.");
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – correct OTP after one wrong attempt completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testEmailOTPSoftResendSuccessfulAuthOnFirstAttempt")
+    public void testEmailOTPSoftResendSuccessfulAuthAfterOneRetry() throws Exception {
+
+        // Clean the mailbox to ensure we read the correct OTP email for this test, independent of previous tests.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = getOTPFromEmail();
+        Assert.assertNotNull(realOtp, "GreenMail did not capture an OTP.");
+        ExtractableResponse<Response> failResp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        Assert.assertEquals(failResp.jsonPath().getString(FLOW_STATUS), FAIL_INCOMPLETE,
+                "Email OTP soft-resend retry: expected FAIL_INCOMPLETE after wrong OTP.");
+        refreshHrefAndAuthenticatorId(failResp);
+        ExtractableResponse<Response> successResp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        Assert.assertEquals(successResp.jsonPath().getString(FLOW_STATUS), SUCCESS_COMPLETED,
+                "Email OTP soft-resend retry: expected SUCCESS_COMPLETED after correct OTP.");
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "Email OTP soft-resend retry: authData.code must be present.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "Email OTP soft-resend retry: authData.code must not be blank.");
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Email OTP (soft-resend) – correct OTP after a resend completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testEmailOTPSoftResendSuccessfulAuthAfterOneRetry")
+    public void testEmailOTPSoftResendSuccessfulAuthAfterResend() throws Exception {
+
+        // Clean the mailbox to ensure we read the correct OTP email for this test, independent of previous tests.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        initiateAuthFlow(appConsumerKey);
+        String ignoredOTP = getOTPFromEmail();
+        // Clean the mailbox to get rid of the OTP email sent during initiation.
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+        ExtractableResponse<Response> resendResp = triggerResend(HttpStatus.SC_OK);
+        Assert.assertEquals(resendResp.jsonPath().getString(FLOW_STATUS), INCOMPLETE,
+                "Email OTP soft-resend: expected INCOMPLETE after resend.");
+        refreshHrefAndAuthenticatorId(resendResp);
+        String newOtp = getOTPFromEmail();
+        Assert.assertNotNull(newOtp, "GreenMail did not capture an OTP after resend.");
+        ExtractableResponse<Response> successResp = submitOTPCode(newOtp, HttpStatus.SC_OK);
+        Assert.assertEquals(successResp.jsonPath().getString(FLOW_STATUS), SUCCESS_COMPLETED,
+                "Email OTP soft-resend: expected SUCCESS_COMPLETED after submitting resent OTP.");
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "Email OTP soft-resend: authData.code must be present.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "Email OTP soft-resend: authData.code must not be blank.");
+        Utils.getMailServer().purgeEmailFromAllMailboxes();
+    }
+
+    /**
+     * Waits for exactly one incoming email on GreenMail (up to 10 s), then extracts
+     */
+    private String getOTPFromEmail() {
+
+        Assert.assertTrue(Utils.getMailServer().waitForIncomingEmail(10000, 1),
+                "Timed out waiting for OTP email from GreenMail.");
+        Message[] messages = Utils.getMailServer().getReceivedMessages();
+        String body = GreenMailUtil.getBody(messages[0]).replaceAll("=\r?\n", "");
+        Pattern pattern = Pattern.compile("\\s*<b>(\\d+)</b>");
+        Matcher matcher = pattern.matcher(body);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    @Override
+    protected void assertSoftResendLimitExceededPayload(ExtractableResponse<Response> resp) {
+
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, FAIL_INCOMPLETE,
+                "Soft resend limit: expected FAIL_INCOMPLETE but got: " + status);
+
+        Constants.OtpLimitExceededMessage expected = Constants.OtpLimitExceededMessage.RESEND_LIMIT_EXCEEDED;
+        String messagesPrefix = NEXT_STEP + "." + MESSAGES + "[1]";
+        String actualType = resp.jsonPath().getString(messagesPrefix + ".type");
+        String actualMessageId = resp.jsonPath().getString(messagesPrefix + "." + MESSAGE_ID);
+        String actualMessage = resp.jsonPath().getString(messagesPrefix + "." + MESSAGE);
+
+        Assert.assertEquals(actualType, expected.getType(),
+                "Soft resend limit: expected message type " + expected.getType() + " but got: " + actualType);
+        Assert.assertEquals(actualMessageId, expected.getMessageId(),
+                "Soft resend limit: expected messageId " + expected.getMessageId()
+                        + " but got: " + actualMessageId);
+        Assert.assertEquals(actualMessage, "resend.count.exceeded",
+                "Soft resend limit: expected message '" + "resend.count.exceeded"
+                        + "' but got: " + actualMessage);
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPSoftResendLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/EmailOTPSoftResendLimitNativeAuthTestCase.java
@@ -53,7 +53,7 @@ import static org.wso2.identity.integration.test.applicationNativeAuthentication
  */
 public class EmailOTPSoftResendLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
 
-    private static final String APP_NAME          = "it-email-otp-soft-resend-limit";
+    private static final String APP_NAME = "it-email-otp-soft-resend-limit";
     private static final String OTP_AUTHENTICATOR = "email-otp-authenticator";
 
     private final TestUserMode userMode;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPLimitNativeAuthTestCase.java
@@ -50,7 +50,7 @@ import static org.wso2.identity.integration.test.applicationNativeAuthentication
  */
 public class SMSOTPLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
 
-    private static final String APP_NAME          = "it-sms-otp-first-factor";
+    private static final String APP_NAME = "it-sms-otp-first-factor";
     private static final String OTP_AUTHENTICATOR = "sms-otp-authenticator";
     private static final String SMS_SENDER_REQUEST_FORMAT =
             "{\"content\": {{body}}, \"to\": {{mobile}} }";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPLimitNativeAuthTestCase.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.applicationNativeAuthentication;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.OtpLimitExceededError;
+import org.wso2.identity.integration.test.base.MockSMSProvider;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.Properties;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.SMSSender;
+import org.wso2.identity.integration.test.restclients.NotificationSenderRestClient;
+
+import java.util.ArrayList;
+
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.AUTH_DATA_CODE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FAIL_INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_STATUS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.SUCCESS_COMPLETED;
+
+/**
+ * Integration tests that validate SMS-OTP retry and resend limit enforcement via
+ * adaptive-auth runtime params, using the API-based (native) authentication flow.
+ */
+public class SMSOTPLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
+
+    private static final String APP_NAME          = "it-sms-otp-first-factor";
+    private static final String OTP_AUTHENTICATOR = "sms-otp-authenticator";
+    private static final String SMS_SENDER_REQUEST_FORMAT =
+            "{\"content\": {{body}}, \"to\": {{mobile}} }";
+
+    private final TestUserMode userMode;
+    private String appId;
+    private String appConsumerKey;
+    private MockSMSProvider mockSMSProvider;
+    private NotificationSenderRestClient notificationSenderRestClient;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public SMSOTPLimitNativeAuthTestCase(TestUserMode userMode) {
+
+        this.userMode = userMode;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER},
+                {TestUserMode.TENANT_USER}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+        commonInit(userMode);
+        mockSMSProvider = new MockSMSProvider();
+        mockSMSProvider.start();
+        notificationSenderRestClient = new NotificationSenderRestClient(backendURL, tenantInfo);
+
+        // Ensure a clean state by deleting any existing SMS sender before creating a new one.
+        try {
+            notificationSenderRestClient.deleteSMSProvider();
+        } catch (Throwable ignored) {
+            // Sender not present or already deleted – nothing to clean up.
+        }
+        notificationSenderRestClient.createSMSProvider(buildSMSSender());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        try {
+            if (appId != null) {
+                deleteApp(appId);
+            }
+
+            if (notificationSenderRestClient != null) {
+                try {
+                    notificationSenderRestClient.deleteSMSProvider();
+                } catch (Throwable ignored) {
+                    // Sender was never registered or was already removed – nothing to do.
+                }
+                notificationSenderRestClient.closeHttpClient();
+            }
+
+            if (mockSMSProvider != null) {
+                mockSMSProvider.stop();
+            }
+        } finally {
+            commonTearDown();
+        }
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Register the SMS-OTP first-factor application with retry/resend "
+                  + "limit adaptive script.")
+    public void testRegisterSMSOTPApplication() throws Exception {
+
+        ApplicationResponseModel app = createOTPApp(APP_NAME, OTP_AUTHENTICATOR);
+        Assert.assertNotNull(app, "SMS-OTP app creation failed.");
+        Assert.assertTrue(
+                app.getAdvancedConfigurations().getEnableAPIBasedAuthentication(),
+                "API-based authentication must be enabled on the SMS-OTP app.");
+
+        appId = app.getId();
+        appConsumerKey = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        Assert.assertNotNull(appConsumerKey, "SMS-OTP app client-id must not be null.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – first wrong OTP submit returns HTTP 200 + FAIL_INCOMPLETE.",
+          dependsOnMethods = "testRegisterSMSOTPApplication")
+    public void testSMSOTPFirstWrongOTPReturnsFAIL_INCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, FAIL_INCOMPLETE,
+                "SMS OTP retry #1: expected FAIL_INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "SMS OTP retry #1: flowId must remain the same after a failed attempt.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – second wrong OTP submit returns HTTP 400 + ABA-60013 payload.",
+          dependsOnMethods = "testSMSOTPFirstWrongOTPReturnsFAIL_INCOMPLETE")
+    public void testSMSOTPSecondWrongOTPReturnsABA60013() {
+
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_BAD_REQUEST);
+        assertOTPLimitExceededPayload(resp, OtpLimitExceededError.RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – first OTP resend returns HTTP 200 + INCOMPLETE.",
+          dependsOnMethods = "testSMSOTPSecondWrongOTPReturnsABA60013")
+    public void testSMSOTPFirstResendReturnsINCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, INCOMPLETE,
+                "SMS OTP resend #1: expected INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "SMS OTP resend #1: flowId must remain unchanged after a resend.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – second OTP resend returns HTTP 400 + ABA-60014 payload.",
+          dependsOnMethods = "testSMSOTPFirstResendReturnsINCOMPLETE")
+    public void testSMSOTPSecondResendReturnsABA60014() {
+
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_BAD_REQUEST);
+        assertOTPLimitExceededPayload(resp, OtpLimitExceededError.RESEND_LIMIT_EXCEEDED);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – submitting the correct OTP on first attempt completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testSMSOTPSecondResendReturnsABA60014")
+    public void testSMSOTPSuccessfulAuthOnFirstAttempt() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = mockSMSProvider.getOTP();
+        Assert.assertNotNull(realOtp, "MockSMSProvider did not capture an OTP – check SMS sender config.");
+        ExtractableResponse<Response> resp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, SUCCESS_COMPLETED,
+                "SMS OTP success (1st attempt): expected SUCCESS_COMPLETED but got: " + status);
+        String authCode = resp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "SMS OTP success (1st attempt): authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "SMS OTP success (1st attempt): authData.code must not be blank.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – submitting the correct OTP after one wrong attempt "
+                  + "completes authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testSMSOTPSuccessfulAuthOnFirstAttempt")
+    public void testSMSOTPSuccessfulAuthAfterOneRetry() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = mockSMSProvider.getOTP();
+        Assert.assertNotNull(realOtp, "MockSMSProvider did not capture an OTP.");
+        ExtractableResponse<Response> failResp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        String failStatus = failResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(failStatus, FAIL_INCOMPLETE,
+                "SMS OTP retry: expected FAIL_INCOMPLETE after wrong OTP but got: " + failStatus);
+        refreshHrefAndAuthenticatorId(failResp);
+        ExtractableResponse<Response> successResp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        String successStatus = successResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(successStatus, SUCCESS_COMPLETED,
+                "SMS OTP retry: expected SUCCESS_COMPLETED after correct OTP but got: " + successStatus);
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "SMS OTP retry: authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "SMS OTP retry: authData.code must not be blank.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP – submitting the OTP received after a resend completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testSMSOTPSuccessfulAuthAfterOneRetry")
+    public void testSMSOTPSuccessfulAuthAfterResend() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        ExtractableResponse<Response> resendResp = triggerResend(HttpStatus.SC_OK);
+        String resendStatus = resendResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(resendStatus, INCOMPLETE,
+                "SMS OTP resend: expected INCOMPLETE after resend but got: " + resendStatus);
+        refreshHrefAndAuthenticatorId(resendResp);
+        String newOtp = mockSMSProvider.getOTP();
+        Assert.assertNotNull(newOtp, "MockSMSProvider did not capture an OTP after resend.");
+        ExtractableResponse<Response> successResp = submitOTPCode(newOtp, HttpStatus.SC_OK);
+        String successStatus = successResp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(successStatus, SUCCESS_COMPLETED,
+                "SMS OTP resend: expected SUCCESS_COMPLETED after submitting resent OTP but got: "
+                        + successStatus);
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "SMS OTP resend: authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "SMS OTP resend: authData.code must not be blank.");
+    }
+
+    private SMSSender buildSMSSender() {
+
+        SMSSender smsSender = new SMSSender();
+        smsSender.setProvider(MockSMSProvider.SMS_SENDER_PROVIDER_TYPE);
+        smsSender.setProviderURL(MockSMSProvider.SMS_SENDER_URL);
+        smsSender.contentType(SMSSender.ContentTypeEnum.JSON);
+        ArrayList<Properties> properties = new ArrayList<>();
+        properties.add(new Properties().key("body").value(SMS_SENDER_REQUEST_FORMAT));
+        smsSender.setProperties(properties);
+        return smsSender;
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPSoftResendLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPSoftResendLimitNativeAuthTestCase.java
@@ -49,7 +49,7 @@ import static org.wso2.identity.integration.test.applicationNativeAuthentication
  */
 public class SMSOTPSoftResendLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
 
-    private static final String APP_NAME          = "it-sms-otp-soft-resend-limit";
+    private static final String APP_NAME = "it-sms-otp-soft-resend-limit";
     private static final String OTP_AUTHENTICATOR = "sms-otp-authenticator";
     private static final String SMS_SENDER_REQUEST_FORMAT =
             "{\"content\": {{body}}, \"to\": {{mobile}} }";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPSoftResendLimitNativeAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/applicationNativeAuthentication/SMSOTPSoftResendLimitNativeAuthTestCase.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.applicationNativeAuthentication;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.OtpLimitExceededError;
+import org.wso2.identity.integration.test.base.MockSMSProvider;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.Properties;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v1.model.SMSSender;
+import org.wso2.identity.integration.test.restclients.NotificationSenderRestClient;
+
+import java.util.ArrayList;
+
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.AUTH_DATA_CODE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FAIL_INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_ID;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.FLOW_STATUS;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.INCOMPLETE;
+import static org.wso2.identity.integration.test.applicationNativeAuthentication.Constants.SUCCESS_COMPLETED;
+
+/**
+ * Integration tests for SMS-OTP where soft resend limits are enforced via adaptive auth script.
+ */
+public class SMSOTPSoftResendLimitNativeAuthTestCase extends AbstractOTPLimitNativeAuthTestCase {
+
+    private static final String APP_NAME          = "it-sms-otp-soft-resend-limit";
+    private static final String OTP_AUTHENTICATOR = "sms-otp-authenticator";
+    private static final String SMS_SENDER_REQUEST_FORMAT =
+            "{\"content\": {{body}}, \"to\": {{mobile}} }";
+
+    private final TestUserMode userMode;
+    private String appId;
+    private String appConsumerKey;
+    private MockSMSProvider mockSMSProvider;
+    private NotificationSenderRestClient notificationSenderRestClient;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public SMSOTPSoftResendLimitNativeAuthTestCase(TestUserMode userMode) {
+
+        this.userMode = userMode;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER},
+                {TestUserMode.TENANT_USER}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+        commonInit(userMode);
+        mockSMSProvider = new MockSMSProvider();
+        mockSMSProvider.start();
+        notificationSenderRestClient = new NotificationSenderRestClient(backendURL, tenantInfo);
+
+        // Ensure a clean state – delete the sender if it already exists.
+        try {
+            notificationSenderRestClient.deleteSMSProvider();
+        } catch (Throwable ignored) {
+            // Sender was never registered or was properly removed.
+        }
+        notificationSenderRestClient.createSMSProvider(buildSMSSender());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        try {
+            if (appId != null) {
+                deleteApp(appId);
+            }
+            if (notificationSenderRestClient != null) {
+                try {
+                    notificationSenderRestClient.deleteSMSProvider();
+                } catch (Throwable ignored) {
+                    // Sender was never registered or was already removed.
+                }
+                notificationSenderRestClient.closeHttpClient();
+            }
+            if (mockSMSProvider != null) {
+                mockSMSProvider.stop();
+            }
+        } finally {
+            commonTearDown();
+        }
+    }
+
+    @Test(groups = "wso2.is",
+          description = "Register the SMS-OTP application with terminateOnResendLimitExceeded=false "
+                  + "adaptive script.")
+    public void testRegisterSMSOTPSoftResendApp() throws Exception {
+
+        ApplicationResponseModel app = createOTPAppWithSoftResendLimit(APP_NAME, OTP_AUTHENTICATOR);
+        Assert.assertNotNull(app, "SMS-OTP soft-resend app creation failed.");
+        Assert.assertTrue(
+                app.getAdvancedConfigurations().getEnableAPIBasedAuthentication(),
+                "API-based authentication must be enabled on the app.");
+        appId = app.getId();
+        appConsumerKey = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        Assert.assertNotNull(appConsumerKey, "SMS-OTP soft-resend app client-id must not be null.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – first wrong OTP returns HTTP 200 + FAIL_INCOMPLETE.",
+          dependsOnMethods = "testRegisterSMSOTPSoftResendApp")
+    public void testSMSOTPSoftResendFirstWrongOTPReturnsFAIL_INCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, FAIL_INCOMPLETE,
+                "SMS OTP soft-resend retry #1: expected FAIL_INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "SMS OTP soft-resend retry #1: flowId must remain the same after a failed attempt.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – second wrong OTP returns HTTP 400 + ABA-60013.",
+          dependsOnMethods = "testSMSOTPSoftResendFirstWrongOTPReturnsFAIL_INCOMPLETE")
+    public void testSMSOTPSoftResendSecondWrongOTPReturnsABA60013() {
+
+        ExtractableResponse<Response> resp = submitOTPCode(WRONG_OTP, HttpStatus.SC_BAD_REQUEST);
+        assertOTPLimitExceededPayload(resp, OtpLimitExceededError.RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – first resend returns HTTP 200 + INCOMPLETE.",
+          dependsOnMethods = "testSMSOTPSoftResendSecondWrongOTPReturnsABA60013")
+    public void testSMSOTPSoftResendFirstResendReturnsINCOMPLETE() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, INCOMPLETE,
+                "SMS OTP soft-resend resend #1: expected INCOMPLETE but got: " + status);
+        Assert.assertEquals(resp.jsonPath().getString(FLOW_ID), flowId,
+                "SMS OTP soft-resend resend #1: flowId must remain unchanged after a resend.");
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – second resend returns HTTP 200 + FAIL_INCOMPLETE "
+                  + "with ABA-60003 in nextStep.messages.",
+          dependsOnMethods = "testSMSOTPSoftResendFirstResendReturnsINCOMPLETE")
+    public void testSMSOTPSoftResendSecondResendReturnsFAIL_INCOMPLETEWithABA60003() {
+
+        ExtractableResponse<Response> resp = triggerResend(HttpStatus.SC_OK);
+        assertSoftResendLimitExceededPayload(resp);
+        refreshHrefAndAuthenticatorId(resp);
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – correct OTP on first attempt completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testSMSOTPSoftResendSecondResendReturnsFAIL_INCOMPLETEWithABA60003")
+    public void testSMSOTPSoftResendSuccessfulAuthOnFirstAttempt() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+
+        String realOtp = mockSMSProvider.getOTP();
+        Assert.assertNotNull(realOtp, "MockSMSProvider did not capture an OTP – check SMS sender config.");
+        ExtractableResponse<Response> resp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        String status = resp.jsonPath().getString(FLOW_STATUS);
+        Assert.assertEquals(status, SUCCESS_COMPLETED,
+                "SMS OTP soft-resend success (1st attempt): expected SUCCESS_COMPLETED but got: " + status);
+        String authCode = resp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "SMS OTP soft-resend: authData.code must be present in SUCCESS_COMPLETED response.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "SMS OTP soft-resend: authData.code must not be blank.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – correct OTP after one wrong attempt completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testSMSOTPSoftResendSuccessfulAuthOnFirstAttempt")
+    public void testSMSOTPSoftResendSuccessfulAuthAfterOneRetry() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        String realOtp = mockSMSProvider.getOTP();
+        Assert.assertNotNull(realOtp, "MockSMSProvider did not capture an OTP.");
+        ExtractableResponse<Response> failResp = submitOTPCode(WRONG_OTP, HttpStatus.SC_OK);
+        Assert.assertEquals(failResp.jsonPath().getString(FLOW_STATUS), FAIL_INCOMPLETE,
+                "SMS OTP soft-resend retry: expected FAIL_INCOMPLETE after wrong OTP.");
+        refreshHrefAndAuthenticatorId(failResp);
+        ExtractableResponse<Response> successResp = submitOTPCode(realOtp, HttpStatus.SC_OK);
+        Assert.assertEquals(successResp.jsonPath().getString(FLOW_STATUS), SUCCESS_COMPLETED,
+                "SMS OTP soft-resend retry: expected SUCCESS_COMPLETED after correct OTP.");
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "SMS OTP soft-resend retry: authData.code must be present.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "SMS OTP soft-resend retry: authData.code must not be blank.");
+    }
+
+    @Test(groups = "wso2.is",
+          description = "SMS OTP (soft-resend) – correct OTP after a resend completes "
+                  + "authentication with SUCCESS_COMPLETED.",
+          dependsOnMethods = "testSMSOTPSoftResendSuccessfulAuthAfterOneRetry")
+    public void testSMSOTPSoftResendSuccessfulAuthAfterResend() throws Exception {
+
+        initiateAuthFlow(appConsumerKey);
+        ExtractableResponse<Response> resendResp = triggerResend(HttpStatus.SC_OK);
+        Assert.assertEquals(resendResp.jsonPath().getString(FLOW_STATUS), INCOMPLETE,
+                "SMS OTP soft-resend: expected INCOMPLETE after resend.");
+        refreshHrefAndAuthenticatorId(resendResp);
+        String newOtp = mockSMSProvider.getOTP();
+        Assert.assertNotNull(newOtp, "MockSMSProvider did not capture an OTP after resend.");
+        ExtractableResponse<Response> successResp = submitOTPCode(newOtp, HttpStatus.SC_OK);
+        Assert.assertEquals(successResp.jsonPath().getString(FLOW_STATUS), SUCCESS_COMPLETED,
+                "SMS OTP soft-resend: expected SUCCESS_COMPLETED after submitting resent OTP.");
+        String authCode = successResp.jsonPath().getString(AUTH_DATA_CODE);
+        Assert.assertNotNull(authCode,
+                "SMS OTP soft-resend: authData.code must be present.");
+        Assert.assertFalse(authCode.trim().isEmpty(),
+                "SMS OTP soft-resend: authData.code must not be blank.");
+    }
+
+    /**
+     * Helper method to build the SMS sender configuration for the tests.
+     */
+    private SMSSender buildSMSSender() {
+
+        SMSSender smsSender = new SMSSender();
+        smsSender.setProvider(MockSMSProvider.SMS_SENDER_PROVIDER_TYPE);
+        smsSender.setProviderURL(MockSMSProvider.SMS_SENDER_URL);
+        smsSender.contentType(SMSSender.ContentTypeEnum.JSON);
+        ArrayList<Properties> properties = new ArrayList<>();
+        properties.add(new Properties().key("body").value(SMS_SENDER_REQUEST_FORMAT));
+        smsSender.setProperties(properties);
+        return smsSender;
+    }
+}
+

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -134,7 +134,11 @@
             <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationTestCase"/>
             <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthentication2FATestCase"/>
             <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.ApplicationNativeAuthenticationDeviceFlowTestCase"/>
-            <!-- <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.CustomAuthenticatorNativeAuthenticationTestCase"/> -->
+            <!--             <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.CustomAuthenticatorNativeAuthenticationTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.EmailOTPLimitNativeAuthTestCase"/>
+            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.SMSOTPLimitNativeAuthTestCase"/>
+            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.EmailOTPSoftResendLimitNativeAuthTestCase"/>
+            <class name="org.wso2.identity.integration.test.applicationNativeAuthentication.SMSOTPSoftResendLimitNativeAuthTestCase"/>
             <class name="org.wso2.identity.integration.test.apiAuthorization.RBACWithAPIAuthorizationTestCase"/>
             <class name="org.wso2.identity.integration.test.oid4vci.OID4VCIIssuanceTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessPasswordGrantTestCase"/>


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/26743

This pull request introduces comprehensive integration tests for enforcing Email-OTP retry and resend limits in the native authentication flow, along with new constants to support these scenarios. The main focus is on validating that the authentication API responds correctly when users exceed OTP retry or resend limits, and that the flow behaves as expected on both successful and failed attempts.

New integration tests for Email-OTP limits:

* Added the `EmailOTPLimitNativeAuthTestCase` class, which covers scenarios for retry and resend limit enforcement, including correct handling of error codes, messages, and authentication flow completion.

Enhancements to constants for test clarity and coverage:

* Introduced new constants for OTP retry and resend limit error codes, messages, and descriptions to ensure tests can validate precise API responses.
* Added constants for IDF (Identifier-First) step parameters and message fields used in nextStep messages, improving test readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating Email and SMS OTP retry and resend limits (hard and soft) for native/API auth flows.
  * Introduced four end-to-end test suites covering email/sms hard and soft resend behaviors, OTP capture, and state/assertion checks.
  * Added a shared test base for common setup/teardown, flow orchestration, OTP provisioning, and error payload validation.
  * Added OTP-limit error/message enums and related constants used by tests.

* **Chores**
  * Updated test execution config to include the new OTP-limit test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->