### PR TITLE
Add pre-issue access token tests for sessionDataKeyConsent

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreIssueAccessTokenEvent.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreIssueAccessTokenEvent.java
@@ -31,6 +31,7 @@ public class PreIssueAccessTokenEvent extends Event {
 
     private TokenRequest request;
     private final AccessToken accessToken;
+    private final Session session;
 
     private PreIssueAccessTokenEvent(Builder builder) {
 
@@ -40,6 +41,7 @@ public class PreIssueAccessTokenEvent extends Event {
         this.tenant = builder.tenant;
         this.user = builder.user;
         this.userStore = builder.userStore;
+        this.session = builder.session;
     }
 
     public TokenRequest getRequest() {
@@ -50,6 +52,11 @@ public class PreIssueAccessTokenEvent extends Event {
     public AccessToken getAccessToken() {
 
         return accessToken;
+    }
+
+    public Session getSession() {
+
+        return session;
     }
 
     @Override
@@ -88,8 +95,8 @@ public class PreIssueAccessTokenEvent extends Event {
         private Organization organization;
         private Tenant tenant;
         private User user;
-
         private UserStore userStore;
+        private Session session;
 
         public Builder accessToken(AccessToken accessToken) {
 
@@ -124,6 +131,12 @@ public class PreIssueAccessTokenEvent extends Event {
         public Builder userStore(UserStore userStore) {
 
             this.userStore = userStore;
+            return this;
+        }
+
+        public Builder session(Session session) {
+
+            this.session = session;
             return this;
         }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Session.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/Session.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+/**
+ * This class models the Session object sent in the request payload to the API endpoint of a pre issue access token
+ * action.
+ */
+@JsonDeserialize(builder = Session.Builder.class)
+public class Session {
+
+    private final String sessionDataKeyConsent;
+
+    private Session(Builder builder) {
+
+        this.sessionDataKeyConsent = builder.sessionDataKeyConsent;
+    }
+
+    public String getSessionDataKeyConsent() {
+
+        return sessionDataKeyConsent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Session session = (Session) o;
+        return Objects.equals(sessionDataKeyConsent, session.sessionDataKeyConsent);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(sessionDataKeyConsent);
+    }
+
+    /**
+     * Builder for the Session.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+        private String sessionDataKeyConsent;
+
+        @JsonProperty("sessionDataKeyConsent")
+        public Builder sessionDataKeyConsent(String sessionDataKeyConsent) {
+
+            this.sessionDataKeyConsent = sessionDataKeyConsent;
+            return this;
+        }
+
+        public Session build() {
+
+            return new Session(this);
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessCodeGrantTestCase.java
@@ -55,6 +55,7 @@ import org.wso2.identity.integration.test.serviceextensions.model.AllowedOperati
 import org.wso2.identity.integration.test.serviceextensions.model.Operation;
 import org.wso2.identity.integration.test.serviceextensions.model.PreIssueAccessTokenActionRequest;
 import org.wso2.identity.integration.test.serviceextensions.model.PreIssueAccessTokenEvent;
+import org.wso2.identity.integration.test.serviceextensions.model.Session;
 import org.wso2.identity.integration.test.serviceextensions.model.Tenant;
 import org.wso2.identity.integration.test.serviceextensions.model.TokenRequest;
 import org.wso2.identity.integration.test.serviceextensions.model.User;
@@ -95,6 +96,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
@@ -149,6 +151,7 @@ public class PreIssueAccessTokenActionSuccessCodeGrantTestCase extends ActionsBa
     private List<String> customScopes;
     private List<String> requestedScopes;
     private String sessionDataKey;
+    private String sessionDataKeyConsent;
     private String authorizationCode;
     private String accessToken;
     private String clientId;
@@ -308,6 +311,19 @@ public class PreIssueAccessTokenActionSuccessCodeGrantTestCase extends ActionsBa
 
         response = sendGetRequest(client, locationHeader.getValue());
         locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Redirection URL to the consent page is null.");
+        EntityUtils.consume(response.getEntity());
+
+        sessionDataKeyConsent = URLEncodedUtils.parse(URI.create(locationHeader.getValue()), StandardCharsets.UTF_8)
+                .stream()
+                .filter(param -> "sessionDataKeyConsent".equals(param.getName()))
+                .map(NameValuePair::getValue)
+                .findFirst()
+                .orElse(null);
+        assertNotNull(sessionDataKeyConsent, "sessionDataKeyConsent is null.");
+
+        response = sendApprovalPost(client, sessionDataKeyConsent);
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
         assertNotNull(locationHeader, "Redirection URL to the application with authorization code is null.");
         EntityUtils.consume(response.getEntity());
 
@@ -360,6 +376,24 @@ public class PreIssueAccessTokenActionSuccessCodeGrantTestCase extends ActionsBa
         PreIssueAccessTokenActionRequest expectedRequest = getRequest();
 
         assertEquals(actualRequest, expectedRequest);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithAuthCodeGrant",
+            description = "Verify that the pre issue access token action request contains the session " +
+                    "with a valid sessionDataKeyConsent for authorization code grant")
+    public void testPreIssueAccessTokenActionRequestContainsSession() throws Exception {
+
+        String actualRequestPayload =
+                serviceExtensionMockServer.getReceivedRequestPayload(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
+        PreIssueAccessTokenActionRequest actualRequest =
+                new ObjectMapper().readValue(actualRequestPayload, PreIssueAccessTokenActionRequest.class);
+
+        Session session = actualRequest.getEvent().getSession();
+        assertNotNull(session, "Session object should be present in the action request for authorization code grant.");
+        assertNotNull(session.getSessionDataKeyConsent(),
+                "sessionDataKeyConsent should be present in the session for authorization code grant.");
+        assertFalse(session.getSessionDataKeyConsent().isEmpty(),
+                "sessionDataKeyConsent should not be empty.");
     }
 
     @Test(groups = "wso2.is", description = "Verify that the access token contains the updated scopes " +
@@ -674,7 +708,7 @@ public class PreIssueAccessTokenActionSuccessCodeGrantTestCase extends ActionsBa
                 .grantTypes(new ArrayList<>(Collections.singleton(OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE)))
                 .tokenType(ApplicationConfig.TokenType.JWT)
                 .expiryTime(3600)
-                .skipConsent(true)
+                .skipConsent(false)
                 .build();
 
         ApplicationResponseModel application = addApplication(applicationConfig);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessCodeGrantTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessCodeGrantTestCase.java
@@ -376,17 +376,6 @@ public class PreIssueAccessTokenActionSuccessCodeGrantTestCase extends ActionsBa
         PreIssueAccessTokenActionRequest expectedRequest = getRequest();
 
         assertEquals(actualRequest, expectedRequest);
-    }
-
-    @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithAuthCodeGrant",
-            description = "Verify that the pre issue access token action request contains the session " +
-                    "with a valid sessionDataKeyConsent for authorization code grant")
-    public void testPreIssueAccessTokenActionRequestContainsSession() throws Exception {
-
-        String actualRequestPayload =
-                serviceExtensionMockServer.getReceivedRequestPayload(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
-        PreIssueAccessTokenActionRequest actualRequest =
-                new ObjectMapper().readValue(actualRequestPayload, PreIssueAccessTokenActionRequest.class);
 
         Session session = actualRequest.getEvent().getSession();
         assertNotNull(session, "Session object should be present in the action request for authorization code grant.");


### PR DESCRIPTION
Related Issue:

- https://github.com/wso2/product-is/issues/27256

Related PR:

- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3133
