### PR TITLE
Add integration tests for shared user direct login to sub-organizations

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserLegacyOrgAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserLegacyOrgAuthenticationTestCase.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.oauth2;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationSharePOSTRequest;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UserSharingRestClient;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.CALLBACK_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
+
+/**
+ * Integration test for legacy organization authentication with shared users.
+ * <p>
+ * This test verifies the following flow:
+ * 1. Create an application in the root org with enhanced org authentication disabled.
+ * 2. Create a sub-organization and share the application to it.
+ * 3. Create a user in the root organization and share the user to the sub-organization.
+ * 4. Login via the shared application by initiating the authorize request from the root organization,
+ * discovering the sub-organization via OrganizationAuthenticator, and authenticating at the sub-organization.
+ * 5. Verify the token is received and the sub claim contains the root organization user ID.
+ */
+public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    private static final String APP_NAME = "SharedUserLegacyOrgAuthApp";
+    private static final String MGT_APP_AUTHORIZED_API_RESOURCES = "management-app-authorized-apis.json";
+    private static final String ROOT_USER_USERNAME = "user";
+    private static final String ROOT_USER_PASSWORD = "SharedUser@wso2";
+    private static final String ROOT_USER_EMAIL = "sharedlegacyuser@wso2.com";
+
+    private final TestUserMode userMode;
+    private final String organizationName;
+    private final String organizationHandle;
+
+    private CloseableHttpClient client;
+    private SCIM2RestClient scim2RestClient;
+    private OrgMgtRestClient orgMgtRestClient;
+    private OAuth2RestClient oAuth2RestClient;
+    private UserSharingRestClient userSharingRestClient;
+
+    private String organizationId;
+    private String rootUserId;
+    private String rootApplicationId;
+    private String sharedAppId;
+    private String clientId;
+    private String clientSecret;
+    private String switchedM2MToken;
+    private String sessionDataKey;
+    private String subOrgSessionDataKey;
+    private String authorizationCode;
+
+    @DataProvider(name = "configProvider")
+    public static Object[][] configProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN, "legacy_shared_sub_org", "legacy_shared_sub_org"},
+                {TestUserMode.TENANT_ADMIN, "legacy_shared_t_sub_org", "legacy_shared_t_sub_org"}};
+    }
+
+    @Factory(dataProvider = "configProvider")
+    public SharedUserLegacyOrgAuthenticationTestCase(TestUserMode userMode, String orgName, String orgHandle) {
+
+        this.userMode = userMode;
+        this.organizationName = orgName;
+        this.organizationHandle = orgHandle;
+    }
+
+    @Test(priority = 1)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+        client = createHttpClient();
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+        userSharingRestClient = new UserSharingRestClient(serverURL, tenantInfo);
+        orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
+                new JSONObject(RESTTestBase.readResource(MGT_APP_AUTHORIZED_API_RESOURCES, this.getClass())));
+    }
+
+    @Test(priority = 2, dependsOnMethods = "testInit")
+    public void testCreateApplicationWithLegacyOrgAuth() throws Exception {
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.addGrantTypesItem(OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
+        oidcConfig.addCallbackURLsItem(CALLBACK_URL);
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+
+        ApplicationModel app = new ApplicationModel()
+                .name(APP_NAME)
+                .enhancedOrgAuthenticationEnabled(false)
+                .inboundProtocolConfiguration(inboundProtocols)
+                .advancedConfigurations(new AdvancedApplicationConfiguration()
+                        .skipLoginConsent(true)
+                        .skipLogoutConsent(true));
+
+        rootApplicationId = oAuth2RestClient.createApplication(app);
+        assertNotNull(rootApplicationId, "Root application ID should not be null.");
+
+        OpenIDConnectConfiguration createdOidcConfig = oAuth2RestClient.getOIDCInboundDetails(rootApplicationId);
+        assertNotNull(createdOidcConfig, "OIDC configuration should not be null.");
+        clientId = createdOidcConfig.getClientId();
+        clientSecret = createdOidcConfig.getClientSecret();
+        assertNotNull(clientId, "Client ID should not be null.");
+        assertNotNull(clientSecret, "Client secret should not be null.");
+    }
+
+    @Test(priority = 3, dependsOnMethods = "testCreateApplicationWithLegacyOrgAuth")
+    public void testCreateSubOrganization() throws Exception {
+
+        String m2mToken = orgMgtRestClient.getM2MAccessToken();
+        organizationId = orgMgtRestClient.addOrganizationWithToken(organizationName, organizationHandle, m2mToken);
+        assertNotNull(organizationId, "Organization ID should not be null.");
+    }
+
+    @Test(priority = 4, dependsOnMethods = "testCreateSubOrganization")
+    public void testShareApplicationToSubOrg() throws Exception {
+
+        ApplicationSharePOSTRequest shareRequest = new ApplicationSharePOSTRequest();
+        shareRequest.setShareWithAllChildren(true);
+        oAuth2RestClient.shareApplication(rootApplicationId, shareRequest);
+
+        switchedM2MToken = orgMgtRestClient.switchM2MToken(organizationId);
+        assertNotNull(switchedM2MToken, "Switched M2M token should not be null.");
+
+        waitForApplicationSharedToSubOrg(APP_NAME, switchedM2MToken, 10000);
+
+        sharedAppId = oAuth2RestClient.getAppIdUsingAppNameInOrganization(APP_NAME, switchedM2MToken);
+        assertNotNull(sharedAppId, "Shared application ID in sub-organization should not be null.");
+    }
+
+    @Test(priority = 5, dependsOnMethods = "testShareApplicationToSubOrg")
+    public void testUpdateSharedAppAuthenticationSequence() {
+
+        AuthenticationSequence authSequence = new AuthenticationSequence()
+                .type(AuthenticationSequence.TypeEnum.USER_DEFINED)
+                .addStepsItem(new AuthenticationStep()
+                        .id(1)
+                        .addOptionsItem(new Authenticator()
+                                .idp("LOCAL")
+                                .authenticator("SharedUserIdentifierExecutor")))
+                .addStepsItem(new AuthenticationStep()
+                        .id(2)
+                        .addOptionsItem(new Authenticator()
+                                .idp("LOCAL")
+                                .authenticator("BasicAuthenticator")));
+
+        ApplicationPatchModel patchModel = new ApplicationPatchModel();
+        patchModel.setAuthenticationSequence(authSequence);
+
+        oAuth2RestClient.updateSubOrgApplication(sharedAppId, patchModel, switchedM2MToken);
+    }
+
+    @Test(priority = 6, dependsOnMethods = "testUpdateSharedAppAuthenticationSequence")
+    public void testCreateRootOrgUser() throws Exception {
+
+        UserObject rootUser = new UserObject();
+        rootUser.setUserName(ROOT_USER_USERNAME);
+        rootUser.setPassword(ROOT_USER_PASSWORD);
+        rootUser.addEmail(new Email().value(ROOT_USER_EMAIL));
+
+        rootUserId = scim2RestClient.createUser(rootUser);
+        assertNotNull(rootUserId, "Root organization user ID should not be null.");
+    }
+
+    @Test(priority = 7, dependsOnMethods = "testCreateRootOrgUser")
+    public void testShareUserToSubOrg() throws Exception {
+
+        UserShareWithAllRequestBody shareRequest = new UserShareWithAllRequestBody();
+        shareRequest.setUserCriteria(new UserShareRequestBodyUserCriteria().addUserIdsItem(rootUserId));
+        shareRequest.setPolicy(ALL_EXISTING_ORGS_ONLY);
+        userSharingRestClient.shareUsersWithAll(shareRequest);
+
+        String userSearchReq = new JSONObject()
+                .put("schemas", new JSONArray().put("urn:ietf:params:scim:api:messages:2.0:SearchRequest"))
+                .put("attributes", new JSONArray().put("id"))
+                .put("filter", "userName eq " + ROOT_USER_USERNAME)
+                .toString();
+
+        boolean isUserShared = scim2RestClient.isSharedUserCreationCompleted(userSearchReq, switchedM2MToken);
+        assertTrue(isUserShared, "User should be shared to the sub-organization.");
+    }
+
+    @Test(priority = 8, dependsOnMethods = "testShareUserToSubOrg")
+    public void testSendAuthorizeRequestFromRootOrg() throws Exception {
+
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("response_type", "code"));
+        params.add(new BasicNameValuePair("client_id", clientId));
+        params.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+        params.add(new BasicNameValuePair("scope", "openid"));
+        params.add(new BasicNameValuePair(OAuth2Constant.FIDP_PARAM, "OrganizationSSO"));
+
+        HttpResponse response = sendPostRequestWithParameters(client, params,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Location header expected for authorize request is not available.");
+        EntityUtils.consume(response.getEntity());
+
+        sessionDataKey = DataExtractUtil.getParamFromURIString(locationHeader.getValue(), "sessionDataKey");
+        assertNotNull(sessionDataKey, "Session data key should not be null.");
+    }
+
+    @Test(priority = 9, dependsOnMethods = "testSendAuthorizeRequestFromRootOrg")
+    public void testDiscoverSubOrganization() throws Exception {
+
+        List<NameValuePair> orgSwitchParams = new ArrayList<>();
+        orgSwitchParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+        orgSwitchParams.add(new BasicNameValuePair("org", organizationName));
+        orgSwitchParams.add(new BasicNameValuePair("idp", "SSO"));
+        orgSwitchParams.add(new BasicNameValuePair("authenticator", "OrganizationAuthenticator"));
+
+        HttpResponse response = sendPostRequestWithParameters(client, orgSwitchParams,
+                getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain()));
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Organization switch response location header is null.");
+        EntityUtils.consume(response.getEntity());
+
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org authorize redirect location header is null.");
+        EntityUtils.consume(response.getEntity());
+
+        subOrgSessionDataKey = DataExtractUtil.getParamFromURIString(locationHeader.getValue(), "sessionDataKey");
+        assertNotNull(subOrgSessionDataKey, "Sub-org session data key should not be null.");
+    }
+
+    @Test(priority = 10, dependsOnMethods = "testDiscoverSubOrganization")
+    public void testAuthenticateAtSubOrganization() throws Exception {
+
+        String subOrgCommonAuthUrl = getTenantQualifiedURL(
+                serverURL + "o/" + organizationId + "/commonauth", tenantInfo.getDomain());
+
+        List<NameValuePair> sidfLoginParams = new ArrayList<>();
+        sidfLoginParams.add(new BasicNameValuePair("sessionDataKey", subOrgSessionDataKey));
+        sidfLoginParams.add(new BasicNameValuePair("username", ROOT_USER_USERNAME));
+
+        HttpResponse response = sendPostRequestWithParameters(client, sidfLoginParams, subOrgCommonAuthUrl);
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org shared user identifier response location header is null.");
+        EntityUtils.consume(response.getEntity());
+
+        List<NameValuePair> loginParams = new ArrayList<>();
+        loginParams.add(new BasicNameValuePair("sessionDataKey", subOrgSessionDataKey));
+        loginParams.add(new BasicNameValuePair("username", ROOT_USER_USERNAME));
+        loginParams.add(new BasicNameValuePair("password", ROOT_USER_PASSWORD));
+
+        response = sendPostRequestWithParameters(client, loginParams, subOrgCommonAuthUrl);
+
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org basic auth response location header is null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Follow redirect hops: sub-org authorize -> root commonauth -> root authorize -> callback.
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org authorized response redirect is null.");
+        EntityUtils.consume(response.getEntity());
+
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Root org commonauth redirect is null.");
+        EntityUtils.consume(response.getEntity());
+
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Root org authorize redirect to callback is null.");
+        EntityUtils.consume(response.getEntity());
+
+        authorizationCode = DataExtractUtil.getParamFromURIString(locationHeader.getValue(), "code");
+        assertNotNull(authorizationCode, "Authorization code should not be null.");
+    }
+
+    @Test(priority = 11, dependsOnMethods = "testAuthenticateAtSubOrganization")
+    public void testGetAccessTokenAndVerifySubClaim() throws Exception {
+
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("code", authorizationCode));
+        params.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        params.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader("Authorization", "Basic " + getBase64EncodedString(clientId, clientSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(client, headers, params,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+        assertNotNull(response, "Token endpoint response should not be null.");
+
+        String responseBody = EntityUtils.toString(response.getEntity(), "UTF-8");
+        org.json.JSONObject jsonResponse = new org.json.JSONObject(responseBody);
+
+        assertTrue(jsonResponse.has("access_token"), "access_token is missing from token response.");
+        String accessToken = jsonResponse.getString("access_token");
+        assertNotNull(accessToken, "Access token should not be null.");
+
+        assertTrue(jsonResponse.has("id_token"), "id_token is missing from token response.");
+        String idToken = jsonResponse.getString("id_token");
+        assertNotNull(idToken, "ID token should not be null.");
+
+        // Verify the sub claim in the ID token contains the root organization user ID.
+        SignedJWT signedJWT = SignedJWT.parse(idToken);
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+        assertNotNull(claimsSet, "JWT claims set should not be null.");
+
+        String subClaim = claimsSet.getSubject();
+        assertNotNull(subClaim, "Sub claim should not be null.");
+        Assert.assertEquals(subClaim, rootUserId,
+                "Sub claim should contain the user ID of the user created in the root organization.");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupTest() {
+
+        if (organizationId != null && orgMgtRestClient != null) {
+            try {
+                orgMgtRestClient.deleteOrganization(organizationId);
+            } catch (Exception e) {
+                log.error("Failed to delete organization: " + organizationId, e);
+            }
+        }
+        if (rootApplicationId != null && oAuth2RestClient != null) {
+            try {
+                oAuth2RestClient.deleteApplication(rootApplicationId);
+            } catch (Exception e) {
+                log.error("Failed to delete application: " + rootApplicationId, e);
+            }
+        }
+        if (rootUserId != null && scim2RestClient != null) {
+            try {
+                scim2RestClient.deleteUser(rootUserId);
+            } catch (Exception e) {
+                log.error("Failed to delete root org user: " + rootUserId, e);
+            }
+        }
+        if (client != null) {
+            try {
+                client.close();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (scim2RestClient != null) {
+            try {
+                scim2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close SCIM2 REST client.", e);
+            }
+        }
+        if (oAuth2RestClient != null) {
+            try {
+                oAuth2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close OAuth2 REST client.", e);
+            }
+        }
+        if (orgMgtRestClient != null) {
+            try {
+                orgMgtRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close org management REST client.", e);
+            }
+        }
+        if (userSharingRestClient != null) {
+            try {
+                userSharingRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close user sharing REST client.", e);
+            }
+        }
+    }
+
+    private void waitForApplicationSharedToSubOrg(String appName, String subOrgToken, long timeoutMs)
+            throws Exception {
+
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        long pollInterval = 500;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                String newSharedAppId = oAuth2RestClient.getAppIdUsingAppNameInOrganization(appName, subOrgToken);
+                if (newSharedAppId != null && !newSharedAppId.isEmpty()) {
+                    return;
+                }
+            } catch (IOException e) {
+                log.debug("Transient error while polling for shared application '" + appName + "', retrying.", e);
+            }
+            Thread.sleep(pollInterval);
+            pollInterval = Math.min(pollInterval * 2, 5000);
+        }
+        Assert.fail("Application '" + appName + "' was not shared to sub-organization within " + timeoutMs + " ms.");
+    }
+
+    private CloseableHttpClient createHttpClient() {
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build())
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+
+                        return false;
+                    }
+                })
+                .build();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserLegacyOrgAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserLegacyOrgAuthenticationTestCase.java
@@ -58,6 +58,9 @@ import org.wso2.identity.integration.test.rest.api.server.user.sharing.managemen
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
+import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
@@ -95,6 +98,9 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
     private static final String ROOT_USER_USERNAME = "user";
     private static final String ROOT_USER_PASSWORD = "SharedUser@wso2";
     private static final String ROOT_USER_EMAIL = "sharedlegacyuser@wso2.com";
+    private static final String ACCOUNT_MGT_CATEGORY_ID = "QWNjb3VudCBNYW5hZ2VtZW50";
+    private static final String MULTI_ATTRIBUTE_CONNECTOR_ID = "bXVsdGlhdHRyaWJ1dGUubG9naW4uaGFuZGxlcg";
+    private static final String MULTI_ATTRIBUTE_ENABLE_PROPERTY = "account.multiattributelogin.handler.enable";
 
     private final TestUserMode userMode;
     private final String organizationName;
@@ -105,6 +111,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
     private OrgMgtRestClient orgMgtRestClient;
     private OAuth2RestClient oAuth2RestClient;
     private UserSharingRestClient userSharingRestClient;
+    private IdentityGovernanceRestClient identityGovernanceRestClient;
 
     private String organizationId;
     private String rootUserId;
@@ -143,9 +150,23 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         userSharingRestClient = new UserSharingRestClient(serverURL, tenantInfo);
         orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
                 new JSONObject(RESTTestBase.readResource(MGT_APP_AUTHORIZED_API_RESOURCES, this.getClass())));
+        identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
     }
 
     @Test(priority = 2, dependsOnMethods = "testInit")
+    public void testDisableMultiAttributeLogin() throws Exception {
+
+        ConnectorsPatchReq connectorPatchReq = new ConnectorsPatchReq();
+        connectorPatchReq.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
+        PropertyReq enableProperty = new PropertyReq();
+        enableProperty.setName(MULTI_ATTRIBUTE_ENABLE_PROPERTY);
+        enableProperty.setValue("false");
+        connectorPatchReq.addProperties(enableProperty);
+        identityGovernanceRestClient.updateConnectors(ACCOUNT_MGT_CATEGORY_ID, MULTI_ATTRIBUTE_CONNECTOR_ID,
+                connectorPatchReq);
+    }
+
+    @Test(priority = 3, dependsOnMethods = "testDisableMultiAttributeLogin")
     public void testCreateApplicationWithLegacyOrgAuth() throws Exception {
 
         OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
@@ -174,7 +195,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(clientSecret, "Client secret should not be null.");
     }
 
-    @Test(priority = 3, dependsOnMethods = "testCreateApplicationWithLegacyOrgAuth")
+    @Test(priority = 4, dependsOnMethods = "testCreateApplicationWithLegacyOrgAuth")
     public void testCreateSubOrganization() throws Exception {
 
         String m2mToken = orgMgtRestClient.getM2MAccessToken();
@@ -182,7 +203,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(organizationId, "Organization ID should not be null.");
     }
 
-    @Test(priority = 4, dependsOnMethods = "testCreateSubOrganization")
+    @Test(priority = 5, dependsOnMethods = "testCreateSubOrganization")
     public void testShareApplicationToSubOrg() throws Exception {
 
         ApplicationSharePOSTRequest shareRequest = new ApplicationSharePOSTRequest();
@@ -198,7 +219,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(sharedAppId, "Shared application ID in sub-organization should not be null.");
     }
 
-    @Test(priority = 5, dependsOnMethods = "testShareApplicationToSubOrg")
+    @Test(priority = 6, dependsOnMethods = "testShareApplicationToSubOrg")
     public void testUpdateSharedAppAuthenticationSequence() {
 
         AuthenticationSequence authSequence = new AuthenticationSequence()
@@ -220,7 +241,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         oAuth2RestClient.updateSubOrgApplication(sharedAppId, patchModel, switchedM2MToken);
     }
 
-    @Test(priority = 6, dependsOnMethods = "testUpdateSharedAppAuthenticationSequence")
+    @Test(priority = 7, dependsOnMethods = "testUpdateSharedAppAuthenticationSequence")
     public void testCreateRootOrgUser() throws Exception {
 
         UserObject rootUser = new UserObject();
@@ -232,7 +253,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(rootUserId, "Root organization user ID should not be null.");
     }
 
-    @Test(priority = 7, dependsOnMethods = "testCreateRootOrgUser")
+    @Test(priority = 8, dependsOnMethods = "testCreateRootOrgUser")
     public void testShareUserToSubOrg() throws Exception {
 
         UserShareWithAllRequestBody shareRequest = new UserShareWithAllRequestBody();
@@ -250,7 +271,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertTrue(isUserShared, "User should be shared to the sub-organization.");
     }
 
-    @Test(priority = 8, dependsOnMethods = "testShareUserToSubOrg")
+    @Test(priority = 9, dependsOnMethods = "testShareUserToSubOrg")
     public void testSendAuthorizeRequestFromRootOrg() throws Exception {
 
         List<NameValuePair> params = new ArrayList<>();
@@ -271,7 +292,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(sessionDataKey, "Session data key should not be null.");
     }
 
-    @Test(priority = 9, dependsOnMethods = "testSendAuthorizeRequestFromRootOrg")
+    @Test(priority = 10, dependsOnMethods = "testSendAuthorizeRequestFromRootOrg")
     public void testDiscoverSubOrganization() throws Exception {
 
         List<NameValuePair> orgSwitchParams = new ArrayList<>();
@@ -296,7 +317,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(subOrgSessionDataKey, "Sub-org session data key should not be null.");
     }
 
-    @Test(priority = 10, dependsOnMethods = "testDiscoverSubOrganization")
+    @Test(priority = 11, dependsOnMethods = "testDiscoverSubOrganization")
     public void testAuthenticateAtSubOrganization() throws Exception {
 
         String subOrgCommonAuthUrl = getTenantQualifiedURL(
@@ -343,7 +364,7 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
         assertNotNull(authorizationCode, "Authorization code should not be null.");
     }
 
-    @Test(priority = 11, dependsOnMethods = "testAuthenticateAtSubOrganization")
+    @Test(priority = 12, dependsOnMethods = "testAuthenticateAtSubOrganization")
     public void testGetAccessTokenAndVerifySubClaim() throws Exception {
 
         List<NameValuePair> params = new ArrayList<>();
@@ -385,6 +406,13 @@ public class SharedUserLegacyOrgAuthenticationTestCase extends OAuth2ServiceAbst
     @AfterClass(alwaysRun = true)
     public void cleanupTest() {
 
+        if (identityGovernanceRestClient != null) {
+            try {
+                identityGovernanceRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close identity governance REST client.", e);
+            }
+        }
         if (organizationId != null && orgMgtRestClient != null) {
             try {
                 orgMgtRestClient.deleteOrganization(organizationId);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserSubOrgAppFederatedAssociationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserSubOrgAppFederatedAssociationTestCase.java
@@ -1,0 +1,675 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.oauth2;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.application.mgt.AbstractIdentityFederationTestCase;
+import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.SubjectConfig;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest.FederatedAuthenticator;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.IdentityProviderPOSTRequest;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Property;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UserSharingRestClient;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+import org.wso2.identity.integration.test.utils.IdentityConstants;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.CALLBACK_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
+
+/**
+ * Integration test for sub-organization application authentication with shared users via federated login.
+ * <p>
+ * This test uses two IS instances (primary IS at port offset 0 and secondary IS at port offset 1) and verifies:
+ * 1. Create a sub-organization on the primary IS.
+ * 2. Create an application on the secondary IS (representing the external IdP's relying party).
+ * 3. Create an application directly in the sub-organization on the primary IS and enable use linked local account
+ * property.
+ * 4. Create a federated OIDC IdP in the sub-organization pointing to the secondary IS.
+ * 5. Update the sub-org application's authentication sequence to use the federated IdP.
+ * 6. Create a user in the root organization and share the user to the sub-organization.
+ * 7. Create a user on the secondary IS (the federated user).
+ * 8. Use the user association API to create an association between the shared user in the sub-org
+ * and the federated IdP (with the secondary IS user's ID as the federated user ID).
+ * 9. Authenticate to the sub-organization application via federated login through the secondary IS.
+ * 10. Verify the token is received and the sub claim contains the root organization user ID.
+ */
+public class SharedUserSubOrgAppFederatedAssociationTestCase extends AbstractIdentityFederationTestCase {
+
+    private static final String SUPER_TENANT = "carbon.super";
+    private static final String TENANT_PATH = "t/";
+    private static final String ORGANIZATION_PATH = "/o/";
+    public static final String OAUTH_2_AUTHORIZE = "/oauth2/authorize";
+    public static final String OAUTH_2_TOKEN = "/oauth2/token";
+    private static final String SUB_ORG_APP_NAME = "SharedUserFedAssocApp";
+    private static final String SECONDARY_IS_APP_NAME = "ExternalIdPRelayApp";
+    private static final String FEDERATED_IDP_NAME = "ExternalOIDCIdP";
+    private static final String MGT_APP_AUTHORIZED_API_RESOURCES = "shared-user-federation-authorized-apis.json";
+    private static final String ASSOCIATION_MGT_API_RESOURCE_NAME = "Association Management API";
+    private static final String API_RESOURCE_ORG_TYPE = "ORGANIZATION";
+    private static final List<String> ASSOCIATION_MGT_API_SCOPES = new ArrayList<String>() {{
+        add("internal_org_user_association_create");
+        add("internal_org_user_association_view");
+        add("internal_org_user_association_delete");
+    }};
+    private static final String ROOT_USER_USERNAME = "fedAssocUser";
+    private static final String ROOT_USER_PASSWORD = "FedAssocUser@wso2";
+    private static final String ROOT_USER_EMAIL = "fedassocuser@wso2.com";
+    private static final String SECONDARY_IS_USER_USERNAME = "externalFedUser";
+    private static final String SECONDARY_IS_USER_PASSWORD = "ExternalFed@wso2";
+
+    private static final int PORT_OFFSET_0 = 0;
+    private static final int PORT_OFFSET_1 = 1;
+
+    // Base64URL encoding of "OpenIDConnectAuthenticator".
+    private static final String OIDC_AUTHENTICATOR_ID = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
+    private static final String OIDC_AUTHENTICATOR_NAME = "OpenIDConnectAuthenticator";
+
+    private static final String PRIMARY_IS_CALLBACK_URL = "https://localhost:9853/commonauth";
+    private static final String SECONDARY_IS_AUTHORIZE_ENDPOINT = "https://localhost:9854/oauth2/authorize";
+    private static final String SECONDARY_IS_TOKEN_ENDPOINT = "https://localhost:9854/oauth2/token";
+    private static final String SECONDARY_IS_LOGOUT_ENDPOINT = "https://localhost:9854/oidc/logout";
+    private static final String SECONDARY_IS_COMMONAUTH_URL = "https://localhost:9854/commonauth";
+
+    private static final String HTTPS_LOCALHOST_SERVICES = "https://localhost:%s/";
+
+    private CloseableHttpClient client;
+    private SCIM2RestClient primaryISSCIM2RestClient;
+    private SCIM2RestClient secondaryISSCIM2RestClient;
+    private OAuth2RestClient primaryISOAuth2RestClient;
+    private OrgMgtRestClient orgMgtRestClient;
+    private UserSharingRestClient userSharingRestClient;
+
+    private String organizationId;
+    private String switchedM2MToken;
+    private String rootUserId;
+    private String secondaryISUserId;
+    private String secondaryISAppId;
+    private String secondaryISClientId;
+    private String secondaryISClientSecret;
+    private String subOrgAppId;
+    private String subOrgClientId;
+    private String subOrgClientSecret;
+    private String sharedUserIdInSubOrg;
+    private String authorizationCode;
+
+    @DataProvider(name = "configProvider")
+    public static Object[][] configProvider() {
+
+        return new Object[][]{{TestUserMode.SUPER_TENANT_ADMIN}};
+    }
+
+    @Factory(dataProvider = "configProvider")
+    public SharedUserSubOrgAppFederatedAssociationTestCase(TestUserMode userMode) throws Exception {
+
+    }
+
+    @Test(priority = 1)
+    public void testInit() throws Exception {
+
+        super.initTest();
+
+        createServiceClients(PORT_OFFSET_0, new IdentityConstants.ServiceClientType[]{
+                IdentityConstants.ServiceClientType.APPLICATION_MANAGEMENT,
+                IdentityConstants.ServiceClientType.IDENTITY_PROVIDER_MGT});
+        createServiceClients(PORT_OFFSET_1, new IdentityConstants.ServiceClientType[]{
+                IdentityConstants.ServiceClientType.APPLICATION_MANAGEMENT});
+
+        client = createHttpClient();
+        primaryISSCIM2RestClient = new SCIM2RestClient(getPrimaryISURI(), tenantInfo);
+        secondaryISSCIM2RestClient = new SCIM2RestClient(getSecondaryISURI(), tenantInfo);
+        primaryISOAuth2RestClient = new OAuth2RestClient(getPrimaryISURI(), tenantInfo);
+        userSharingRestClient = new UserSharingRestClient(getPrimaryISURI(), tenantInfo);
+        orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, getPrimaryISURI(),
+                new JSONObject(RESTTestBase.readResource(MGT_APP_AUTHORIZED_API_RESOURCES, this.getClass())));
+        orgMgtRestClient.authorizeAPIForB2BApp(ASSOCIATION_MGT_API_RESOURCE_NAME, API_RESOURCE_ORG_TYPE,
+                ASSOCIATION_MGT_API_SCOPES);
+    }
+
+    @Test(priority = 2, dependsOnMethods = "testInit")
+    public void testCreateSubOrganization() throws Exception {
+
+        String m2mToken = orgMgtRestClient.getM2MAccessToken();
+        organizationId = orgMgtRestClient.addOrganizationWithToken(
+                "fed_assoc_sub_org", "fed_assoc_sub_org", m2mToken);
+        assertNotNull(organizationId, "Organization ID should not be null.");
+
+        switchedM2MToken = orgMgtRestClient.switchM2MToken(organizationId);
+        assertNotNull(switchedM2MToken, "Switched M2M token should not be null.");
+    }
+
+    @Test(priority = 3, dependsOnMethods = "testCreateSubOrganization")
+    public void testCreateApplicationInSecondaryIS() throws Exception {
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(new ArrayList<>(Collections.singletonList(OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE)));
+        oidcConfig.addCallbackURLsItem(PRIMARY_IS_CALLBACK_URL);
+
+        ApplicationModel app = new ApplicationModel()
+                .name(SECONDARY_IS_APP_NAME)
+                .inboundProtocolConfiguration(new InboundProtocols().oidc(oidcConfig))
+                .advancedConfigurations(new AdvancedApplicationConfiguration()
+                        .skipLoginConsent(true)
+                        .skipLogoutConsent(true));
+
+        secondaryISAppId = addApplication(PORT_OFFSET_1, app);
+        assertNotNull(secondaryISAppId, "Secondary IS application ID should not be null.");
+
+        OpenIDConnectConfiguration createdOidcConfig = getOIDCInboundDetailsOfApplication(PORT_OFFSET_1,
+                secondaryISAppId);
+        assertNotNull(createdOidcConfig, "Secondary IS OIDC configuration should not be null.");
+        secondaryISClientId = createdOidcConfig.getClientId();
+        secondaryISClientSecret = createdOidcConfig.getClientSecret();
+        assertNotNull(secondaryISClientId, "Secondary IS client ID should not be null.");
+        assertNotNull(secondaryISClientSecret, "Secondary IS client secret should not be null.");
+    }
+
+    @Test(priority = 4, dependsOnMethods = "testCreateApplicationInSecondaryIS")
+    public void testCreateApplicationInSubOrg() throws Exception {
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.addGrantTypesItem(OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
+        oidcConfig.addCallbackURLsItem(CALLBACK_URL);
+
+        ApplicationModel app = new ApplicationModel()
+                .name(SUB_ORG_APP_NAME)
+                .inboundProtocolConfiguration(new InboundProtocols().oidc(oidcConfig))
+                .advancedConfigurations(new AdvancedApplicationConfiguration()
+                        .skipLoginConsent(true)
+                        .skipLogoutConsent(true))
+                .claimConfiguration(new ClaimConfiguration()
+                        .subject(new SubjectConfig().useMappedLocalSubject(true)));
+
+        subOrgAppId = primaryISOAuth2RestClient.createOrganizationApplication(app, switchedM2MToken);
+        assertNotNull(subOrgAppId, "Sub-organization application ID should not be null.");
+
+        OpenIDConnectConfiguration createdOidcConfig =
+                primaryISOAuth2RestClient.getOIDCInboundDetailsOfOrganizationApp(subOrgAppId, switchedM2MToken);
+        assertNotNull(createdOidcConfig, "Sub-org OIDC configuration should not be null.");
+        subOrgClientId = createdOidcConfig.getClientId();
+        subOrgClientSecret = createdOidcConfig.getClientSecret();
+        assertNotNull(subOrgClientId, "Sub-org client ID should not be null.");
+        assertNotNull(subOrgClientSecret, "Sub-org client secret should not be null.");
+    }
+
+    @Test(priority = 5, dependsOnMethods = "testCreateApplicationInSubOrg")
+    public void testCreateFederatedIdpInSubOrg() throws Exception {
+
+        FederatedAuthenticator oidcAuthenticator = new FederatedAuthenticator()
+                .authenticatorId(OIDC_AUTHENTICATOR_ID)
+                .name(OIDC_AUTHENTICATOR_NAME)
+                .isEnabled(true)
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.IDP_NAME)
+                        .value(FEDERATED_IDP_NAME))
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.CLIENT_ID)
+                        .value(secondaryISClientId))
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.CLIENT_SECRET)
+                        .value(secondaryISClientSecret))
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.OAUTH2_AUTHZ_URL)
+                        .value(SECONDARY_IS_AUTHORIZE_ENDPOINT))
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.OAUTH2_TOKEN_URL)
+                        .value(SECONDARY_IS_TOKEN_ENDPOINT))
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.CALLBACK_URL)
+                        .value(PRIMARY_IS_CALLBACK_URL))
+                .addProperty(new Property()
+                        .key(IdentityConstants.Authenticator.OIDC.OIDC_LOGOUT_URL)
+                        .value(SECONDARY_IS_LOGOUT_ENDPOINT));
+
+        FederatedAuthenticatorRequest oidcAuthnConfig = new FederatedAuthenticatorRequest()
+                .defaultAuthenticatorId(OIDC_AUTHENTICATOR_ID)
+                .addAuthenticator(oidcAuthenticator);
+
+        IdentityProviderPOSTRequest idpPostRequest = new IdentityProviderPOSTRequest()
+                .name(FEDERATED_IDP_NAME)
+                .federatedAuthenticators(oidcAuthnConfig);
+
+        String subOrgIdpId = createIdpInSubOrg(idpPostRequest);
+        assertNotNull(subOrgIdpId, "Sub-org federated IDP ID should not be null.");
+    }
+
+    @Test(priority = 6, dependsOnMethods = "testCreateFederatedIdpInSubOrg")
+    public void testUpdateSubOrgAppAuthSequence() {
+
+        AuthenticationSequence authSequence = new AuthenticationSequence()
+                .type(AuthenticationSequence.TypeEnum.USER_DEFINED)
+                .addStepsItem(new AuthenticationStep()
+                        .id(1)
+                        .addOptionsItem(new Authenticator()
+                                .idp(FEDERATED_IDP_NAME)
+                                .authenticator(OIDC_AUTHENTICATOR_NAME)));
+
+        ApplicationPatchModel patchModel = new ApplicationPatchModel();
+        patchModel.setAuthenticationSequence(authSequence);
+
+        primaryISOAuth2RestClient.updateSubOrgApplication(subOrgAppId, patchModel, switchedM2MToken);
+    }
+
+    @Test(priority = 7, dependsOnMethods = "testUpdateSubOrgAppAuthSequence")
+    public void testCreateRootOrgUser() throws Exception {
+
+        UserObject rootUser = new UserObject();
+        rootUser.setUserName(ROOT_USER_USERNAME);
+        rootUser.setPassword(ROOT_USER_PASSWORD);
+        rootUser.addEmail(new Email().value(ROOT_USER_EMAIL));
+
+        rootUserId = primaryISSCIM2RestClient.createUser(rootUser);
+        assertNotNull(rootUserId, "Root organization user ID should not be null.");
+    }
+
+    @Test(priority = 8, dependsOnMethods = "testCreateRootOrgUser")
+    public void testShareUserToSubOrg() throws Exception {
+
+        UserShareWithAllRequestBody shareRequest = new UserShareWithAllRequestBody();
+        shareRequest.setUserCriteria(new UserShareRequestBodyUserCriteria().addUserIdsItem(rootUserId));
+        shareRequest.setPolicy(ALL_EXISTING_ORGS_ONLY);
+        userSharingRestClient.shareUsersWithAll(shareRequest);
+
+        String userSearchReq = new JSONObject()
+                .put("schemas", new JSONArray().put("urn:ietf:params:scim:api:messages:2.0:SearchRequest"))
+                .put("attributes", new JSONArray().put("id"))
+                .put("filter", "userName eq " + ROOT_USER_USERNAME)
+                .toString();
+
+        boolean isUserShared = primaryISSCIM2RestClient.isSharedUserCreationCompleted(userSearchReq, switchedM2MToken);
+        assertTrue(isUserShared, "User should be shared to the sub-organization.");
+
+        // Retrieve the shared user's ID in the sub-organization.
+        org.json.simple.JSONObject searchResult = primaryISSCIM2RestClient.searchSubOrgUser(
+                userSearchReq, switchedM2MToken);
+        org.json.simple.JSONArray resources = (org.json.simple.JSONArray) searchResult.get("Resources");
+        assertNotNull(resources, "Resources array should not be null in search results.");
+        assertFalse(resources.isEmpty(), "Should have at least one shared user.");
+        org.json.simple.JSONObject firstUser = (org.json.simple.JSONObject) resources.get(0);
+        sharedUserIdInSubOrg = (String) firstUser.get("id");
+        assertNotNull(sharedUserIdInSubOrg, "Shared user ID in sub-org should not be null.");
+    }
+
+    @Test(priority = 9, dependsOnMethods = "testShareUserToSubOrg")
+    public void testCreateUserInSecondaryIS() throws Exception {
+
+        UserObject secondaryUser = new UserObject();
+        secondaryUser.setUserName(SECONDARY_IS_USER_USERNAME);
+        secondaryUser.setPassword(SECONDARY_IS_USER_PASSWORD);
+
+        secondaryISUserId = secondaryISSCIM2RestClient.createUser(secondaryUser);
+        assertNotNull(secondaryISUserId, "Secondary IS user ID should not be null.");
+    }
+
+    @Test(priority = 10, dependsOnMethods = "testCreateUserInSecondaryIS")
+    public void testCreateFederatedAssociation() throws Exception {
+
+        createFederatedAssociationInSubOrg(sharedUserIdInSubOrg, FEDERATED_IDP_NAME, secondaryISUserId);
+    }
+
+    @Test(priority = 11, dependsOnMethods = "testCreateFederatedAssociation")
+    public void testAuthenticateViaFederatedLogin() throws Exception {
+
+        // Step 1: Send authorize request to sub-org.
+        String subOrgAuthorizeUrl = getPrimaryISURI() + TENANT_PATH + SUPER_TENANT + ORGANIZATION_PATH +
+                organizationId + OAUTH_2_AUTHORIZE;
+
+        List<NameValuePair> authorizeParams = new ArrayList<>();
+        authorizeParams.add(new BasicNameValuePair("response_type", "code"));
+        authorizeParams.add(new BasicNameValuePair("client_id", subOrgClientId));
+        authorizeParams.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+        authorizeParams.add(new BasicNameValuePair("scope", "openid"));
+
+        HttpResponse response = sendPostRequestWithParameters(client, authorizeParams, subOrgAuthorizeUrl);
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Authorize response location header should not be null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Step 2: Follow redirect to commonauth which will redirect to the federated IDP (secondary IS).
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Commonauth redirect to federated IDP should not be null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Step 3: Extract sessionDataKey from secondary IS login page redirect.
+        String secondaryISSessionDataKey = DataExtractUtil.getParamFromURIString(
+                locationHeader.getValue(), "sessionDataKey");
+        assertNotNull(secondaryISSessionDataKey, "Secondary IS session data key should not be null.");
+
+        // Step 4: Authenticate at the secondary IS.
+        List<NameValuePair> loginParams = new ArrayList<>();
+        loginParams.add(new BasicNameValuePair("sessionDataKey", secondaryISSessionDataKey));
+        loginParams.add(new BasicNameValuePair("username", SECONDARY_IS_USER_USERNAME));
+        loginParams.add(new BasicNameValuePair("password", SECONDARY_IS_USER_PASSWORD));
+
+        response = sendPostRequestWithParameters(client, loginParams, SECONDARY_IS_COMMONAUTH_URL);
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Secondary IS login response location header should not be null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Step 5: Follow redirect chain back through secondary IS authorize to primary IS commonauth.
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Secondary IS authorize callback redirect should not be null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Step 6: Follow redirect to primary IS commonauth (federated response processing).
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Primary IS commonauth redirect should not be null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Step 7: Follow redirect to sub-org authorize endpoint to get the authorization code.
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org authorize redirect to callback should not be null.");
+        EntityUtils.consume(response.getEntity());
+
+        authorizationCode = DataExtractUtil.getParamFromURIString(locationHeader.getValue(), "code");
+        assertNotNull(authorizationCode, "Authorization code should not be null.");
+    }
+
+    @Test(priority = 12, dependsOnMethods = "testAuthenticateViaFederatedLogin")
+    public void testGetAccessTokenAndVerifySubClaim() throws Exception {
+
+        String subOrgTokenUrl = getPrimaryISURI() + TENANT_PATH + SUPER_TENANT + ORGANIZATION_PATH + organizationId +
+                OAUTH_2_TOKEN;
+
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("code", authorizationCode));
+        params.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        params.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader("Authorization", "Basic " +
+                Base64.encodeBase64String((subOrgClientId + ":" + subOrgClientSecret).getBytes()).trim()));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(client, headers, params, subOrgTokenUrl);
+        assertNotNull(response, "Token endpoint response should not be null.");
+
+        String responseBody = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseBody);
+
+        assertTrue(jsonResponse.has("access_token"), "access_token is missing from token response.");
+        String accessToken = jsonResponse.getString("access_token");
+        assertNotNull(accessToken, "Access token should not be null.");
+
+        assertTrue(jsonResponse.has("id_token"), "id_token is missing from token response.");
+        String idToken = jsonResponse.getString("id_token");
+        assertNotNull(idToken, "ID token should not be null.");
+
+        // Verify the sub claim in the ID token contains the root organization user ID.
+        SignedJWT signedJWT = SignedJWT.parse(idToken);
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+        assertNotNull(claimsSet, "JWT claims set should not be null.");
+
+        String subClaim = claimsSet.getSubject();
+        assertNotNull(subClaim, "Sub claim should not be null.");
+        Assert.assertEquals(subClaim, rootUserId,
+                "Sub claim should contain the user ID of the user created in the root organization.");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupTest() {
+
+        if (secondaryISAppId != null) {
+            try {
+                deleteApplication(PORT_OFFSET_1, secondaryISAppId);
+            } catch (Exception e) {
+                log.error("Failed to delete secondary IS application: " + secondaryISAppId, e);
+            }
+        }
+        if (organizationId != null && orgMgtRestClient != null) {
+            try {
+                orgMgtRestClient.deleteOrganization(organizationId);
+            } catch (Exception e) {
+                log.error("Failed to delete organization: " + organizationId, e);
+            }
+        }
+        if (rootUserId != null && primaryISSCIM2RestClient != null) {
+            try {
+                primaryISSCIM2RestClient.deleteUser(rootUserId);
+            } catch (Exception e) {
+                log.error("Failed to delete root org user: " + rootUserId, e);
+            }
+        }
+        if (secondaryISUserId != null && secondaryISSCIM2RestClient != null) {
+            try {
+                secondaryISSCIM2RestClient.deleteUser(secondaryISUserId);
+            } catch (Exception e) {
+                log.error("Failed to delete secondary IS user: " + secondaryISUserId, e);
+            }
+        }
+        if (client != null) {
+            try {
+                client.close();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (primaryISSCIM2RestClient != null) {
+            try {
+                primaryISSCIM2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (secondaryISSCIM2RestClient != null) {
+            try {
+                secondaryISSCIM2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (primaryISOAuth2RestClient != null) {
+            try {
+                primaryISOAuth2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (orgMgtRestClient != null) {
+            try {
+                orgMgtRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (userSharingRestClient != null) {
+            try {
+                userSharingRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+    }
+
+    /**
+     * Create an Identity Provider in the sub-organization using the switched M2M token.
+     */
+    private String createIdpInSubOrg(IdentityProviderPOSTRequest idpRequest) throws Exception {
+
+        String endPointUrl = getPrimaryISURI() + "o/api/server/v1/identity-providers";
+        String jsonRequest = new com.google.gson.GsonBuilder().setPrettyPrinting().create().toJson(idpRequest);
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpPost request = new HttpPost(endPointUrl);
+            request.setHeader("Authorization", "Bearer " + switchedM2MToken);
+            request.setHeader("Content-Type", "application/json");
+            request.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
+            request.setEntity(new StringEntity(jsonRequest));
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                String responseBody = EntityUtils.toString(response.getEntity());
+                Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
+                        "Sub-org IDP creation failed. Response: " + responseBody);
+                JSONParser parser = new JSONParser();
+                org.json.simple.JSONObject jsonResponse =
+                        (org.json.simple.JSONObject) parser.parse(responseBody);
+                return jsonResponse.get("id").toString();
+            }
+        }
+    }
+
+    /**
+     * Create a federated association for a user in the sub-organization.
+     */
+    private void createFederatedAssociationInSubOrg(String userId, String idpName,
+                                                    String federatedUserId) throws Exception {
+
+        String endPointUrl = getPrimaryISURI() + "o/api/users/v1/" + userId + "/federated-associations";
+        String body = "{\"idp\":\"" + idpName + "\",\"federatedUserId\":\"" + federatedUserId + "\"}";
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpPost request = new HttpPost(endPointUrl);
+            request.setHeader("Authorization", "Bearer " + switchedM2MToken);
+            request.setHeader("Content-Type", "application/json");
+            request.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
+            request.setEntity(new StringEntity(body));
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                String responseBody = EntityUtils.toString(response.getEntity());
+                int statusCode = response.getStatusLine().getStatusCode();
+                Assert.assertTrue(statusCode == HttpServletResponse.SC_OK ||
+                                statusCode == HttpServletResponse.SC_CREATED ||
+                                statusCode == HttpServletResponse.SC_NO_CONTENT,
+                        "Federated association creation failed with status: " + statusCode +
+                                ". Response: " + responseBody);
+            }
+        }
+    }
+
+    private String getPrimaryISURI() {
+
+        return String.format(HTTPS_LOCALHOST_SERVICES, DEFAULT_PORT);
+    }
+
+    private String getSecondaryISURI() {
+
+        return String.format(HTTPS_LOCALHOST_SERVICES, DEFAULT_PORT + PORT_OFFSET_1);
+    }
+
+    private HttpResponse sendPostRequestWithParameters(CloseableHttpClient httpClient,
+                                                       List<NameValuePair> urlParameters,
+                                                       String url) throws IOException {
+
+        HttpPost request = new HttpPost(url);
+        request.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
+        request.setEntity(new UrlEncodedFormEntity(urlParameters));
+        return httpClient.execute(request);
+    }
+
+    private HttpResponse sendGetRequest(CloseableHttpClient httpClient, String locationURL) throws IOException {
+
+        HttpGet getRequest = new HttpGet(locationURL);
+        getRequest.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
+        return httpClient.execute(getRequest);
+    }
+
+    private HttpResponse sendPostRequest(CloseableHttpClient httpClient, List<Header> headerList,
+                                         List<NameValuePair> urlParameters, String url) throws IOException {
+
+        HttpPost request = new HttpPost(url);
+        request.setHeaders(headerList.toArray(new Header[0]));
+        request.setEntity(new UrlEncodedFormEntity(urlParameters));
+        return httpClient.execute(request);
+    }
+
+    private CloseableHttpClient createHttpClient() {
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build())
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+
+                        return false;
+                    }
+                })
+                .build();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserSubOrgApplicationAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserSubOrgApplicationAuthenticationTestCase.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.oauth2;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.common.RESTTestBase;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareRequestBodyUserCriteria;
+import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.restclients.UserSharingRestClient;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody.PolicyEnum.ALL_EXISTING_ORGS_ONLY;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.CALLBACK_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
+
+/**
+ * Integration test for sub-organization application authentication with shared users.
+ * <p>
+ * This test verifies the following flow:
+ * 1. Create a sub-organization.
+ * 2. Create an application directly in the sub-organization.
+ * 3. Create a user in the root organization and share the user to the sub-organization.
+ * 4. Login via the sub-organization application by initiating the authorize request directly
+ * at the sub-organization and authenticating with the shared user.
+ * 5. Verify the token is received and the sub claim contains the root organization user ID.
+ */
+public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    private static final String APP_NAME = "SharedUserSubOrgApp";
+    private static final String MGT_APP_AUTHORIZED_API_RESOURCES = "management-app-authorized-apis.json";
+    private static final String ROOT_USER_USERNAME = "user";
+    private static final String ROOT_USER_PASSWORD = "SharedUser@wso2";
+    private static final String ROOT_USER_EMAIL = "sharedsuborguser@wso2.com";
+    public static final String ORGANIZATION_PATH = "o/";
+    public static final String OAUTH_2_AUTHORIZE = "/oauth2/authorize";
+    public static final String OAUTH_2_TOKEN = "/oauth2/token";
+
+    private final TestUserMode userMode;
+    private final String organizationName;
+    private final String organizationHandle;
+
+    private CloseableHttpClient client;
+    private SCIM2RestClient scim2RestClient;
+    private OrgMgtRestClient orgMgtRestClient;
+    private OAuth2RestClient oAuth2RestClient;
+    private UserSharingRestClient userSharingRestClient;
+
+    private String organizationId;
+    private String rootUserId;
+    private String subOrgAppId;
+    private String clientId;
+    private String clientSecret;
+    private String switchedM2MToken;
+    private String subOrgSessionDataKey;
+    private String authorizationCode;
+
+    @DataProvider(name = "configProvider")
+    public static Object[][] configProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN, "suborg_app_sub_org", "suborg_app_sub_org"},
+                {TestUserMode.TENANT_ADMIN, "suborg_app_t_sub_org", "suborg_app_t_sub_org"}};
+    }
+
+    @Factory(dataProvider = "configProvider")
+    public SharedUserSubOrgApplicationAuthenticationTestCase(TestUserMode userMode, String orgName, String orgHandle) {
+
+        this.userMode = userMode;
+        this.organizationName = orgName;
+        this.organizationHandle = orgHandle;
+    }
+
+    @Test(priority = 1)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+        client = createHttpClient();
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+        userSharingRestClient = new UserSharingRestClient(serverURL, tenantInfo);
+        orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
+                new JSONObject(RESTTestBase.readResource(MGT_APP_AUTHORIZED_API_RESOURCES, this.getClass())));
+    }
+
+    @Test(priority = 2, dependsOnMethods = "testInit")
+    public void testCreateSubOrganization() throws Exception {
+
+        String m2mToken = orgMgtRestClient.getM2MAccessToken();
+        organizationId = orgMgtRestClient.addOrganizationWithToken(organizationName, organizationHandle, m2mToken);
+        assertNotNull(organizationId, "Organization ID should not be null.");
+
+        switchedM2MToken = orgMgtRestClient.switchM2MToken(organizationId);
+        assertNotNull(switchedM2MToken, "Switched M2M token should not be null.");
+    }
+
+    @Test(priority = 3, dependsOnMethods = "testCreateSubOrganization")
+    public void testCreateApplicationInSubOrg() throws Exception {
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.addGrantTypesItem(OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
+        oidcConfig.addCallbackURLsItem(CALLBACK_URL);
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+
+        ApplicationModel app = new ApplicationModel()
+                .name(APP_NAME)
+                .inboundProtocolConfiguration(inboundProtocols)
+                .advancedConfigurations(new AdvancedApplicationConfiguration()
+                        .skipLoginConsent(true)
+                        .skipLogoutConsent(true));
+
+        subOrgAppId = oAuth2RestClient.createOrganizationApplication(app, switchedM2MToken);
+        assertNotNull(subOrgAppId, "Sub-organization application ID should not be null.");
+
+        OpenIDConnectConfiguration createdOidcConfig =
+                oAuth2RestClient.getOIDCInboundDetailsOfOrganizationApp(subOrgAppId, switchedM2MToken);
+        assertNotNull(createdOidcConfig, "OIDC configuration should not be null.");
+        clientId = createdOidcConfig.getClientId();
+        clientSecret = createdOidcConfig.getClientSecret();
+        assertNotNull(clientId, "Client ID should not be null.");
+        assertNotNull(clientSecret, "Client secret should not be null.");
+    }
+
+    @Test(priority = 4, dependsOnMethods = "testCreateApplicationInSubOrg")
+    public void testUpdateSubOrgAppAuthenticationSequence() {
+
+        AuthenticationSequence authSequence = new AuthenticationSequence()
+                .type(AuthenticationSequence.TypeEnum.USER_DEFINED)
+                .addStepsItem(new AuthenticationStep()
+                        .id(1)
+                        .addOptionsItem(new Authenticator()
+                                .idp("LOCAL")
+                                .authenticator("SharedUserIdentifierExecutor")))
+                .addStepsItem(new AuthenticationStep()
+                        .id(2)
+                        .addOptionsItem(new Authenticator()
+                                .idp("LOCAL")
+                                .authenticator("BasicAuthenticator")));
+
+        ApplicationPatchModel patchModel = new ApplicationPatchModel();
+        patchModel.setAuthenticationSequence(authSequence);
+
+        oAuth2RestClient.updateSubOrgApplication(subOrgAppId, patchModel, switchedM2MToken);
+    }
+
+    @Test(priority = 5, dependsOnMethods = "testUpdateSubOrgAppAuthenticationSequence")
+    public void testCreateRootOrgUser() throws Exception {
+
+        UserObject rootUser = new UserObject();
+        rootUser.setUserName(ROOT_USER_USERNAME);
+        rootUser.setPassword(ROOT_USER_PASSWORD);
+        rootUser.addEmail(new Email().value(ROOT_USER_EMAIL));
+
+        rootUserId = scim2RestClient.createUser(rootUser);
+        assertNotNull(rootUserId, "Root organization user ID should not be null.");
+    }
+
+    @Test(priority = 6, dependsOnMethods = "testCreateRootOrgUser")
+    public void testShareUserToSubOrg() throws Exception {
+
+        UserShareWithAllRequestBody shareRequest = new UserShareWithAllRequestBody();
+        shareRequest.setUserCriteria(new UserShareRequestBodyUserCriteria().addUserIdsItem(rootUserId));
+        shareRequest.setPolicy(ALL_EXISTING_ORGS_ONLY);
+        userSharingRestClient.shareUsersWithAll(shareRequest);
+
+        String userSearchReq = new JSONObject()
+                .put("schemas", new JSONArray().put("urn:ietf:params:scim:api:messages:2.0:SearchRequest"))
+                .put("attributes", new JSONArray().put("id"))
+                .put("filter", "userName eq " + ROOT_USER_USERNAME)
+                .toString();
+
+        boolean isUserShared = scim2RestClient.isSharedUserCreationCompleted(userSearchReq, switchedM2MToken);
+        assertTrue(isUserShared, "User should be shared to the sub-organization.");
+    }
+
+    @Test(priority = 7, dependsOnMethods = "testShareUserToSubOrg")
+    public void testSendAuthorizeRequestToSubOrg() throws Exception {
+
+        String subOrgAuthorizeUrl = getTenantQualifiedURL(serverURL + ORGANIZATION_PATH + organizationId +
+                OAUTH_2_AUTHORIZE, tenantInfo.getDomain());
+
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("response_type", "code"));
+        params.add(new BasicNameValuePair("client_id", clientId));
+        params.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+        params.add(new BasicNameValuePair("scope", "openid"));
+
+        HttpResponse response = sendPostRequestWithParameters(client, params, subOrgAuthorizeUrl);
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Location header expected for authorize request is not available.");
+        EntityUtils.consume(response.getEntity());
+
+        subOrgSessionDataKey = DataExtractUtil.getParamFromURIString(locationHeader.getValue(), "sessionDataKey");
+        assertNotNull(subOrgSessionDataKey, "Sub-org session data key should not be null.");
+    }
+
+    @Test(priority = 8, dependsOnMethods = "testSendAuthorizeRequestToSubOrg")
+    public void testAuthenticateAtSubOrganization() throws Exception {
+
+        String subOrgCommonAuthUrl = getTenantQualifiedURL(
+                serverURL + ORGANIZATION_PATH + organizationId + "/commonauth", tenantInfo.getDomain());
+
+        List<NameValuePair> sidfLoginParams = new ArrayList<>();
+        sidfLoginParams.add(new BasicNameValuePair("sessionDataKey", subOrgSessionDataKey));
+        sidfLoginParams.add(new BasicNameValuePair("username", ROOT_USER_USERNAME));
+
+        HttpResponse response = sendPostRequestWithParameters(client, sidfLoginParams, subOrgCommonAuthUrl);
+
+        Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org shared user identifier response location header is null.");
+        EntityUtils.consume(response.getEntity());
+
+        List<NameValuePair> loginParams = new ArrayList<>();
+        loginParams.add(new BasicNameValuePair("sessionDataKey", subOrgSessionDataKey));
+        loginParams.add(new BasicNameValuePair("username", ROOT_USER_USERNAME));
+        loginParams.add(new BasicNameValuePair("password", ROOT_USER_PASSWORD));
+
+        response = sendPostRequestWithParameters(client, loginParams, subOrgCommonAuthUrl);
+
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org basic auth response location header is null.");
+        EntityUtils.consume(response.getEntity());
+
+        // Follow redirect to sub-org authorize endpoint to get the authorization code.
+        response = sendGetRequest(client, locationHeader.getValue());
+        locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Sub-org authorize redirect to callback is null.");
+        EntityUtils.consume(response.getEntity());
+
+        authorizationCode = DataExtractUtil.getParamFromURIString(locationHeader.getValue(), "code");
+        assertNotNull(authorizationCode, "Authorization code should not be null.");
+    }
+
+    @Test(priority = 9, dependsOnMethods = "testAuthenticateAtSubOrganization")
+    public void testGetAccessTokenAndVerifySubClaim() throws Exception {
+
+        String subOrgTokenUrl = getTenantQualifiedURL(serverURL + ORGANIZATION_PATH + organizationId +
+                OAUTH_2_TOKEN, tenantInfo.getDomain());
+
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("code", authorizationCode));
+        params.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        params.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader("Authorization", "Basic " + getBase64EncodedString(clientId, clientSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(client, headers, params, subOrgTokenUrl);
+        assertNotNull(response, "Token endpoint response should not be null.");
+
+        String responseBody = EntityUtils.toString(response.getEntity(), "UTF-8");
+        org.json.JSONObject jsonResponse = new org.json.JSONObject(responseBody);
+
+        assertTrue(jsonResponse.has("access_token"), "access_token is missing from token response.");
+        String accessToken = jsonResponse.getString("access_token");
+        assertNotNull(accessToken, "Access token should not be null.");
+
+        assertTrue(jsonResponse.has("id_token"), "id_token is missing from token response.");
+        String idToken = jsonResponse.getString("id_token");
+        assertNotNull(idToken, "ID token should not be null.");
+
+        // Verify the sub claim in the ID token contains the root organization user ID.
+        SignedJWT signedJWT = SignedJWT.parse(idToken);
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+        assertNotNull(claimsSet, "JWT claims set should not be null.");
+
+        String subClaim = claimsSet.getSubject();
+        assertNotNull(subClaim, "Sub claim should not be null.");
+        Assert.assertEquals(subClaim, rootUserId,
+                "Sub claim should contain the user ID of the user created in the root organization.");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupTest() {
+
+        if (organizationId != null && orgMgtRestClient != null) {
+            try {
+                orgMgtRestClient.deleteOrganization(organizationId);
+            } catch (Exception e) {
+                log.error("Failed to delete organization: " + organizationId, e);
+            }
+        }
+        if (rootUserId != null && scim2RestClient != null) {
+            try {
+                scim2RestClient.deleteUser(rootUserId);
+            } catch (Exception e) {
+                log.error("Failed to delete root org user: " + rootUserId, e);
+            }
+        }
+        if (client != null) {
+            try {
+                client.close();
+            } catch (Exception e) {
+                log.error("Failed to close HTTP client.", e);
+            }
+        }
+        if (scim2RestClient != null) {
+            try {
+                scim2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close SCIM2 REST client.", e);
+            }
+        }
+        if (oAuth2RestClient != null) {
+            try {
+                oAuth2RestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close OAuth2 REST client.", e);
+            }
+        }
+        if (orgMgtRestClient != null) {
+            try {
+                orgMgtRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close org management REST client.", e);
+            }
+        }
+        if (userSharingRestClient != null) {
+            try {
+                userSharingRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close user sharing REST client.", e);
+            }
+        }
+    }
+
+    private CloseableHttpClient createHttpClient() {
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        return HttpClientBuilder.create()
+                .setDefaultCookieStore(new BasicCookieStore())
+                .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build())
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+
+                        return false;
+                    }
+                })
+                .build();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserSubOrgApplicationAuthenticationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/oauth2/SharedUserSubOrgApplicationAuthenticationTestCase.java
@@ -57,6 +57,9 @@ import org.wso2.identity.integration.test.rest.api.server.user.sharing.managemen
 import org.wso2.identity.integration.test.rest.api.server.user.sharing.management.v1.model.UserShareWithAllRequestBody;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
+import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
 import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
 import org.wso2.identity.integration.test.restclients.OrgMgtRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
@@ -94,6 +97,9 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
     public static final String ORGANIZATION_PATH = "o/";
     public static final String OAUTH_2_AUTHORIZE = "/oauth2/authorize";
     public static final String OAUTH_2_TOKEN = "/oauth2/token";
+    private static final String ACCOUNT_MGT_CATEGORY_ID = "QWNjb3VudCBNYW5hZ2VtZW50";
+    private static final String MULTI_ATTRIBUTE_CONNECTOR_ID = "bXVsdGlhdHRyaWJ1dGUubG9naW4uaGFuZGxlcg";
+    private static final String MULTI_ATTRIBUTE_ENABLE_PROPERTY = "account.multiattributelogin.handler.enable";
 
     private final TestUserMode userMode;
     private final String organizationName;
@@ -104,6 +110,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
     private OrgMgtRestClient orgMgtRestClient;
     private OAuth2RestClient oAuth2RestClient;
     private UserSharingRestClient userSharingRestClient;
+    private IdentityGovernanceRestClient identityGovernanceRestClient;
 
     private String organizationId;
     private String rootUserId;
@@ -140,9 +147,23 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         userSharingRestClient = new UserSharingRestClient(serverURL, tenantInfo);
         orgMgtRestClient = new OrgMgtRestClient(isServer, tenantInfo, serverURL,
                 new JSONObject(RESTTestBase.readResource(MGT_APP_AUTHORIZED_API_RESOURCES, this.getClass())));
+        identityGovernanceRestClient = new IdentityGovernanceRestClient(serverURL, tenantInfo);
     }
 
     @Test(priority = 2, dependsOnMethods = "testInit")
+    public void testDisableMultiAttributeLogin() throws Exception {
+
+        ConnectorsPatchReq connectorPatchReq = new ConnectorsPatchReq();
+        connectorPatchReq.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
+        PropertyReq enableProperty = new PropertyReq();
+        enableProperty.setName(MULTI_ATTRIBUTE_ENABLE_PROPERTY);
+        enableProperty.setValue("false");
+        connectorPatchReq.addProperties(enableProperty);
+        identityGovernanceRestClient.updateConnectors(ACCOUNT_MGT_CATEGORY_ID, MULTI_ATTRIBUTE_CONNECTOR_ID,
+                connectorPatchReq);
+    }
+
+    @Test(priority = 3, dependsOnMethods = "testDisableMultiAttributeLogin")
     public void testCreateSubOrganization() throws Exception {
 
         String m2mToken = orgMgtRestClient.getM2MAccessToken();
@@ -153,7 +174,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         assertNotNull(switchedM2MToken, "Switched M2M token should not be null.");
     }
 
-    @Test(priority = 3, dependsOnMethods = "testCreateSubOrganization")
+    @Test(priority = 4, dependsOnMethods = "testCreateSubOrganization")
     public void testCreateApplicationInSubOrg() throws Exception {
 
         OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
@@ -182,7 +203,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         assertNotNull(clientSecret, "Client secret should not be null.");
     }
 
-    @Test(priority = 4, dependsOnMethods = "testCreateApplicationInSubOrg")
+    @Test(priority = 5, dependsOnMethods = "testCreateApplicationInSubOrg")
     public void testUpdateSubOrgAppAuthenticationSequence() {
 
         AuthenticationSequence authSequence = new AuthenticationSequence()
@@ -204,7 +225,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         oAuth2RestClient.updateSubOrgApplication(subOrgAppId, patchModel, switchedM2MToken);
     }
 
-    @Test(priority = 5, dependsOnMethods = "testUpdateSubOrgAppAuthenticationSequence")
+    @Test(priority = 6, dependsOnMethods = "testUpdateSubOrgAppAuthenticationSequence")
     public void testCreateRootOrgUser() throws Exception {
 
         UserObject rootUser = new UserObject();
@@ -216,7 +237,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         assertNotNull(rootUserId, "Root organization user ID should not be null.");
     }
 
-    @Test(priority = 6, dependsOnMethods = "testCreateRootOrgUser")
+    @Test(priority = 7, dependsOnMethods = "testCreateRootOrgUser")
     public void testShareUserToSubOrg() throws Exception {
 
         UserShareWithAllRequestBody shareRequest = new UserShareWithAllRequestBody();
@@ -234,7 +255,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         assertTrue(isUserShared, "User should be shared to the sub-organization.");
     }
 
-    @Test(priority = 7, dependsOnMethods = "testShareUserToSubOrg")
+    @Test(priority = 8, dependsOnMethods = "testShareUserToSubOrg")
     public void testSendAuthorizeRequestToSubOrg() throws Exception {
 
         String subOrgAuthorizeUrl = getTenantQualifiedURL(serverURL + ORGANIZATION_PATH + organizationId +
@@ -256,7 +277,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         assertNotNull(subOrgSessionDataKey, "Sub-org session data key should not be null.");
     }
 
-    @Test(priority = 8, dependsOnMethods = "testSendAuthorizeRequestToSubOrg")
+    @Test(priority = 9, dependsOnMethods = "testSendAuthorizeRequestToSubOrg")
     public void testAuthenticateAtSubOrganization() throws Exception {
 
         String subOrgCommonAuthUrl = getTenantQualifiedURL(
@@ -293,7 +314,7 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
         assertNotNull(authorizationCode, "Authorization code should not be null.");
     }
 
-    @Test(priority = 9, dependsOnMethods = "testAuthenticateAtSubOrganization")
+    @Test(priority = 10, dependsOnMethods = "testAuthenticateAtSubOrganization")
     public void testGetAccessTokenAndVerifySubClaim() throws Exception {
 
         String subOrgTokenUrl = getTenantQualifiedURL(serverURL + ORGANIZATION_PATH + organizationId +
@@ -337,6 +358,13 @@ public class SharedUserSubOrgApplicationAuthenticationTestCase extends OAuth2Ser
     @AfterClass(alwaysRun = true)
     public void cleanupTest() {
 
+        if (identityGovernanceRestClient != null) {
+            try {
+                identityGovernanceRestClient.closeHttpClient();
+            } catch (Exception e) {
+                log.error("Failed to close identity governance REST client.", e);
+            }
+        }
         if (organizationId != null && orgMgtRestClient != null) {
             try {
                 orgMgtRestClient.deleteOrganization(organizationId);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/oauth2/shared-user-federation-authorized-apis.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/oauth2/shared-user-federation-authorized-apis.json
@@ -1,0 +1,32 @@
+{
+  "/api/server/v1/organizations": [
+    "internal_organization_view",
+    "internal_organization_create",
+    "internal_organization_update",
+    "internal_organization_delete"
+  ],
+  "/o/api/server/v1/applications": [
+    "internal_org_application_mgt_update",
+    "internal_org_application_mgt_view",
+    "internal_org_application_mgt_create",
+    "internal_org_application_mgt_delete",
+    "internal_org_application_internal_api_update",
+    "internal_org_application_business_api_update"
+  ],
+  "/o/api/server/v1/api-resources": [
+    "internal_org_api_resource_view"
+  ],
+  "/o/scim2/Users": [
+    "internal_org_user_mgt_view",
+    "internal_org_user_mgt_list",
+    "internal_org_user_mgt_create",
+    "internal_org_user_mgt_update",
+    "internal_org_user_mgt_delete"
+  ],
+  "/o/api/server/v1/identity-providers": [
+    "internal_org_idp_view",
+    "internal_org_idp_create",
+    "internal_org_idp_update",
+    "internal_org_idp_delete"
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -188,10 +188,12 @@
             <class name="org.wso2.identity.integration.test.apiAuthorization.APIResourceInheritanceTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.workflow.v1.WorkflowSuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.workflow.v1.WorkflowFailureTest"/>
-            <class name="org.wso2.identity.integration.test.rest.api.server.workflow.v1.WorkflowRulesTest"/>  
+            <class name="org.wso2.identity.integration.test.rest.api.server.workflow.v1.WorkflowRulesTest"/>
             <class name="org.wso2.identity.integration.test.inheritance.ConfigInheritanceTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.compatibilitysettings.CompatibilitySettingsDeploymentConfigTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.EnhancedOrgAuthenticationDirectPathTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SharedUserLegacyOrgAuthenticationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SharedUserSubOrgApplicationAuthenticationTestCase"/>
         </classes>
     </test>
 
@@ -472,6 +474,7 @@
             <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>
             <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.JITUserAssociationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SharedUserSubOrgAppFederatedAssociationTestCase"/>
         </classes>
     </test>
     <test name="is-tests-jdbc-userstore" preserve-order="true" parallel="false" group-by-instances="true">

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -198,6 +198,8 @@
             <class name="org.wso2.identity.integration.test.inheritance.ConfigInheritanceTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.compatibilitysettings.CompatibilitySettingsDeploymentConfigTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.EnhancedOrgAuthenticationDirectPathTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SharedUserLegacyOrgAuthenticationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SharedUserSubOrgApplicationAuthenticationTestCase"/>
             <class name="org.wso2.identity.integration.test.passkey.PasskeyRedirectBasedTest"/>
             <class name="org.wso2.identity.integration.test.passkey.PasskeyAppNativeTest"/>
         </classes>
@@ -480,6 +482,7 @@
             <class name="org.wso2.identity.integration.test.base.SecondaryCarbonServerInitializerTestCase"/>
             <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>
             <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.SharedUserSubOrgAppFederatedAssociationTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.JITUserAssociationTestCase"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose

- Adds integration tests covering shared user direct login scenarios for sub-organization applications
- Includes three new test cases:
  - `SharedUserLegacyOrgAuthenticationTestCase` — tests legacy org authentication via shared apps for shared users
  - `SharedUserSubOrgAppFederatedAssociationTestCase` — tests federated authentication for shared users when use linked local account configuration is set to true.
  - `SharedUserSubOrgApplicationAuthenticationTestCase` — tests authentication via sub-org apps for shared users
- Registers the new test cases in `testng.xml`

### Related issue
- https://github.com/wso2/product-is/issues/27371