### PR TITLE
fix: specify UTF-8 charset in getBytes() calls on security-sensitive paths

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/ExternalLDAPServer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/ExternalLDAPServer.java
@@ -511,14 +511,14 @@ public class ExternalLDAPServer {
             String passwordToStore = "{" + algorithm.getAlgorithmName() + "}";
             if (algorithm != PasswordAlgorithm.PLAIN_TEXT) {
                 MessageDigest md = MessageDigest.getInstance(algorithm.getAlgorithmName());
-                md.update(password.getBytes());
+                md.update(password.getBytes(StandardCharsets.UTF_8));
                 byte[] bytes = md.digest();
                 String hash = Base64.encode(bytes);
                 passwordToStore = passwordToStore + hash;
             } else {
                 passwordToStore = password;
             }
-            adminEntry.put("userPassword", passwordToStore.getBytes());
+            adminEntry.put("userPassword", passwordToStore.getBytes(StandardCharsets.UTF_8));
         } catch (NoSuchAlgorithmException e) {
             throw new Exception("Could not find matching hash algorithm - " + algorithm.getAlgorithmName(), e);
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/ExternalLDAPServer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/ExternalLDAPServer.java
@@ -61,6 +61,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -193,14 +194,14 @@ public class ExternalLDAPServer {
                         throw new Exception(
                                 "Could not find digest algorithm - " + ADMIN_PASSWORD_ALGORITHM, e);
                     }
-                    messageDigest.update(password.getBytes());
+                    messageDigest.update(password.getBytes(StandardCharsets.UTF_8));
                     byte[] bytes = messageDigest.digest();
                     String hash = Base64.encode(bytes);
                     passwordToStore = passwordToStore + hash;
-                    adminPrincipal.setUserPassword(passwordToStore.getBytes());
+                    adminPrincipal.setUserPassword(passwordToStore.getBytes(StandardCharsets.UTF_8));
                     Attribute passwordAttribute = new DefaultAttribute(getAttributeType("userPassword"));
                     try {
-                        passwordAttribute.add(passwordToStore.getBytes());
+                        passwordAttribute.add(passwordToStore.getBytes(StandardCharsets.UTF_8));
                     } catch (LdapInvalidAttributeValueException e) {
                         String msg = "Adding password attribute failed .";
                         throw new Exception(msg, e);

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/SAML2SSOTestBase.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/identity/scenarios/commons/SAML2SSOTestBase.java
@@ -593,11 +593,11 @@ public class SAML2SSOTestBase extends SSOCommonClientForSAML {
                     .toByteArray(), Base64.DONT_BREAK_LINES);
             return URLEncoder.encode(encodedRequestMessage, StandardCharsets.UTF_8.name()).trim();
         } else if (SAMLConstants.SAML2_POST_BINDING_URI.equals(binding)) {
-            return Base64.encodeBytes(rspWrt.toString().getBytes(),
+            return Base64.encodeBytes(rspWrt.toString().getBytes(StandardCharsets.UTF_8),
                     Base64.DONT_BREAK_LINES);
         } else {
             log.warn("Unsupported SAML2 HTTP Binding. Defaulting to " + SAMLConstants.SAML2_POST_BINDING_URI);
-            return Base64.encodeBytes(rspWrt.toString().getBytes(), Base64.DONT_BREAK_LINES);
+            return Base64.encodeBytes(rspWrt.toString().getBytes(StandardCharsets.UTF_8), Base64.DONT_BREAK_LINES);
         }
     }
 
@@ -1064,7 +1064,7 @@ public class SAML2SSOTestBase extends SSOCommonClientForSAML {
             throws IOException, SAXException, ParserConfigurationException {
 
         DocumentBuilder docBuilder = documentBuilderFactory.newDocumentBuilder();
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(samlString.getBytes());
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(samlString.getBytes(StandardCharsets.UTF_8));
         return docBuilder.parse(inputStream);
     }
 


### PR DESCRIPTION
fix: specify UTF-8 charset in getBytes() calls on security-sensitive paths

String.getBytes() without an explicit charset uses the JVM's default platform encoding, which varies by OS and locale. This causes non-deterministic byte output in security-sensitive code paths.

In SAML2SSOTestBase.java, the redirect-binding branch already used UTF-8 explicitly, but the POST-binding and fallback branches did not. This inconsistency could produce garbled SAML assertions or signature verification failures on non-UTF-8 systems. The getDocument() helper also parsed SAML XML using platform-default bytes.

In ExternalLDAPServer.java, three getBytes() calls in the password hashing path were platform-dependent. Since MessageDigest operates on raw bytes, a charset mismatch between the system storing the hash and the system verifying it could cause authentication failures.Changes made:
SAML2SSOTestBase.java: replaced getBytes() with getBytes(StandardCharsets.UTF_8) in the POST-binding branch, fallback branch, and getDocument().
ExternalLDAPServer.java: replaced getBytes() with getBytes(StandardCharsets.UTF_8) in all three password-handling calls and added the missing import for StandardCharsets.

No behavioral change on systems already using UTF-8 as default. Fixes incorrect encoding on Windows or other non-UTF-8 locales. StandardCharsets.UTF_8 is always available per the Java spec so no new checked exceptions are introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized UTF-8 encoding for LDAP password handling to ensure correct processing and storage of credentials with non-ASCII characters.
  * Standardized UTF-8 encoding for SAML message processing (including POST and fallback binding paths) to ensure consistent, reliable handling of SAML payloads across bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->