### PR TITLE
Fix MySQL collation error in EmailTemplatesNegativeTest by updating template type to use ASCII characters.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v1/EmailTemplatesNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v1/EmailTemplatesNegativeTest.java
@@ -40,7 +40,7 @@ import java.util.Map;
  */
 public class EmailTemplatesNegativeTest extends EmailTemplatesTestBase {
 
-    private static final String INCORRECT_TEMPLATE_TYPE_ID = "QWNjb3VudEVuYWJsZQqwSa";
+    private static final String INCORRECT_TEMPLATE_TYPE_ID = "Tm9uRXhpc3RlbnRUeXBl";
     private static final String UNDECODABLE_TEMPLATE_TYPE_ID = "QWNjb3VudEVuYWJsZQ111";
     private static final String INCORRECT_TEMPLATE_ID = "en_FR";
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v2/EmailTemplatesNegativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/email/template/v2/EmailTemplatesNegativeTest.java
@@ -39,7 +39,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
  */
 public class EmailTemplatesNegativeTest extends EmailTemplatesTestBase {
 
-    private static final String INCORRECT_TEMPLATE_TYPE_ID = "QWNjb3VudEVuYWJsZQqwSa";
+    private static final String INCORRECT_TEMPLATE_TYPE_ID = "Tm9uRXhpc3RlbnRUeXBl";
     private static final String UNDECODABLE_TEMPLATE_TYPE_ID = "QWNjb3VudEVuYWJsZQ111";
     private static final String INVALID_APPLICATION_UUID = "invalid-uuid";
     private static final String INCORRECT_TEMPLATE_ID = "en_FR";


### PR DESCRIPTION
### Purpose

Replace unicode-containing template type ID with an ASCII-only value in testGetEmailTemplateTypeWithIncorrectTemplateTypeId to avoid latin1/utf8mb4 collation mismatch on MySQL 8.x. Unicode characters are not supported in email template type names by design.

| | Value | Decoded |
|---|---|---|
| ❌ Previous | `QWNjb3VudEVuYWJsZQqwSa` | `AccountEnable\n�I` |
| ✅ New | `Tm9uRXhpc3RlbnRUeXBl` | `NonExistentType` (pure ASCII) |

Refer https://github.com/wso2/product-is/issues/27345#issuecomment-4172413219 for more details.

### Related Issue

- https://github.com/wso2/product-is/issues/27345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated email template API test parameters to enhance validation of error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->