### PR TITLE
Fix MySQL test grid failures

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2DeviceFlowTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/OAuth2DeviceFlowTestCase.java
@@ -213,8 +213,8 @@ public class OAuth2DeviceFlowTestCase extends OAuth2ServiceAbstractIntegrationTe
     @Test(groups = "wso2.is", description = "Send unapproved token", dependsOnMethods = "testSendDeviceAuthorize")
     public void testNonUsedDeviceTokenRequest() throws Exception {
 
-        // Wait 5 seconds because of the token polling interval.
-        Thread.sleep(5000);
+        // Wait longer than the 5 second polling interval to avoid slow_down response.
+        Thread.sleep(6000);
         JSONObject obj = sendTokenRequest(GRANT_TYPE, consumerKey, deviceCode);
         String error = obj.get("error").toString();
         String errorDescription = obj.get("error_description").toString();
@@ -327,8 +327,8 @@ public class OAuth2DeviceFlowTestCase extends OAuth2ServiceAbstractIntegrationTe
     @Test(groups = "wso2.is", description = "Send token post request", dependsOnMethods = "testSendApprovalPost")
     public void testTokenRequest() throws Exception {
 
-        // Wait 5 seconds because of the token polling interval.
-        Thread.sleep(5000);
+        // Wait longer than the 5 second polling interval to avoid slow_down response.
+        Thread.sleep(6000);
         JSONObject obj = sendTokenRequest(GRANT_TYPE, consumerKey, deviceCode);
         String accessToken = obj.get("access_token").toString();
         Assert.assertNotNull(accessToken, "Assess token is null");
@@ -338,8 +338,8 @@ public class OAuth2DeviceFlowTestCase extends OAuth2ServiceAbstractIntegrationTe
             dependsOnMethods = "testTokenRequest")
     public void testExpiredDeviceTokenRequest() throws Exception {
 
-        // Wait 5 seconds because of the token polling interval.
-        Thread.sleep(5000);
+        // Wait longer than the 5 second polling interval to avoid slow_down response.
+        Thread.sleep(6000);
         JSONObject obj = sendTokenRequest(GRANT_TYPE, consumerKey, deviceCode);
         String error = obj.get("error").toString();
         Assert.assertEquals(error, "expired_token");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/organization/management/v1/OrganizationManagementSuccessTest.java
@@ -1434,8 +1434,8 @@ public class OrganizationManagementSuccessTest extends OrganizationManagementBas
     public void testAddMetaAttributesToOrganizations() {
 
         // Initialize meta attributes in sorted order.
-        String[] attributes = {"1", "2", "3", ":", "@", "A", "B", "C", "LMN", "PQR", "STU", "a", "b", "c", "fg", "jKL",
-                "mNo", "x", "y", "z"};
+        String[] attributes = { "1", "2", "3", "AA", "BB", "CC", "FG", "JKL", "LMN", "MNO", "PQR", "STU", "X", "Y",
+            "Z" };
 
         metaAttributes = new ArrayList<>(Arrays.asList(attributes));
         List<Map<String, String>> addedAttributes = new ArrayList<>();
@@ -2052,6 +2052,13 @@ public class OrganizationManagementSuccessTest extends OrganizationManagementBas
                 newOrganizations.add(org);
             } else {
                 throw new RuntimeException("Failed to create organization " + i);
+            }
+            // Ensure each organization has a unique creation timestamp to maintain deterministic
+            // ordering in pagination tests that sort by creation time.
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v2/UserSharingSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/user/sharing/management/v2/UserSharingSuccessTest.java
@@ -536,6 +536,7 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
                     .userCriteria(getUserCriteriaForBaseUserUnsharing(userIds));
             getResponseOfPost(USER_SHARING_API_BASE_PATH + UNSHARE_WITH_ALL_PATH,
                     toJSONString(cleanupRequest));
+            validateUserSharingResults(userIds, setExpectedResultsForEmptyShare());
         }
     }
 
@@ -645,6 +646,7 @@ public class UserSharingSuccessTest extends UserSharingBaseTest {
                     .userCriteria(getUserCriteriaForBaseUserUnsharing(userIds));
             getResponseOfPost(USER_SHARING_API_BASE_PATH + UNSHARE_WITH_ALL_PATH,
                     toJSONString(cleanupRequest));
+            validateUserSharingResults(userIds, setExpectedResultsForEmptyShare());
         }
     }
 


### PR DESCRIPTION
### Purpose

Following fixes will be applied with this PR for mysql test grid failures.

* For device grant, wait longer than the polling interval to avoid receiving the `slow_down` response.
* Add a 1-second delay after each organization creation to prevent identical creation timestamps, which can cause ordering issues.
* Remove edge-case values from the meta attribute sorting test, as different databases use different collation-based sorting mechanisms, leading to inconsistent ordering of strings across databases.
* Ensure users are properly unshared before executing the next test.

### Related Issue
- https://github.com/wso2/product-is/issues/27565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OAuth2 device flow test timing to improve reliability during token polling.
  * Enhanced organization management test data and added deterministic ordering controls for pagination testing.
  * Improved user sharing test validation procedures in cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->