### PR TITLE
Bump framework and saml versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2684,7 +2684,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.138</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.139</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <identity.notification.push.version>1.1.5</identity.notification.push.version>
@@ -2714,7 +2714,7 @@
 
         <!-- Identity Inbound Versions   -->
         <identity.inbound.auth.oauth.version>7.4.90</identity.inbound.auth.oauth.version>
-        <identity.inbound.auth.saml.version>5.12.4</identity.inbound.auth.saml.version>
+        <identity.inbound.auth.saml.version>5.12.5</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.0</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>
         <identity.inbound.provisioning.scim.version>5.8.1</identity.inbound.provisioning.scim.version>


### PR DESCRIPTION
### Purpose
> $subject

### Related Issue
- https://github.com/wso2/product-is/issues/27489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Carbon Identity Framework to version 7.10.139
  * Updated Identity Inbound Auth SAML to version 5.12.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->