### PR TITLE
Bump oauth to 7.4.99 and framework to 7.10.155

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2684,7 +2684,7 @@
     <properties>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.152</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.155</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
         <identity.notification.push.version>1.1.5</identity.notification.push.version>
@@ -2713,7 +2713,7 @@
         <identity.carbon.auth.rest.version>1.12.11</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.4.97</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.4.99</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.5</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>


### PR DESCRIPTION
## Purpose
Update identity oauth and carbon identity framework dependency versions.

## Related Issue
N/A

## Implementation
Updated version properties in pom.xml:
- identity.inbound.auth.oauth.version: 7.4.97 → 7.4.99
- carbon.identity.framework.version: 7.10.152 → 7.10.155