### PR TITLE
Bump identity.inbound.auth.oauth version to v7.4.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2715,7 +2715,7 @@
         <identity.carbon.auth.rest.version>1.12.6</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.51</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.54</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.4</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>


### PR DESCRIPTION
$subject

Related: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3107 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth dependency version for improved security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->