### PR TITLE
Update carbon.registry.version to 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2849,7 +2849,7 @@
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.14.1</carbon.deployment.version>
         <carbon.commons.version>4.14.4</carbon.commons.version>
-        <carbon.registry.version>4.9.6</carbon.registry.version>
+        <carbon.registry.version>4.10.0</carbon.registry.version>
         <carbon.multitenancy.version>4.14.2</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.analytics-common.version>5.5.2</carbon.analytics-common.version>


### PR DESCRIPTION
Closes #27402

## Summary
- Bumps `carbon.registry.version` from `4.9.6` to `4.10.0` in `pom.xml`

## Test plan
- [ ] Build passes with updated dependency version