### PR TITLE
Bump inbound.oauth version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2691,7 +2691,7 @@
         <identity.carbon.auth.rest.version>1.12.2</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.33</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.34</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.3</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>


### PR DESCRIPTION
### Purpose
- Bump `identity.inbound.auth.oauth.version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Identity inbound OAuth dependency to the latest patch version to maintain compatibility and security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->