### PR TITLE
Remove team/AI and team/Content labels from being considered in AI based issue classification

### DIFF
--- a/.github/workflows/add-team-label.yaml
+++ b/.github/workflows/add-team-label.yaml
@@ -44,17 +44,6 @@ jobs:
           5. Team/Identity Server Core
              Use for: email provider configuration, SMS provider configuration, deployment configuration, server performance improvements, infrastructure issues, core backend services, tenant management, web application or API performance and maintenance.
 
-          6. Team/AI
-             Use for: AI agent identity management, AI-assisted login flows, AI-based branding, AI-driven identity features, any AI capability within WSO2 Identity Server.
-
-          7. Team/Content
-             Use for: broken documentation links, incorrect grammar, generic documentation improvements, documentation maintenance IN PRODUCT DOCUMENTATION websites.
-             
-             IMPORTANT:
-             * DO NOT USE this "Team/Content" label for,
-               - broken links in web applications such as console, myaccount etc. For those, use the appropriate team label based on the affected section in the web application.
-               - documentation issues that are about documenting product features, configurations etc. For such issues, use the appropriate team label based on what needs to be documented.
-
           RULES:
           - Analyze both the issue title and description.
           - Assign only ONE label — the one that best matches the dominant topic.


### PR DESCRIPTION
## Purpose

$subject

Since the content team is a sub team of the IS core team and the features developed by the AI team are eventually owned by the respective feature area based sub teams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to refine automated label classification for team categorization in the issue and pull request management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->