### PR TITLE
Remove H2 configurations from the primary IS TOML files

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identityMgt/case_insensitive_user_false.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/identityMgt/case_insensitive_user_false.toml
@@ -14,16 +14,16 @@ type = "database_unique_id"
 use_case_sensitive_username_for_cache_keys = "false"
 
 [database.identity_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
 
 [database.shared_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
 
 [datasource.AgentIdentity]
 id = "AgentIdentity"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/nashorn_script_engine_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/nashorn_script_engine_config.toml
@@ -13,16 +13,16 @@ create_admin_account = true
 type = "database_unique_id"
 
 [database.identity_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
 
 [database.shared_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
 
 [datasource.AgentIdentity]
 id = "AgentIdentity"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/openjdknashorn_script_engine_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/scriptEngine/openjdknashorn_script_engine_config.toml
@@ -13,16 +13,16 @@ create_admin_account = true
 type = "database_unique_id"
 
 [database.identity_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
 
 [database.shared_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
 
 [datasource.AgentIdentity]
 id = "AgentIdentity"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/ldap_user_mgt_config.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/IS/userMgt/ldap_user_mgt_config.toml
@@ -17,16 +17,16 @@ connection_password = "admin"
 base_dn = "dc=wso2,dc=org"
 
 [database.identity_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{IDENTITY_DATABASE_DRIVER}"
+url = "$env{IDENTITY_DATABASE_URL}"
+username = "$env{IDENTITY_DATABASE_USERNAME}"
+password = "$env{IDENTITY_DATABASE_PASSWORD}"
 
 [database.shared_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
 
 [datasource.AgentIdentity]
 id = "AgentIdentity"


### PR DESCRIPTION
### Purpose
Since the integration suite needs to support multiple databases, the primary IS TOML should use environment variables for database configurations when being replaced.

### Related Issue
- https://github.com/wso2/product-is/issues/27565