### PR TITLE
Replace Random with SecureRandom for improved randomness in SAML2SSOTestBase

### DIFF
--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/SAML2SSOTestBase.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/SAML2SSOTestBase.java
@@ -122,11 +122,11 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.rmi.RemoteException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
@@ -183,7 +183,7 @@ public class SAML2SSOTestBase extends SSOCommonClientForSAML {
     private X509Credential defaultX509Cred;
 
     private static boolean isBootStrapped = false;
-    private static Random random = new Random();
+    private static SecureRandom random = new SecureRandom();
 
 //    public void init() throws Exception {
 //


### PR DESCRIPTION
Problem
The [createID()](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method used [java.util.Random](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which relies on a linear congruential generator (LCG). LCGs are not cryptographically secure — an attacker who observes a sufficient number of generated SAML request IDs can predict future values, enabling:

SAML request ID spoofing
Replay attacks against the SAML authentication flow
This is a violation of OWASP Top 10 — A02: Cryptographic Failures.

Changes
[SAML2SSOTestBase.java](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Replaced import java.util.Random with [import java.security.SecureRandom](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[SAML2SSOTestBase.java](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed field declaration from private static Random random = new Random() to [private static SecureRandom random = new SecureRandom()](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Impact
[SecureRandom](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is backed by OS-level entropy sources and satisfies cryptographic unpredictability requirements. The [nextBytes()](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) call site at [createID()](vscode-file://vscode-app/c:/Users/harik/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html) requires no changes — the API is identical.

No functional behaviour changes; this is a security hardening fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ID generation in SAML2SSO test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->