### PR TITLE
Refactor saas app creation test case

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationManagementTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationManagementTestCase.java
@@ -138,13 +138,11 @@ public class ApplicationManagementTestCase extends ISIntegrationTest {
             ServiceProvider serviceProvider = applicationManagementServiceClient.getApplication
                     (applicationName);
             serviceProvider.setDescription("Updated description");
-            serviceProvider.setSaasApp(true);
             applicationManagementServiceClient.updateApplicationData(serviceProvider);
             ServiceProvider updatedServiceProvider = applicationManagementServiceClient
                     .getApplication(applicationName);
             Assert.assertEquals(updatedServiceProvider.getDescription(), "Updated description",
                     "Failed update application description");
-            Assert.assertEquals(updatedServiceProvider.getSaasApp(), true, "Set isSaasApp failed");
         } catch (Exception e) {
             Assert.fail("Error while trying to update Service Provider", e);
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationTemplateMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationTemplateMgtTestCase.java
@@ -267,7 +267,6 @@ public class ApplicationTemplateMgtTestCase extends ISIntegrationTest {
             ServiceProvider serviceProvider = new ServiceProvider();
             serviceProvider.setApplicationName(name);
             serviceProvider.setDescription(description);
-            serviceProvider.setSaasApp(true);
             applicationManagementServiceClient.createApplication(serviceProvider);
         } catch (Exception e) {
             fail("Error while trying to create Service Provider", e);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2GroupTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/scim2/rest/api/SCIM2GroupTest.java
@@ -227,7 +227,6 @@ public class SCIM2GroupTest extends SCIM2BaseTest {
         ServiceProvider serviceProviderApp = new ServiceProvider();
         serviceProviderApp.setApplicationName(APPLICATION_NAME);
         serviceProviderApp.setDescription("sample-description");
-        serviceProviderApp.setSaasApp(true);
         applicationManagementServiceClient.createApplication(serviceProviderApp);
         serviceProviderApp = applicationManagementServiceClient.getApplication(APPLICATION_NAME);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -47,6 +47,7 @@
             <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase"/>
             <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase"/>
             <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>
+            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
             <!--<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>-->
             <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
             <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
@@ -254,6 +255,7 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>
@@ -556,8 +558,6 @@
     <test name="is-tests-saas-app-creation" preserve-order="true" parallel="false" group-by-instances="true">
         <classes>
             <class name="org.wso2.identity.integration.test.application.mgt.SaasAppCreationInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to stop assuming or enforcing the SAAS flag on created applications, focusing validation on persisted application data.
  * Reorganized the TestNG suite: redistributed a couple of test cases across test groupings to better reflect default and REST API test scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->