### PR TITLE
Update Github action scripts

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -4,6 +4,11 @@ OUTBOUND_AUTH_OIDC_REPO_CLONE_LINK=https://github.com/wso2-extensions/identity-o
 SCIM2_REPO=identity-inbound-provisioning-scim2
 SCIM2_REPO_CLONE_LINK=https://github.com/wso2-extensions/identity-inbound-provisioning-scim2.git
 
+# Define workflow branch (selected branch for the workflow run).
+# Prefer WORKFLOW_BRANCH (explicit), otherwise GITHUB_REF_NAME, otherwise "master".
+WORKFLOW_BRANCH=${WORKFLOW_BRANCH:-${GITHUB_REF_NAME:-master}}
+WORKFLOW_BRANCH=${WORKFLOW_BRANCH#refs/heads/}
+
 # Define all available tests.
 declare -a ALL_TESTS=(
     "is-tests-default-configuration"
@@ -28,6 +33,24 @@ declare -a ALL_TESTS=(
     "is-test-session-mgt"
     "is-tests-password-update-api"
 )
+
+# Get PR base branch using GitHub API.
+# Requires GITHUB_TOKEN to be set in workflow env.
+get_pr_base_branch() {
+  local user=$1
+  local repo=$2
+  local pr_number=$3
+
+  if [ -z "${GITHUB_TOKEN}" ]; then
+    echo "::error::GITHUB_TOKEN is not set. Cannot determine PR base branch."
+    exit 1
+  fi
+
+  curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" \
+       -H "Accept: application/vnd.github+json" \
+       "https://api.github.com/repos/$user/$repo/pulls/$pr_number" | \
+    python -c "import sys,json; print(json.load(sys.stdin)['base']['ref'])"
+}
 
 # Function to disable tests not in the enabled list.
 disable_tests() {
@@ -65,29 +88,6 @@ get_expected_build_success_count() {
     fi
 }
 
-# Function to fetch PR base branch.
-get_pr_base_branch() {
-  local user=$1
-  local repo=$2
-  local pull_number=$3
-  local pr_api_url="https://api.github.com/repos/$user/$repo/pulls/$pull_number"
-  local auth_header=()
-
-  if [ -n "$GITHUB_TOKEN" ]; then
-    auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
-  fi
-
-  local pr_metadata
-  pr_metadata=$(curl -sSL "${auth_header[@]}" -H "Accept: application/vnd.github+json" "$pr_api_url")
-
-  echo "$pr_metadata" | python -c 'import sys, json
-try:
-  data = json.load(sys.stdin)
-  print(data.get("base", {}).get("ref", ""))
-except Exception:
-  print("")'
-}
-
 # Main execution starts here.
 BUILDER_NUMBER=$1
 ENABLED_TESTS=$2
@@ -98,33 +98,25 @@ PR_LINK=${PR_LINK%/}
 JAVA_21_HOME=${JAVA_21_HOME%/}
 echo "    PR_LINK: $PR_LINK"
 echo "    JAVA 21 Home: $JAVA_21_HOME"
+echo "    WORKFLOW_BRANCH (product-is): $WORKFLOW_BRANCH"
 echo "::warning::Build ran for PR $PR_LINK"
 
 USER=$(echo $PR_LINK | awk -F'/' '{print $4}')
 REPO=$(echo $PR_LINK | awk -F'/' '{print $5}')
 PULL_NUMBER=$(echo $PR_LINK | awk -F'/' '{print $7}')
-PR_BASE_BRANCH=$(get_pr_base_branch "$USER" "$REPO" "$PULL_NUMBER")
+BASE_BRANCH=$(get_pr_base_branch "$USER" "$REPO" "$PULL_NUMBER")
 
 echo "    USER: $USER"
 echo "    REPO: $REPO"
 echo "    PULL_NUMBER: $PULL_NUMBER"
-if [ -n "$PR_BASE_BRANCH" ]; then
-    echo "    PR_BASE_BRANCH: $PR_BASE_BRANCH"
-else
-    echo "    PR_BASE_BRANCH: <not-resolved>"
-fi
+echo "    BASE_BRANCH: $BASE_BRANCH"
 echo "REPO_NAME=$REPO" >> "$GITHUB_OUTPUT"
+echo "BASE_BRANCH=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 echo "=========================================================="
 echo "Cloning product-is"
 echo "=========================================================="
 
-if [ -n "$PR_BASE_BRANCH" ]; then
-  echo "Cloning product-is from PR base branch: $PR_BASE_BRANCH"
-  git clone --branch "$PR_BASE_BRANCH" --single-branch https://github.com/wso2/product-is product-is-$BUILDER_NUMBER
-else
-  echo "Unable to resolve PR base branch. Cloning product-is default branch."
-  git clone https://github.com/wso2/product-is product-is-$BUILDER_NUMBER
-fi
+git clone --branch "$WORKFLOW_BRANCH" --single-branch https://github.com/wso2/product-is product-is-$BUILDER_NUMBER
 
 disable_tests "$ENABLED_TESTS"
 
@@ -191,7 +183,7 @@ else
   echo ""
   echo "Determining dependency version property key..."
   echo "=========================================================="
-  wget https://raw.githubusercontent.com/wso2/product-is/next/.github/scripts/version_property_finder.py
+  wget https://raw.githubusercontent.com/wso2/product-is/$WORKFLOW_BRANCH/.github/scripts/version_property_finder.py
   VERSION_PROPERTY=$(python version_property_finder.py $REPO product-is-$BUILDER_NUMBER 2>&1)
   VERSION_PROPERTY_KEY=""
   if [ "$VERSION_PROPERTY" != "invalid" ]; then
@@ -224,7 +216,11 @@ else
       echo ""
       echo "Checking out for 5.5.x branch in carbon-analytics-common..."
       echo "=========================================================="
-      git checkout 5.5.x
+  else
+    echo ""
+    echo "Checking out for PR base branch $BASE_BRANCH..."
+    echo "=========================================================="
+    git checkout "$BASE_BRANCH"
   fi
   DEPENDENCY_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
   echo "Dependency Version: $DEPENDENCY_VERSION"


### PR DESCRIPTION
This PR updates .github/scripts/pr-builder.sh to:

-  Use the workflow-selected branch (e.g., next) for product-is-related operations (cloning product-is and downloading helper scripts from product-is).
-  Use the PR base branch (the branch the PR targets) when applying the PR diff and building dependency repositories, so builds are performed against the correct target branch.


1) Product-is related operations use the workflow branch
-   Introduced WORKFLOW_BRANCH, derived from:
WORKFLOW_BRANCH env var (preferred), else
GITHUB_REF_NAME, else
defaults to master
-   wso2/product-is is cloned using WORKFLOW_BRANCH (instead of default branch).
-   version_property_finder.py is downloaded from wso2/product-is/$WORKFLOW_BRANCH/... (instead of hardcoded master).

2) Dependency repo builds use PR base branch (from GitHub API)
-   Added get_pr_base_branch() which queries the GitHub API to resolve the PR’s base branch (base.ref) using GITHUB_TOKEN.
-   For dependency PRs (i.e., PRs not in product-is), the script checks out and builds against the PR base branch.