### PR TITLE
Update Carbon Identity Framework and OAuth versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2685,7 +2685,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.10.133</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.134</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2715,7 +2715,7 @@
         <identity.carbon.auth.rest.version>1.12.6</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.85</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.86</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.4</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven dependencies: Carbon Identity Framework to version 7.10.134 and Identity Inbound Auth OAuth to version 7.4.86.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->