### PR TITLE
Bump carbon kernel version to 4.12.34

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.33" useFeatures="true" includeLaunchers="true">
+version="4.12.34" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.33" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.33"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.34"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2839,7 +2839,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.33</carbon.kernel.version>
+        <carbon.kernel.version>4.12.34</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.2</identity.verification.version>


### PR DESCRIPTION
## Purpose
Bump carbon kernel version from 4.12.33 to 4.12.34 to incorporate latest updates.

## Related Issue
N/A

## Implementation
Updated version references in:
- modules/p2-profile-gen/carbon.product
- pom.xml