### PR TITLE
Revert user input validation related test changes

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/flow/execution/v1/FlowExecutionNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/flow/execution/v1/FlowExecutionNegativeTest.java
@@ -84,15 +84,7 @@ public class FlowExecutionNegativeTest extends FlowExecutionTestBase {
         flowExecutionClient = new FlowExecutionClient(serverURL, tenantInfo);
         flowManagementClient = new FlowManagementClient(serverURL, tenantInfo);
         identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
-        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
         addRegistrationFlow(flowManagementClient);
-
-        UserObject secondaryUser = new UserObject()
-                .userName(SECONDARY_TEST_USER)
-                .password(SECONDARY_TEST_USER_PASSWORD)
-                .name(new Name().givenName("Secondary").familyName("User"))
-                .addEmail(new Email().value(SECONDARY_TEST_USER_EMAIL));
-        secondaryTestUserId = scim2RestClient.createUser(secondaryUser);
     }
 
     @AfterClass(alwaysRun = true)
@@ -100,13 +92,9 @@ public class FlowExecutionNegativeTest extends FlowExecutionTestBase {
 
         super.conclude();
         disableFlow(REGISTRATION, flowManagementClient);
-        if (secondaryTestUserId != null) {
-            scim2RestClient.deleteUser(secondaryTestUserId);
-        }
         identityGovernanceRestClient.closeHttpClient();
         flowManagementClient.closeHttpClient();
         flowExecutionClient.closeHttpClient();
-        scim2RestClient.closeHttpClient();
     }
 
     @Test
@@ -206,33 +194,6 @@ public class FlowExecutionNegativeTest extends FlowExecutionTestBase {
         Assert.assertNotNull(error);
         Assert.assertNotNull(error.getCode());
         Assert.assertEquals(error.getCode(), "FE-60008");
-    }
-
-    @Test(dependsOnMethods = "testExecuteFlowWithInvalidInputs")
-    public void testExecuteFlowWithDuplicateUsername() throws Exception {
-
-        initiateFlow();
-        Map<String, String> inputs = new HashMap<>();
-        inputs.put("http://wso2.org/claims/username", SECONDARY_TEST_USER);
-        inputs.put("password", "Wso2@Test2");
-        inputs.put("http://wso2.org/claims/emailaddress", "another.dup@example.com");
-        inputs.put("http://wso2.org/claims/givenname", "Another");
-        inputs.put("http://wso2.org/claims/lastname", "User");
-        Object responseObj = flowExecutionClient.executeFlow(getFlowExecutionRequest(flowId, inputs));
-        Assert.assertTrue(responseObj instanceof FlowExecutionResponse,
-                "Expected FlowExecutionResponse for duplicate username but got: " +
-                        (responseObj != null ? responseObj.getClass().getName() : "null"));
-        FlowExecutionResponse response = (FlowExecutionResponse) responseObj;
-        Assert.assertNotNull(response);
-        Assert.assertEquals(response.getFlowStatus(), STATUS_INCOMPLETE,
-                "Expected INCOMPLETE status when duplicate username is submitted.");
-        Assert.assertEquals(response.getType().toString(), TYPE_VIEW,
-                "Expected VIEW type when duplicate username is submitted.");
-        Assert.assertNotNull(response.getData());
-        Assert.assertNotNull(response.getData().getAdditionalData(),
-                "Expected additionalData with validation error for duplicate username.");
-        Assert.assertNotNull(response.getData().getAdditionalData().get("error"),
-                "Expected 'error' key in additionalData for duplicate username.");
     }
 
     private static FlowExecutionRequest getFlowExecutionRequest(String flowId,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionBaseTestCase.java
@@ -535,18 +535,17 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
 
     protected Object executeAdminInvitedUserRegistrationFlow() throws Exception {
 
+        Object initiationResponseObj = flowExecutionClient.initiateFlowExecution(INVITED_USER_REGISTRATION_FLOW_TYPE);
+        FlowExecutionResponse initiationResponse = (FlowExecutionResponse) initiationResponseObj;
+        String flowId = initiationResponse.getFlowId();
+
         String recoveryLink = getRecoveryURLFromEmail();
         String confirmationCode = extractConfirmationCode(recoveryLink);
 
-        FlowExecutionRequest confirmationRequest = buildConfirmationRequest(confirmationCode);
-        Object confirmationResponseObj = flowExecutionClient.executeFlow(confirmationRequest);
-        if (!(confirmationResponseObj instanceof FlowExecutionResponse)) {
-            return confirmationResponseObj;
-        }
-        FlowExecutionResponse confirmationResponse = (FlowExecutionResponse) confirmationResponseObj;
+        FlowExecutionRequest confirmationRequest = buildConfirmationRequest(flowId, confirmationCode);
+        flowExecutionClient.executeFlow(confirmationRequest);
 
-        FlowExecutionRequest passwordRequest = buildAdminInvitedUserRegistrationFlowRequest(
-                confirmationResponse.getFlowId());
+        FlowExecutionRequest passwordRequest = buildAdminInvitedUserRegistrationFlowRequest(flowId);
 
         return flowExecutionClient.executeFlow(passwordRequest);
     }
@@ -565,10 +564,11 @@ public class PreUpdatePasswordActionBaseTestCase extends ActionsBaseTestCase {
         return flowExecutionRequest;
     }
 
-    private FlowExecutionRequest buildConfirmationRequest(String confirmationCode) {
+    private FlowExecutionRequest buildConfirmationRequest(String flowId, String confirmationCode) {
 
         FlowExecutionRequest confirmationRequest = new FlowExecutionRequest();
         confirmationRequest.setFlowType(INVITED_USER_REGISTRATION_FLOW_TYPE);
+        confirmationRequest.setFlowId(flowId);
 
         Map<String, String> confirmationInputs = new HashMap<>();
         confirmationInputs.put("confirmationCode", confirmationCode);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdatepassword/PreUpdatePasswordActionSuccessTestCase.java
@@ -391,11 +391,6 @@ public class PreUpdatePasswordActionSuccessTestCase extends PreUpdatePasswordAct
         Object executionResponseObj = flowExecutionClient.executeFlow(flowExecutionRequest);
         assertTrue(executionResponseObj instanceof FlowExecutionResponse,
                 "Unexpected response type for flow execution.");
-        FlowExecutionResponse executionResponse = (FlowExecutionResponse) executionResponseObj;
-        assertEquals(executionResponse.getFlowStatus(), "COMPLETE",
-                "Expected flow status COMPLETE for user self-registration via flow execution API. " +
-                        "Got INCOMPLETE — this may indicate that user '" + TEST_USER2_USERNAME +
-                        "' already exists (leftover from a previous failed run).");
 
         assertActionRequestPayloadWithUserCreation(PreUpdatePasswordEvent.FlowInitiatorType.USER,
                 PreUpdatePasswordEvent.Action.REGISTER);


### PR DESCRIPTION
This pull request primarily removes test code related to handling a secondary test user and duplicate username scenarios in the flow execution negative tests. It also refines the admin-invited user registration flow test to ensure the correct use of `flowId` throughout the flow, and simplifies the self-registration test by removing unnecessary assertions.

**Test cleanup and simplification:**

* Removed creation and deletion of a secondary test user and the associated SCIM2 client from the `FlowExecutionNegativeTest` lifecycle methods.
* Removed the test method `testExecuteFlowWithDuplicateUsername` from `FlowExecutionNegativeTest`, eliminating duplicate username validation from this suite.

**Improvements to admin-invited user registration flow:**

* Updated `executeAdminInvitedUserRegistrationFlow` in `PreUpdatePasswordActionBaseTestCase` to consistently use the correct `flowId` throughout the flow execution steps, ensuring flow continuity.
* Modified `buildConfirmationRequest` to accept and set a `flowId`, aligning with the updated flow execution logic.

**Self-registration test simplification:**

* Removed redundant assertions about flow status from the self-registration flow execution test, streamlining the test logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed test coverage for duplicate username flow execution scenario.
  * Refactored internal flow execution test handling for password action flows.
  * Updated test flow identifier handling to ensure consistency across password reset flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->