### PR TITLE
Bump log4j version to 2.25.4

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -48,8 +48,8 @@ org.wso2.carbon.identity.application.authentication.endpoint.util-7.10.78.jar   
 validation-api-2.0.1.Final.jar                                                                      bundle         apache2
 javax.annotation-api-1.3.2.jar                                                                      bundle         cddl1
 config-mapper-1.0.22.jar                                                                            jar            apache2
-log4j-core-2.25.3.jar                                                                               bundle         apache2
-log4j-api-2.25.3.jar                                                                                bundle         apache2
+log4j-core-2.25.4.jar                                                                               bundle         apache2
+log4j-api-2.25.4.jar                                                                                bundle         apache2
 antlr4-runtime-4.7.1.jar                                                                            bundle         bsd
 jaxws-ri-2.3.2.wso2v1.jar                                                                           bundle         apache2 + edl1
 jaxb-impl-2.4.0-b180830.0438.jar                                                                    bundle         cddl1
@@ -73,7 +73,7 @@ ant-contrib-1.0b3.jar                                                           
 jackson-dataformat-yaml-2.16.1.jar                                                                  bundle         apache2
 slf4j-api-2.0.16.jar                                                                                bundle         mit
 geronimo-jta_1.1_spec-1.1.jar                                                                       jar            apache2
-log4j-jcl-2.25.3.jar                                                                                bundle         apache2
+log4j-jcl-2.25.4.jar                                                                                bundle         apache2
 commons-lang-2.6.0.wso2v1.jar                                                                       bundle         apache2
 org.wso2.carbon.server-4.12.13.jar                                                                  bundle         apache2
 stax2-api-3.1.4.jar                                                                                 bundle         bsd

--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.30" useFeatures="true" includeLaunchers="true">
+version="4.12.32" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.30" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.30"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.32"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2847,7 +2847,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.30</carbon.kernel.version>
+        <carbon.kernel.version>4.12.32</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.2</identity.verification.version>
@@ -2983,7 +2983,7 @@
         <!--ws-trust-client-->
         <org.apache.velocity.version>1.7</org.apache.velocity.version>
         <org.xmlunit.version>2.6.3</org.xmlunit.version>
-        <org.apache.logging.log4j.version>2.25.3</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.25.4</org.apache.logging.log4j.version>
         <org.apache.log4j.wso2.version>1.2.17.wso2v1</org.apache.log4j.wso2.version>
 
         <project.scm.id>my-scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose
Update log4j dependencies (`log4j-core`, `log4j-api`, and `log4j-jcl`) from version `2.25.3` to `2.25.4` to stay current with the latest release.

## Related Issue
Fixes #27612

## Implementation
Updated the `org.apache.logging.log4j.version` property in the root `pom.xml` from `2.25.3` to `2.25.4`. Also bumped `carbon.kernel.version` to `4.12.32` and updated the corresponding jar filename references in `LICENSE.txt` to reflect the new version. This is a port of #27620 to the `next` branch.