### PR TITLE
Update Carbon Identity Framework dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2685,7 +2685,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.10.99</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.100</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request updates the Carbon Identity Framework dependency version in the `pom.xml` file.

- Dependency version update:
  * Bumped the `carbon.identity.framework.version` from `7.10.99` to `7.10.100` in `pom.xml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated identity framework dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->