### PR TITLE
Set Conformance suite version to v5.1.39

### DIFF
--- a/.github/workflows/fapi-oidc-conformance-test.yml
+++ b/.github/workflows/fapi-oidc-conformance-test.yml
@@ -136,7 +136,7 @@ jobs:
         # TODO: Pinned to release-v5.1.39 due to tests failing in v5.1.40. Revert to latest once upstream fix is available.
         # LATEST_RELEASE_BRANCH=$(curl -s https://gitlab.com/api/v4/projects/4175605/releases/ | jq '.[]' | jq -r '.name' | head -1)
         # echo ">>> Conformance suite latest release branch: $LATEST_RELEASE_BRANCH"
-        CONFORMANCE_SUITE_BRANCH=release-v5.1.39
+        LATEST_RELEASE_BRANCH=release-v5.1.39
         echo ">>> Conformance suite pinned branch is taken: $CONFORMANCE_SUITE_BRANCH"
         PROVIDED_VERSION=${{github.event.inputs.conformance-suite-version}}
         if [[ -z "${PROVIDED_VERSION}" ]]; then

--- a/.github/workflows/oidc-conformance-test.yml
+++ b/.github/workflows/oidc-conformance-test.yml
@@ -56,7 +56,7 @@ jobs:
         # TODO: Pinned to release-v5.1.39 due to tests failing in v5.1.40. Revert to latest once upstream fix is available.
         # LATEST_RELEASE_BRANCH=$(curl -s https://gitlab.com/api/v4/projects/4175605/releases/ | jq '.[]' | jq -r '.name' | head -1)
         # echo ">>> Conformance suite latest release branch: $LATEST_RELEASE_BRANCH"
-        CONFORMANCE_SUITE_BRANCH=release-v5.1.39
+        LATEST_RELEASE_BRANCH=release-v5.1.39
         echo ">>> Conformance suite pinned branch is taken: $CONFORMANCE_SUITE_BRANCH"
         PROVIDED_VERSION=${{github.event.inputs.conformance-suite-version}}
         if [[ -z "${PROVIDED_VERSION}" ]]; then


### PR DESCRIPTION
This pull request temporarily pins the OIDC conformance suite version used in our GitHub Actions workflows to `release-v5.1.39`, due to test failures in the newer `v5.1.40` release. Comments have been added to indicate this is a temporary workaround until the upstream issue is resolved.

Workflow updates:

* Pin the conformance suite branch to `release-v5.1.39` instead of dynamically selecting the latest release in both `.github/workflows/fapi-oidc-conformance-test.yml` [[1]](diffhunk://#diff-319395c7159d19a8d7bc956fe432a1c9c563fef1204f2af85d6e2e33712b5f13L136-R140) and `.github/workflows/oidc-conformance-test.yml` [[2]](diffhunk://#diff-702aa414472d3433c8725536f872f387f4e5fcc8bad4d4b9744778253c27503dL56-R60).
* Add comments explaining the reason for the pin and noting that the change should be reverted once the upstream fix is available [[1]](diffhunk://#diff-319395c7159d19a8d7bc956fe432a1c9c563fef1204f2af85d6e2e33712b5f13L136-R140) [[2]](diffhunk://#diff-702aa414472d3433c8725536f872f387f4e5fcc8bad4d4b9744778253c27503dL56-R60).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI conformance tests now use a pinned test-suite version for consistent test runs.
  * Pipeline now explicitly reports which test-suite version is selected.
  * Existing behavior to accept a provided test-suite version remains, allowing overrides when specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->