### PR TITLE
Bump xalan to 2.7.3.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -892,7 +892,7 @@
                 <version>${joda.wso2.version}</version>
             </dependency>
             <dependency>
-                <groupId>xalan</groupId>
+                <groupId>org.wso2.orbit.xalan</groupId>
                 <artifactId>xalan</artifactId>
                 <version>${xalan.version}</version>
             </dependency>
@@ -2910,7 +2910,7 @@
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
         <wss4j.wso2.version>1.6.0-wso2v9</wss4j.wso2.version>
         <openws.version>1.5.4</openws.version>
-        <xalan.version>2.7.3</xalan.version>
+        <xalan.version>2.7.3.wso2v1</xalan.version>
         <xalan.wso2.version>2.7.0.wso2v1</xalan.wso2.version>
         <rampart.wso2.version>1.6.1-wso2v43</rampart.wso2.version>
         <orbit.version.commons.httpclient>4.5.13.wso2v1</orbit.version.commons.httpclient>


### PR DESCRIPTION
Note $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the XML processing library to a WSO2-aligned build and adjusted its managed version. This change ensures improved compatibility and consistency of the resolved dependency across builds, reducing potential runtime conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->