### PR TITLE
Fix MySQL charset, MSSQL env var, and Ubuntu version in DB test runner

### DIFF
--- a/.github/workflows/integration-test-runner-mssql.yml
+++ b/.github/workflows/integration-test-runner-mssql.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ github.event.inputs.database_type == 'mssql' }}
         run: |
           docker run -d --name mssql \
-            -e SA_PASSWORD="$DB_PASSWORD" \
+            -e MSSQL_SA_PASSWORD="$DB_PASSWORD" \
             -e ACCEPT_EULA=Y \
             -e MSSQL_PID=Developer \
             -p 1433:1433 \
@@ -153,7 +153,7 @@ jobs:
         if: ${{ github.event.inputs.database_type == 'mssql' }}
         run: |
           curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
-          curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+          curl -fsSL https://packages.microsoft.com/config/ubuntu/24.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
           sudo apt-get update -y
           sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev
           echo "/opt/mssql-tools18/bin" >> $GITHUB_PATH
@@ -162,14 +162,21 @@ jobs:
         if: ${{ github.event.inputs.database_type == 'mssql' }}
         run: |
           echo "Waiting for MSSQL to be ready..."
+          MSSQL_READY=false
           for i in $(seq 1 30); do
             if sqlcmd -S localhost,1433 -U SA -P "$DB_PASSWORD" -Q "SELECT 1" -C 2>/dev/null; then
               echo "MSSQL is ready."
+              MSSQL_READY=true
               break
             fi
             echo "Attempt $i: MSSQL not ready yet, retrying in 5 seconds..."
             sleep 5
           done
+          if [ "$MSSQL_READY" != "true" ]; then
+            echo "ERROR: MSSQL did not become ready after 30 attempts."
+            docker logs mssql || true
+            exit 1
+          fi
           echo "Creating WSO2 IS databases..."
           sqlcmd -S localhost,1433 -U SA -P "$DB_PASSWORD" -Q "CREATE DATABASE [$WSO2_IDENTITY_DB]" -C
           sqlcmd -S localhost,1433 -U SA -P "$DB_PASSWORD" -Q "CREATE DATABASE [$WSO2_SHARED_DB]" -C
@@ -296,9 +303,9 @@ jobs:
             exit 1
           fi
           echo "Creating WSO2 IS databases..."
-          mysql -h 127.0.0.1 -P 3306 -u root -p"$DB_PASSWORD" -e "CREATE DATABASE \`$WSO2_IDENTITY_DB\` CHARACTER SET latin1;"
-          mysql -h 127.0.0.1 -P 3306 -u root -p"$DB_PASSWORD" -e "CREATE DATABASE \`$WSO2_SHARED_DB\` CHARACTER SET latin1;"
-          mysql -h 127.0.0.1 -P 3306 -u root -p"$DB_PASSWORD" -e "CREATE DATABASE \`$WSO2_AGENT_IDENTITY_DB\` CHARACTER SET latin1;"
+          mysql -h 127.0.0.1 -P 3306 -u root -p"$DB_PASSWORD" -e "CREATE DATABASE \`$WSO2_IDENTITY_DB\`;"
+          mysql -h 127.0.0.1 -P 3306 -u root -p"$DB_PASSWORD" -e "CREATE DATABASE \`$WSO2_SHARED_DB\`;"
+          mysql -h 127.0.0.1 -P 3306 -u root -p"$DB_PASSWORD" -e "CREATE DATABASE \`$WSO2_AGENT_IDENTITY_DB\`;"
           echo "Databases created successfully."
 
       - name: Run MySQL schema scripts


### PR DESCRIPTION
## Summary

- Remove `CHARACTER SET latin1` from MySQL database creation — MySQL 8.0 default `utf8mb4` is now used, matching the app connection charset and surfacing collation mismatches (e.g. wso2/product-is#27345)
- Replace deprecated `SA_PASSWORD` with `MSSQL_SA_PASSWORD` for SQL Server 2022
- Update mssql-tools18 apt repo from `ubuntu/22.04` to `ubuntu/24.04` to match the current `ubuntu-latest` runner, with `-fsSL` added to the curl call to catch HTTP errors

## Test plan

- [ ] Trigger workflow with `database_type=mysql` and verify collation errors surface correctly
- [ ] Trigger workflow with `database_type=mssql` and verify MSSQL starts correctly with the updated env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database initialization reliability with improved startup verification, timeout-based readiness checks, and comprehensive error diagnostics including system logs for easier troubleshooting.
  * Resolved database compatibility concerns by updating character encoding configurations in database creation processes.

* **Chores**
  * Updated CI/CD configuration and package repository references to improve system compatibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->