### PR TITLE
Bump registry version to 4.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2849,7 +2849,7 @@
         <!-- Carbon Repo Versions -->
         <carbon.deployment.version>4.14.1</carbon.deployment.version>
         <carbon.commons.version>4.14.4</carbon.commons.version>
-        <carbon.registry.version>4.10.1</carbon.registry.version>
+        <carbon.registry.version>4.10.2</carbon.registry.version>
         <carbon.multitenancy.version>4.14.2</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <carbon.analytics-common.version>5.5.3</carbon.analytics-common.version>


### PR DESCRIPTION
### Purpose

Bump registry version to 4.10.2

- Related Issue: https://github.com/wso2/product-is/issues/27457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->