### PR TITLE
Refactor saas app creation test case

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationManagementTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationManagementTestCase.java
@@ -138,13 +138,11 @@ public class ApplicationManagementTestCase extends ISIntegrationTest {
             ServiceProvider serviceProvider = applicationManagementServiceClient.getApplication
                     (applicationName);
             serviceProvider.setDescription("Updated description");
-            serviceProvider.setSaasApp(true);
             applicationManagementServiceClient.updateApplicationData(serviceProvider);
             ServiceProvider updatedServiceProvider = applicationManagementServiceClient
                     .getApplication(applicationName);
             Assert.assertEquals(updatedServiceProvider.getDescription(), "Updated description",
                     "Failed update application description");
-            Assert.assertEquals(updatedServiceProvider.getSaasApp(), true, "Set isSaasApp failed");
         } catch (Exception e) {
             Assert.fail("Error while trying to update Service Provider", e);
         }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationTemplateMgtTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/application/mgt/ApplicationTemplateMgtTestCase.java
@@ -267,7 +267,6 @@ public class ApplicationTemplateMgtTestCase extends ISIntegrationTest {
             ServiceProvider serviceProvider = new ServiceProvider();
             serviceProvider.setApplicationName(name);
             serviceProvider.setDescription(description);
-            serviceProvider.setSaasApp(true);
             applicationManagementServiceClient.createApplication(serviceProvider);
         } catch (Exception e) {
             fail("Error while trying to create Service Provider", e);


### PR DESCRIPTION
The SaaS app creation is disabled in the product by default.
The SaaS app enable logic in the test are not necessary as the tests are related application management operations.

There is specific integration test by enabling SaaS app creation, hence these logics are not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed SaaS configuration and related assertions from application management test cases. Updates simplify test setup for application creation scenarios without affecting production functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->