### PR TITLE
Version bump

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/application/management/v1/oidc-metadata.json
@@ -44,7 +44,7 @@
       {
         "name": "urn:openid:params:grant-type:ciba",
         "displayName": "CIBA",
-        "publicClientAllowed": true
+        "publicClientAllowed": false
       },
       {
         "name": "account_switch",

--- a/pom.xml
+++ b/pom.xml
@@ -2685,7 +2685,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.10.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.92</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
### Purpose
- Bump framework version
- Bump inbound.oauth version
- Change the default value of the `publicClientAllowed` to fix the test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CIBA grant configuration updated to disallow public client usage, tightening authentication flows.

* **Chores**
  * Framework dependencies updated to a newer Carbon Identity release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->