### PR TITLE
Update Github actions to support next branch strategy

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -80,7 +80,7 @@ PR_LINK=${PR_LINK%/}
 JAVA_21_HOME=${JAVA_21_HOME%/}
 echo "    PR_LINK: $PR_LINK"
 echo "    JAVA 21 Home: $JAVA_21_HOME"
-echo "    WORKFLOW_BRANCH: $WORKFLOW_BRANCH"
+echo "    WORKFLOW_BRANCH (product-is): $WORKFLOW_BRANCH"
 echo "::warning::Build ran for PR $PR_LINK"
 
 USER=$(echo $PR_LINK | awk -F'/' '{print $4}')
@@ -91,7 +91,6 @@ echo "    USER: $USER"
 echo "    REPO: $REPO"
 echo "    PULL_NUMBER: $PULL_NUMBER"
 echo "REPO_NAME=$REPO" >> "$GITHUB_OUTPUT"
-echo "WORKFLOW_BRANCH=$WORKFLOW_BRANCH" >> "$GITHUB_OUTPUT"
 echo "=========================================================="
 echo "Cloning product-is"
 echo "=========================================================="
@@ -159,7 +158,7 @@ else
   echo ""
   echo "Cloning $USER/$REPO"
   echo "=========================================================="
-  git clone --branch "$WORKFLOW_BRANCH" --single-branch https://github.com/$USER/$REPO
+  git clone https://github.com/$USER/$REPO
   echo ""
   echo "Determining dependency version property key..."
   echo "=========================================================="
@@ -196,8 +195,15 @@ else
       echo ""
       echo "Checking out for 5.5.x branch in carbon-analytics-common..."
       echo "=========================================================="
-      git checkout 5.5.x
+  else
+    if [ "$WORKFLOW_BRANCH" = "next" ]; then
+      echo ""
+      echo "Checking out for next branch..."
+      echo "=========================================================="
+      git checkout next
+    fi
   fi
+
   DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
   echo "Dependency Version: $DEPENDENCY_VERSION"
   echo ""
@@ -291,7 +297,7 @@ else
     echo ""
     echo "Building Outbound Auth OIDC repo..."
     echo "=========================================================="
-    git clone --branch "$WORKFLOW_BRANCH" --single-branch $OUTBOUND_AUTH_OIDC_REPO_CLONE_LINK
+    git clone $OUTBOUND_AUTH_OIDC_REPO_CLONE_LINK
     OUTBOUND_AUTH_OIDC_VERSION_PROPERTY=$(python version_property_finder.py $OUTBOUND_AUTH_OIDC_REPO product-is-$BUILDER_NUMBER 2>&1)
     if [ "$OUTBOUND_AUTH_OIDC_VERSION_PROPERTY" != "invalid" ]; then
       echo "Version property key for the $OUTBOUND_AUTH_OIDC_REPO is $OUTBOUND_AUTH_OIDC_VERSION_PROPERTY"
@@ -306,7 +312,6 @@ else
       exit 1
     fi
     cd $OUTBOUND_AUTH_OIDC_REPO
-    git checkout "$WORKFLOW_BRANCH"
     OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
     echo "Outbound Auth OIDC Dependency Version: $OUTBOUND_AUTH_OIDC_DEPENDENCY_VERSION"
     echo ""
@@ -347,7 +352,7 @@ else
     echo ""
     echo "Building SCIM2 repo..."
     echo "=========================================================="
-    git clone --branch "$WORKFLOW_BRANCH" --single-branch $SCIM2_REPO_CLONE_LINK
+    git clone $SCIM2_REPO_CLONE_LINK
     SCIM2_VERSION_PROPERTY=$(python version_property_finder.py $SCIM2_REPO product-is-$BUILDER_NUMBER 2>&1)
     if [ "$SCIM2_VERSION_PROPERTY" != "invalid" ]; then
       echo "Version property key for the $SCIM2_REPO is $SCIM2_VERSION_PROPERTY"
@@ -362,7 +367,6 @@ else
       exit 1
     fi
     cd $SCIM2_REPO
-    git checkout "$WORKFLOW_BRANCH"
     SCIM2_DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
     echo "SCIM2 Dependency Version: $SCIM2_DEPENDENCY_VERSION"
     echo ""

--- a/.github/workflows/dependency-updater-next.yml
+++ b/.github/workflows/dependency-updater-next.yml
@@ -5,6 +5,12 @@ on:
   schedule:
     # Everyday at 15:00 UTC (8.30 PM SL time)
     - cron:  '0 15 * * *'
+  push:
+    branches:
+      - next
+  pull_request:
+    branches:
+      - next
 
 env:
   MAVEN_OPTS: -Xmx4g -Xms1g -XX:+HeapDumpOnOutOfMemoryError
@@ -24,10 +30,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Adopt JDK 11
+        with:
+          ref: next
+      - name: Set up Adopt JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "11"
+          java-version: "21"
           distribution: "adopt"
       - name: Check $JAVA_HOME
         run: |
@@ -44,57 +52,51 @@ jobs:
             ${{ runner.os }}-maven-${{ env.cache-name }}-
             ${{ runner.os }}-maven-
             ${{ runner.os }}-
-      - name: Update Dependencies
+      - name: Clone Repository
         id: builder_step
         run: |
           echo "REPO_NAME=${{ env.REPOSITORY }}" >> "$GITHUB_OUTPUT"
-          echo ""
           echo "Starting dependency upgrade"
           echo "=========================================================="
-          echo ""
           echo "Clean up any existing files"
           echo "=========================================================="
           rm -rf ${{ env.REPOSITORY }}
-          echo ""
           echo "Cloning: https://github.com/'${{ env.PRODUCT_REPOSITORY_FORKED }}"
           echo "=========================================================="
           git clone 'https://github.com/'${{ env.PRODUCT_REPOSITORY_FORKED }}'.git'
           cd ${{ env.REPOSITORY }}
-          echo ""
           echo 'Add remote: '${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }} 'as https://github.com/'${{ env.PRODUCT_REPOSITORY_PUBLIC }}
           echo "=========================================================="
           git remote add ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }} 'https://@github.com/'${{ env.PRODUCT_REPOSITORY_PUBLIC }}
-          echo ""
-          echo 'Fetching:' ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }}
+          echo "Fetching: ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }}"
           echo "=========================================================="
           git fetch ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }}
-          echo ""
-          echo 'Checking out:' ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }} 'next branch'
+          echo "Checking out: ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }} next branch"
           echo "=========================================================="
           git checkout -b ${{ env.DEPENDENCY_UPGRADE_BRANCH_NAME }} ${{ env.REMOTE_PRODUCT_REPOSITORY_PUBLIC }}'/next'
 
-          echo ""
-          echo 'Updating dependencies'
+      - name: Update Dependencies
+        working-directory: ${{ env.REPOSITORY }}
+        run: |
+          echo "Updating dependencies"
           echo "=========================================================="
-          mvn versions:update-properties -U -DgenerateBackupPoms=false -DallowMajorUpdates=false -Dincludes=org.wso2.carbon.identity.*,org.wso2.carbon.extension.identity.*,org.wso2.identity.*,org.wso2.carbon.consent.*,org.wso2.carbon.healthcheck.*,org.wso2.carbon.utils,org.wso2.charon,org.apache.rampart.wso2,org.apache.ws.security.wso2,org.wso2.carbon.identity.framework:* -Dexcludes=org.wso2.carbon.extension.identity.authenticator.utils
-          echo ""
-          echo 'Available updates'
+          mvn versions:update-properties -U -DgenerateBackupPoms=false -DallowMajorUpdates=false -DallowMinorUpdates=false -Dincludes=org.wso2.carbon.identity.*,org.wso2.carbon.extension.identity.*,org.wso2.identity.*,org.wso2.carbon.consent.*,org.wso2.carbon.healthcheck.*,org.wso2.carbon.utils,org.wso2.charon,org.apache.rampart.wso2,org.apache.ws.security.wso2,org.wso2.carbon.identity.framework:*,org.wso2.carbon.multitenancy:*,org.wso2.carbon.registry:* -Dexcludes=org.wso2.carbon.extension.identity.authenticator.utils
+          echo "Available updates"
           echo "=========================================================="
           git diff --color > dependency_updates.diff
           cat dependency_updates.diff
 
-          echo ""
-          echo 'Build'
+      - name: Build
+        working-directory: ${{ env.REPOSITORY }}
+        run: |
+          echo "Building project"
           echo "=========================================================="
-          mvn clean install -Dmaven.test.failure.ignore=false | tee mvn-build.log
+          mvn clean install -DskipTests | tee mvn-build.log
           PR_BUILD_STATUS=$(cat mvn-build.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
-          PR_TEST_RESULT=$(sed -n -e '/\[INFO\] Results:/,/\[INFO\] Tests run:/ p' mvn-build.log)
           PR_BUILD_FINAL_RESULT=$(
             echo "==========================================================="
             echo "product-is BUILD $PR_BUILD_STATUS"
             echo "=========================================================="
-            echo ""
-            echo "$PR_TEST_RESULT"
           )
           PR_BUILD_RESULT_LOG_TEMP=$(echo "$PR_BUILD_FINAL_RESULT" | sed 's/$/%0A/')
           PR_BUILD_RESULT_LOG=$(echo $PR_BUILD_RESULT_LOG_TEMP)
@@ -106,26 +108,58 @@ jobs:
             exit 1
           fi
 
-          if [ -s dependency_updates.diff ]
-          then
+      - name: Run Integration Tests
+        working-directory: ${{ env.REPOSITORY }}
+        run: |
+          echo "Running integration tests"
+          echo "=========================================================="
+          cd modules/integration/tests-integration/tests-backend
+          mvn clean install -Dmaven.test.failure.ignore=false | tee mvn-test.log
+          PR_TEST_STATUS=$(cat mvn-test.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
+          PR_TEST_RESULT=$(sed -n -e '/\[INFO\] Results:/,/\[INFO\] Tests run:/ p' mvn-test.log)
+          PR_BUILD_FINAL_RESULT=$(
+            echo "==========================================================="
+            echo "product-is TESTS $PR_TEST_STATUS"
+            echo "=========================================================="
             echo ""
-            echo 'Commit Changes'
+            echo "$PR_TEST_RESULT"
+          )
+          PR_BUILD_RESULT_LOG_TEMP=$(echo "$PR_BUILD_FINAL_RESULT" | sed 's/$/%0A/')
+          PR_BUILD_RESULT_LOG=$(echo $PR_BUILD_RESULT_LOG_TEMP)
+          echo "::warning::$PR_BUILD_RESULT_LOG"
+          PR_TEST_SUCCESS_COUNT=$(grep -o -i "\[INFO\] BUILD SUCCESS" mvn-test.log | wc -l)
+          if [ "$PR_TEST_SUCCESS_COUNT" != "17" ]; then
+            echo "Integration tests not successfull. Aborting."
+            echo "::error::Integration tests not successfull. Check artifacts for logs."
+            exit 1
+          fi
+
+      - name: Commit and Push Changes
+        working-directory: ${{ env.REPOSITORY }}
+        run: |
+          if [ -s dependency_updates.diff ]; then
+            echo "Committing changes"
             echo "=========================================================="
             git config --global user.email ${{ env.GIT_EMAIL }}
             git config --global user.name ${{ env.GIT_USERNAME }}
             git commit -a -m 'Bump dependencies (next branch) from '${{ env.DEPENDENCY_UPGRADE_BRANCH_NAME }}
             git remote rm origin
             git remote add origin 'https://'${{ secrets.PAT }}'@github.com/'${{ env.PRODUCT_REPOSITORY_FORKED }}
-
-            echo ""
-            echo 'Push Changes'
+            echo "Pushing changes"
             echo "=========================================================="
             git push -u origin ${{ env.DEPENDENCY_UPGRADE_BRANCH_NAME }}
-
-            echo ""
-            echo 'Send Pull Request'
+          else
+            echo "There are no dependency updates available"
             echo "=========================================================="
+            exit 0
+          fi
 
+      - name: Send Pull Request
+        working-directory: ${{ env.REPOSITORY }}
+        run: |
+          if [ -s dependency_updates.diff ]; then
+            echo "Sending Pull Request"
+            echo "=========================================================="
             TITLE="[Next Branch] Bump Dependencies #"${{ env.BUILD_NUMBER }}
             RESPONSE=$(curl -s -w "%{http_code}" -k -X \
             POST https://api.github.com/repos/${{ env.PRODUCT_REPOSITORY_PUBLIC }}/pulls \
@@ -137,11 +171,6 @@ jobs:
             if [[ $STATUS == "201" ]]; then
               echo "PR=$(echo $RESPONSE_BODY | jq -r '.html_url')" >> $GITHUB_ENV
             fi
-          else
-            echo ""
-            echo "There are no dependency updates available"
-            echo "=========================================================="
-            exit 0
           fi
       - name: Archive dependency diff file
         if: always()
@@ -157,6 +186,14 @@ jobs:
           name: mvn-build.log
           path: |
             ${{steps.builder_step.outputs.REPO_NAME}}/mvn-build.log
+          if-no-files-found: warn
+      - name: Archive maven-test-log file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvn-test.log
+          path: |
+            ${{steps.builder_step.outputs.REPO_NAME}}/modules/integration/tests-integration/tests-backend/mvn-test.log
           if-no-files-found: warn
       - name: Archive heap dump
         if: always()


### PR DESCRIPTION
This PR updates .github/scripts/pr-builder.sh to:

-  Use the workflow-selected branch (e.g., next) for product-is-related operations (cloning product-is and downloading helper scripts from product-is).
-  Use the PR base branch (the branch the PR targets) when applying the PR diff and building dependency repositories, so builds are performed against the correct target branch.


1) Product-is related operations use the workflow branch
-   Introduced WORKFLOW_BRANCH, derived from:
WORKFLOW_BRANCH env var (preferred), else
GITHUB_REF_NAME, else
defaults to master
-   wso2/product-is is cloned using WORKFLOW_BRANCH (instead of default branch).
-   version_property_finder.py is downloaded from wso2/product-is/$WORKFLOW_BRANCH/... (instead of hardcoded master).

2) Dependency repo builds use PR base branch (from GitHub API)
-   Added get_pr_base_branch() which queries the GitHub API to resolve the PR’s base branch (base.ref) using GITHUB_TOKEN.
-   For dependency PRs (i.e., PRs not in product-is), the script checks out and builds against the PR base branch.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow: smarter branch selection, targeted repository checkout, updated Java runtime, refined dependency update behavior, and conditional commit/PR creation when changes exist.
* **Tests**
  * Added a dedicated integration test step with test result archival and stricter success validation; main build now skips unit tests to isolate integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->