### PR TITLE
Fix integration-test-runner to support forks by dynamically selecting runner

### DIFF
--- a/.github/workflows/integration-test-runner.yml
+++ b/.github/workflows/integration-test-runner.yml
@@ -12,8 +12,7 @@ env:
 
 jobs:
   run-test-runners:
-    runs-on: 
-      - codebuild-wso2_product-is-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ${{ github.repository == 'wso2/product-is' && fromJSON(format('["codebuild-wso2_product-is-{0}-{1}"]', github.run_id, github.run_attempt)) || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,8 +112,7 @@ jobs:
   comment-and-approve:
     name: Comment the status and Approve PR
     needs: run-test-runners
-    runs-on:
-      - codebuild-wso2_product-is-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ${{ github.repository == 'wso2/product-is' && fromJSON(format('["codebuild-wso2_product-is-{0}-{1}"]', github.run_id, github.run_attempt)) || 'ubuntu-latest' }}
     if: always()
     steps:
       - name: Comment build status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to dynamically select test execution environment based on repository context, falling back to a standard runner when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->