### PR TITLE
ci: implement concurrency controls for the sync-prs-to-next workflow

### DIFF
--- a/.github/workflows/sync-prs-to-next.yml
+++ b/.github/workflows/sync-prs-to-next.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: sync-prs-to-next-${{ github.event.workflow_run.id || github.event.inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -28,6 +32,7 @@ env:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: >
       github.repository == 'wso2/product-is' &&
       (


### PR DESCRIPTION
Add workflow-level concurrency to `sync-prs-to-next` to prevent overlapping runs. In-progress runs are canceled when a newer run starts for the same PR/workflow context, reducing duplicate sync attempts and contention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved sync workflow reliability with dynamic concurrency control that automatically cancels redundant background processes and prevents extended execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->