### PR TITLE
Restore test classes to original blocks and remove SaaS app creation test group

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -13,7 +13,6 @@ WORKFLOW_BRANCH=${WORKFLOW_BRANCH#refs/heads/}
 declare -a ALL_TESTS=(
     "is-tests-default-configuration"
     "is-test-rest-api"
-    "is-tests-saas-app-creation"
     "is-test-webhooks"
     "is-tests-scim2"
     "is-test-adaptive-authentication"

--- a/.github/workflows/integration-test-runner.yml
+++ b/.github/workflows/integration-test-runner.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - runner_id: 1
-            tests: "is-tests-default-configuration,is-test-rest-api,is-tests-saas-app-creation,is-test-webhooks,is-tests-scim2,is-test-adaptive-authentication"
+            tests: "is-tests-default-configuration,is-test-rest-api,is-test-webhooks,is-tests-scim2,is-test-adaptive-authentication"
           - runner_id: 2
             tests: "is-test-adaptive-authentication-nashorn,is-test-adaptive-authentication-nashorn-with-restart,is-tests-default-configuration-ldap,is-tests-uuid-user-store,is-tests-federation,is-tests-federation-restart"
           - runner_id: 3

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -47,6 +47,7 @@
             <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase"/>
             <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase"/>
             <class name="org.wso2.identity.integration.test.application.mgt.ImportExportServiceProviderTest"/>
+            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
             <!--<class name="org.wso2.identity.integration.test.application.mgt.DefaultAuthSeqManagementTestCase"/>-->
             <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
             <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
@@ -254,6 +255,7 @@
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthFailureTest"/>
@@ -553,11 +555,4 @@
         </classes>
     </test>
 
-    <test name="is-tests-saas-app-creation" preserve-order="true" parallel="false" group-by-instances="true">
-        <classes>
-            <class name="org.wso2.identity.integration.test.application.mgt.SaasAppCreationInitializerTestCase"/>
-            <class name="org.wso2.identity.integration.test.application.mgt.ApplicationTemplateMgtTestCase"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
-        </classes>
-    </test>
 </suite>


### PR DESCRIPTION
- $Subject 
- With https://github.com/wso2/product-is/pull/27321, we have removed the SaaS App creation. Hence a separate test block with altered deployment.toml is not required. 
- Related PR : https://github.com/wso2/product-is/pull/27284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test configuration and removed a dedicated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->