### PR TITLE
Bump local sms otp authenticator version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2799,7 +2799,7 @@
         <authenticator.magiclink.version>1.2.0</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.2.0</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.1.2</authenticator.local.auth.emailotp.version>
-        <authenticator.local.auth.smsotp.version>1.1.1</authenticator.local.auth.smsotp.version>
+        <authenticator.local.auth.smsotp.version>1.1.2</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.2.0</authenticator.twitter.version>
         <authenticator.x509.version>3.2.0</authenticator.x509.version>
         <identity.extension.utils>1.3.0</identity.extension.utils>


### PR DESCRIPTION
Note $subjects

package `com.fasterxml.jackson.datatype.jsr310` orbit bundle from sms otp.

Ref: https://github.com/wso2/product-is/issues/27197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Updated SMS OTP authenticator component with the latest version improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->