### PR TITLE
Pack Amazon SNS Push Provider by default to the product

### DIFF
--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -581,6 +581,9 @@
                                     org.wso2.carbon.identity.notification.push:org.wso2.carbon.identity.notification.push.feature:${identity.notification.push.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
+                                    org.wso2.carbon.identity.notification.push:org.wso2.carbon.identity.notification.push.provider.amazonsns.feature:${identity.notification.push.provider.amazonsns.version}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.identity.local.auth.push:org.wso2.carbon.identity.local.auth.push.feature:${identity.local.auth.push.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
@@ -1234,6 +1237,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.notification.push.feature.group</id>
                                     <version>${identity.notification.push.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.notification.push.provider.amazonsns.feature.group</id>
+                                    <version>${identity.notification.push.provider.amazonsns.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.local.auth.push.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2006,6 +2006,16 @@
                 <version>${identity.notification.push.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.notification.push</groupId>
+                <artifactId>org.wso2.carbon.identity.notification.push.provider.amazonsns</artifactId>
+                <version>${identity.notification.push.provider.amazonsns.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.notification.push</groupId>
+                <artifactId>org.wso2.carbon.identity.notification.push.provider.amazonsns.feature</artifactId>
+                <version>${identity.notification.push.provider.amazonsns.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.local.auth.push</groupId>
                 <artifactId>org.wso2.carbon.identity.local.auth.push.authenticator</artifactId>
                 <version>${identity.local.auth.push.version}</version>
@@ -2675,6 +2685,9 @@
 
         <identity.notification.push.version>1.1.2</identity.notification.push.version>
         <identity.notification.push.version.range>[1.0.0,2.0.0)</identity.notification.push.version.range>
+
+        <identity.notification.push.provider.amazonsns.version>1.0.0</identity.notification.push.provider.amazonsns.version>
+        <identity.notification.push.provider.amazonsns.version.range>[1.0.0,2.0.0)</identity.notification.push.provider.amazonsns.version.range>
 
         <identity.local.auth.push.version>1.1.2</identity.local.auth.push.version>
         <identity.local.auth.push.version.range>[1.0.0,2.0.0)</identity.local.auth.push.version.range>


### PR DESCRIPTION
Amazon SNS Connector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Amazon SNS (Simple Notification Service) as a new push notification provider, enabling integration with Amazon's notification infrastructure.
  * Included UI templates and configuration interfaces for seamless Amazon SNS setup and notification delivery management.
  * Provides version 1.0.0 with forward compatibility planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->