### PR TITLE
Add workflow cleanup steps before workflow creation

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/workflow/v1/WorkflowBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/workflow/v1/WorkflowBaseTest.java
@@ -19,7 +19,9 @@
 package org.wso2.identity.integration.test.rest.api.server.workflow.v1;
 
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -27,6 +29,8 @@ import org.testng.annotations.BeforeMethod;
 import org.wso2.identity.integration.test.rest.api.server.common.RESTAPIServerTestBase;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base test class for workflow management REST APIs.
@@ -68,5 +72,37 @@ public class WorkflowBaseTest extends RESTAPIServerTestBase {
     public void testFinish() {
 
         RestAssured.basePath = StringUtils.EMPTY;
+    }
+
+    /**
+     * Deletes any workflow associations and workflows matching the given name.
+     * Used at test setup to handle dirty state left by previous failed runs.
+     */
+    protected void cleanupWorkflowByName(String name) {
+
+        RestAssured.basePath = basePath;
+        Response assocResp = getResponseOfGet(WORKFLOW_ASSOCIATION_API_BASE_PATH);
+        if (assocResp.getStatusCode() == HttpStatus.SC_OK) {
+            List<Map<String, Object>> assocs = assocResp.jsonPath().getList("workflowAssociations");
+            if (assocs != null) {
+                for (Map<String, Object> assoc : assocs) {
+                    if (name.equals(assoc.get("workflowName"))) {
+                        getResponseOfDelete(
+                                WORKFLOW_ASSOCIATION_API_BASE_PATH + PATH_SEPARATOR + assoc.get("id"));
+                    }
+                }
+            }
+        }
+        Response workflowsResp = getResponseOfGet(WORKFLOW_API_BASE_PATH);
+        if (workflowsResp.getStatusCode() == HttpStatus.SC_OK) {
+            List<Map<String, Object>> workflows = workflowsResp.jsonPath().getList("workflows");
+            if (workflows != null) {
+                for (Map<String, Object> workflow : workflows) {
+                    if (name.equals(workflow.get("name"))) {
+                        getResponseOfDelete(WORKFLOW_API_BASE_PATH + PATH_SEPARATOR + workflow.get("id"));
+                    }
+                }
+            }
+        }
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/workflow/v1/WorkflowRulesTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/workflow/v1/WorkflowRulesTest.java
@@ -93,6 +93,7 @@ public class WorkflowRulesTest extends WorkflowBaseTest {
         super.testInit(API_VERSION, swaggerDefinition, tenant);
         RestAssured.basePath = basePath;
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        cleanupWorkflowByName("User Approval Workflow");
 
         // Create the workflow.
         String body = readResource("add-workflow.json");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/workflow/v1/WorkflowSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/workflow/v1/WorkflowSuccessTest.java
@@ -82,6 +82,7 @@ public class WorkflowSuccessTest extends WorkflowBaseTest {
     public void init() throws IOException {
 
         super.testInit(API_VERSION, swaggerDefinition, tenant);
+        cleanupWorkflowByName("User Approval Workflow");
         // Prepare SCIM2 client for user operations used in approval flow test.
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
     }
@@ -89,6 +90,12 @@ public class WorkflowSuccessTest extends WorkflowBaseTest {
     @AfterClass(alwaysRun = true)
     public void cleanup() throws Exception {
 
+        if (workflowAssociationId != null) {
+            getResponseOfDelete(WORKFLOW_ASSOCIATION_API_BASE_PATH + PATH_SEPARATOR + workflowAssociationId);
+        }
+        if (workflowId != null) {
+            getResponseOfDelete(WORKFLOW_API_BASE_PATH + PATH_SEPARATOR + workflowId);
+        }
         if (createdRoleId != null) {
             scim2RestClient.deleteV2Role(createdRoleId);
         }


### PR DESCRIPTION
This pull request improves the reliability and cleanliness of workflow-related integration tests by ensuring that any pre-existing workflows or associations with the same name are removed before tests run. This prevents test failures due to leftover state from previous runs. The main changes are as follows:

**Test environment cleanup improvements:**

* Added a new `cleanupWorkflowByName(String name)` helper method to `WorkflowBaseTest.java` that deletes any workflow associations and workflows matching a given name, to ensure a clean state before tests.
* Updated the `init()` methods in both `WorkflowRulesTest.java` and `WorkflowSuccessTest.java` to call `cleanupWorkflowByName("User Approval Workflow")` before creating new workflows, preventing conflicts from previous test runs. [[1]](diffhunk://#diff-67ec7127d98800513922b1eb695f65277f6933f9e002581f6ead71b62479ada5R96) [[2]](diffhunk://#diff-d3932d72cb3ff8ff65cc175484bfe7532925dbd92ff17d6c9bd33db18582998eR85-R98)

**Test resource cleanup:**

* Enhanced the `cleanup()` method in `WorkflowSuccessTest.java` to explicitly delete created workflow associations and workflows after tests complete, further ensuring no residual data is left behind.

**Dependency updates:**

* Added necessary imports in `WorkflowBaseTest.java` for REST-assured `Response`, `HttpStatus`, and collection types to support the new cleanup logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced workflow test suite with improved cleanup mechanisms to ensure proper test isolation
  * Added pre-test cleanup steps to prevent state pollution from previous test runs
  * Strengthened teardown procedures for workflow-related resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->