### PR TITLE
Bump federated saml authenticator version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2750,7 +2750,7 @@
         <identity.outbound.auth.oidc.version>5.15.2</identity.outbound.auth.oidc.version>
         <identity.outbound.auth.oauth2.version>1.1.0</identity.outbound.auth.oauth2.version>
         <identity.outbound.auth.passive.sts.version>5.6.0</identity.outbound.auth.passive.sts.version>
-        <identity.outbound.auth.samlsso.version>5.12.5</identity.outbound.auth.samlsso.version>
+        <identity.outbound.auth.samlsso.version>5.12.6</identity.outbound.auth.samlsso.version>
         <identity.outbound.auth.requestpath.basicauth.version>5.6.0</identity.outbound.auth.requestpath.basicauth.version>
         <identity.outbound.auth.requestpath.oauth.version>5.6.0</identity.outbound.auth.requestpath.oauth.version>
 


### PR DESCRIPTION
### Purpose
> $subject

### Related PR
- https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/199

### Related Issue
- https://github.com/wso2/product-is/issues/26845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated outbound SAML SSO authenticator to version 5.12.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->