### PR TITLE
Add patched IS zip support to integration test runner

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -93,7 +93,7 @@ git clone https://github.com/wso2/product-is product-is-$BUILDER_NUMBER
 
 disable_tests "$ENABLED_TESTS"
 
-if [ -n "$PATCHED_IS_ZIP_URL" ]; then
+if [ "$REPO" = "product-is" ] && [ -n "$PATCHED_IS_ZIP_URL" ]; then
   echo ""
   echo "=========================================================="
   echo "Patched IS zip provided. Skipping IS build from source."
@@ -114,6 +114,15 @@ if [ -n "$PATCHED_IS_ZIP_URL" ]; then
     echo "::error::Failed to download patched IS zip from the provided URL."
     exit 1
   }
+
+  if [ -n "$PATCHED_IS_ZIP_SHA256" ]; then
+    echo "Verifying SHA256 checksum..."
+    echo "${PATCHED_IS_ZIP_SHA256}  /tmp/patched-is.zip" | sha256sum -c - || {
+      echo "::error::Patched IS zip SHA256 checksum verification failed."
+      exit 1
+    }
+    echo "Checksum verified."
+  fi
 
   echo ""
   echo "Installing patched IS zip to local Maven repository..."
@@ -141,6 +150,7 @@ if [ -n "$PATCHED_IS_ZIP_URL" ]; then
   echo "=========================================================="
   cat pom.xml
   mvn clean install -pl '!modules/distribution' --batch-mode | tee mvn-build.log
+  MAVEN_EXIT_CODE=${PIPESTATUS[0]}
 
   PR_BUILD_STATUS=$(cat mvn-build.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
   PR_TEST_RESULT=$(sed -n -e '/\[INFO\] Results:/,/\[INFO\] Tests run:/ p' mvn-build.log)
@@ -157,9 +167,7 @@ if [ -n "$PATCHED_IS_ZIP_URL" ]; then
   PR_BUILD_RESULT_LOG=$(echo $PR_BUILD_RESULT_LOG_TEMP)
   echo "::warning::$PR_BUILD_RESULT_LOG"
 
-  PR_BUILD_SUCCESS_COUNT=$(grep -o -i "\[INFO\] BUILD SUCCESS" mvn-build.log | wc -l)
-  EXPECTED_BUILD_SUCCESS_COUNT=$(get_expected_build_success_count "$ENABLED_TESTS")
-  if [ "$PR_BUILD_SUCCESS_COUNT" != "$EXPECTED_BUILD_SUCCESS_COUNT" ]; then
+  if [ "$MAVEN_EXIT_CODE" -ne 0 ]; then
     echo "PR BUILD not successfull. Aborting."
     echo "::error::PR BUILD not successfull. Check artifacts for logs."
     exit 1

--- a/.github/workflows/integration-test-runner.yml
+++ b/.github/workflows/integration-test-runner.yml
@@ -10,6 +10,10 @@ on:
         description: "Optional: Direct download URL of a pre-built patched IS zip. When provided, this zip is used instead of building IS from source."
         default:
         required: false
+      patched_is_zip_sha256:
+        description: "Optional: SHA256 checksum of the patched IS zip for integrity verification. Recommended when patched_is_zip_url is provided."
+        default:
+        required: false
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Djdk.util.zip.disableZip64ExtraFieldValidation=true -XX:+HeapDumpOnOutOfMemoryError
@@ -73,6 +77,7 @@ jobs:
           PR_LINK: ${{github.event.inputs.pr}}
           JAVA_21_HOME: ${{env.J21HOME}}
           PATCHED_IS_ZIP_URL: ${{github.event.inputs.patched_is_zip_url}}
+          PATCHED_IS_ZIP_SHA256: ${{github.event.inputs.patched_is_zip_sha256}}
         run: |
           bash .github/scripts/pr-builder.sh ${{ matrix.runner_id }} "${{ matrix.tests }}"
       - name: Archive PR diff file


### PR DESCRIPTION
## What

Adds an optional `patched_is_zip_url` input to the `integration-test-runner` workflow. When provided, the workflow downloads the IS zip from the given URL and runs the integration tests against it directly, skipping the IS build from source.

## Why

When iterating on a fix, rebuilding IS from scratch on every CI run is expensive. If a developer has already built a patched IS pack locally (or via another pipeline), they should be able to hand it directly to the test runner without waiting for a full rebuild.

## How it works

**Workflow change** — new optional input `patched_is_zip_url`:
```
Optional: Direct download URL of a pre-built patched IS zip.
When provided, this zip is used instead of building IS from source.
```

**Script change** — when `PATCHED_IS_ZIP_URL` is set, `pr-builder.sh` takes a different path:

1. Downloads the zip from the provided URL
2. Installs it to the local Maven repository as `org.wso2.is:wso2is:${VERSION}:zip`
3. Places it at `modules/distribution/target/wso2is-${VERSION}.zip`
4. Runs `mvn clean install -pl '!modules/distribution'` — builds all test infrastructure and executes integration tests, skipping the distribution module so the provided zip is not overwritten

When `patched_is_zip_url` is not provided, behavior is completely unchanged.

## Why the Maven install step is needed in CI but not locally

The workflow Maven cache explicitly excludes `~/.m2/repository/org/wso2/is/wso2is`:

```yaml
path: |
  ~/.m2
  !~/.m2/repository/org/wso2/is/wso2is
```

So the `wso2is` artifact is always absent at the start of a CI run. The `tests-backend` compile phase has an `unpack-mar-jks` execution that resolves `org.wso2.is:wso2is:zip` as a Maven artifact to extract JKS/MAR/axis2 files — without installing the patched zip to local m2 first, this step would fail.

Locally this is not an issue because a previous `mvn clean install` of product-is already put the artifact in `~/.m2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the CI/CD integration testing workflow to support using pre-built patched Identity Server distributions as an efficient alternative to building from source, enabling faster test execution and improved development efficiency.
  * Added optional SHA256 checksum verification support to ensure integrity validation of patched distributions during automated testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->