### PR TITLE
Add integration tests for client credentials–based authentication support in Actions.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/ActionTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/ActionTestBase.java
@@ -59,7 +59,6 @@ public class ActionTestBase extends RESTAPIServerTestBase {
     protected static final String TEST_ACTION_UPDATED_NAME = "Action name Updated";
     protected static final String TEST_ACTION_UPDATED_DESCRIPTION = "This is the updated configuration of action.";
     protected static final String TEST_UPDATED_ENDPOINT_URI = "https://abc.com/tokenUpdated";
-    protected static final String TEST_PROPERTIES_AUTH_ATTRIBUTE = "properties";
     protected static final String TEST_ACCESS_TOKEN_AUTH_PROPERTY = "accessToken";
     protected static final String TEST_ACCESS_TOKEN_AUTH_PROPERTY_VALUE = "24f64d17-9824-4e28-8413-de45728d8e84";
     protected static final String TEST_UPDATED_ACCESS_TOKEN_AUTH_PROPERTY_VALUE = "88f63a16-9824-4e28-e463-de11118d8e84";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/ActionTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/ActionTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -68,6 +68,20 @@ public class ActionTestBase extends RESTAPIServerTestBase {
     protected static final String TEST_APIKEY_VALUE_AUTH_PROPERTY = "value";
     protected static final String TEST_APIKEY_VALUE_AUTH_PROPERTY_VALUE = "secret";
     protected static final String TEST_USERNAME_INVALID_AUTH_PROPERTY = "invalidUsername";
+    protected static final String TEST_CLIENT_ID_AUTH_PROPERTY = "clientId";
+    protected static final String TEST_CLIENT_ID_AUTH_PROPERTY_VALUE = "3e172dd2-901b-43a9-a26a-728466795f01";
+    protected static final String TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE = "9a1da123-7f12-4cd1-bbb4-31e5d9f5e2b3";
+    protected static final String TEST_CLIENT_SECRET_AUTH_PROPERTY = "clientSecret";
+    protected static final String TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE = "83cdc120-ccf6-4163-a4a8-c1ba3e872daa";
+    protected static final String TEST_UPDATED_CLIENT_SECRET_AUTH_PROPERTY_VALUE =
+            "ab12c45e-bd0a-4e1c-9f5e-7d4ab612b8c2";
+    protected static final String TEST_TOKEN_ENDPOINT_AUTH_PROPERTY = "tokenEndpoint";
+    protected static final String TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE = "https://custom.idp.com/token";
+    protected static final String TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE =
+            "https://custom.idp.com/token/updated";
+    protected static final String TEST_SCOPES_AUTH_PROPERTY = "scopes";
+    protected static final String TEST_SCOPES_AUTH_PROPERTY_VALUE = "send_scope";
+    protected static final String TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE = "send_scope read_scope";
     protected static final String TEST_ACTION_INVALID_ID = "invalid_id";
     protected static final String TEST_ACTION_VERSION = "v1";
     protected static final String TEST_ACTION_VERSION_V2 = "v2";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/model/AuthenticationType.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,7 +37,7 @@ public class AuthenticationType {
     @XmlEnum(String.class)
     public enum TypeEnum {
 
-        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL"));
 
         private String value;
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -320,6 +320,150 @@ public class PreIssueAccessTokenActionFailureTest extends ActionTestBase {
         responseOfPost.then().assertThat().statusCode(HttpStatus.SC_CREATED);
 
         return responseOfPost.getBody().jsonPath().getString("id");
+    }
+
+    @Test(dependsOnMethods = {"testDeactivateActionWithInvalidID"})
+    public void testCreateActionWithClientCredentialMissingClientId() {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialMissingClientId"})
+    public void testCreateActionWithClientCredentialMissingClientSecret() {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialMissingClientSecret"})
+    public void testCreateActionWithClientCredentialMissingTokenEndpoint() {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialMissingTokenEndpoint"})
+    public void testCreateActionWithClientCredentialEmptyClientId() {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, "");
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialEmptyClientId"})
+    public void testCreateActionWithClientCredentialEmptyClientSecret() {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, "");
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialEmptyClientSecret"})
+    public void testCreateActionWithClientCredentialEmptyTokenEndpoint() {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, "");
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
     }
 
     private String createActionWithRule() {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionSuccessTest.java
@@ -112,7 +112,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
 
         testActionId = responseOfPost.getBody().jsonPath().getString("id");
     }
@@ -153,7 +155,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testGetActionByActionId"})
@@ -203,7 +207,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingAllProperties"})
@@ -226,7 +232,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingName"})
@@ -250,7 +258,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingEndpoint"})
@@ -279,7 +289,7 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue());
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingAuthentication"})
@@ -308,7 +318,7 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue());
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingAuthenticationProperties"})
@@ -339,7 +349,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingEndpointUriAndAuthentication"})
@@ -370,7 +382,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingEndpointUriAndAuthenticationProperties"})
@@ -401,7 +415,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("rule.condition", equalTo("OR"))
                 .body("rule.rules[0].condition", equalTo("AND"))
                 .body("rule.rules[0].expressions[0].field", equalTo("application"))
@@ -443,7 +459,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("rule.condition", equalTo("OR"))
                 .body("rule.rules[0].condition", equalTo("AND"))
                 .body("rule.rules[0].expressions[0].field", equalTo("application"))
@@ -480,7 +498,9 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("$", not(hasKey("rule")));
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionSuccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -43,6 +43,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests for happy paths of the Action Management REST API.
@@ -613,5 +614,210 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
                 .body("rule.rules[0].expressions[1].value", equalTo("authorization_code"));
 
         deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, responseOfPost.getBody().jsonPath().getString("id"));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithRule"})
+    public void testCreateActionWithClientCredentialAuthentication() {
+
+        ActionModel clientCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        String body = toJSONString(clientCredentialAction);
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("id", notNullValue())
+                .body("name", equalTo(TEST_ACTION_NAME))
+                .body("description", equalTo(TEST_ACTION_DESCRIPTION))
+                .body("version", equalTo(TEST_ACTION_VERSION))
+                .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
+                .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue());
+
+        String createdActionId = responseOfPost.getBody().jsonPath().getString("id");
+
+        // Verify GET by id returns the same auth properties (and clientSecret is still hidden).
+        Response responseOfGet = getResponseOfGet(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialAuthentication"})
+    public void testCreateActionWithClientCredentialAuthenticationWithoutScopes() {
+
+        ActionModel clientCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        String body = toJSONString(clientCredentialAction);
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, responseOfPost.getBody().jsonPath().getString("id"));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialAuthenticationWithoutScopes"})
+    public void testUpdateActionAuthenticationToClientCredential() {
+
+        // Start with a BASIC auth action and update its endpoint auth to CLIENT_CREDENTIAL.
+        ActionModel basicAuthAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.BASIC)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(basicAuthAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdateActionAuthenticationToClientCredential"})
+    public void testUpdateClientCredentialAuthenticationProperties() {
+
+        // Create an action with CLIENT_CREDENTIAL auth and update each property (including secret and scopes).
+        ActionModel clientCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(clientCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY,
+                                            TEST_UPDATED_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                                            TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueidtoken/PreIssueIDTokenActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueidtoken/PreIssueIDTokenActionSuccessTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasKey;
 
 /**
@@ -101,7 +102,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
 
         testActionId = responseOfPost.getBody().jsonPath().getString("id");
     }
@@ -142,7 +145,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testGetActionByActionId"})
@@ -192,7 +197,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingAllProperties"})
@@ -215,7 +222,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingName"})
@@ -239,7 +248,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingEndpoint"})
@@ -268,7 +279,7 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue());
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingAuthentication"})
@@ -297,7 +308,7 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue());
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingAuthenticationProperties"})
@@ -323,7 +334,7 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue())
                 .body("endpoint.allowedHeaders", equalTo(Arrays.asList("user-agent", "host")))
                 .body("endpoint.allowedParameters", equalTo(Arrays.asList("redirect_uri", "scope")));
     }
@@ -356,7 +367,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingEndpointUriAndAuthentication"})
@@ -387,7 +400,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)));
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)));
     }
 
     @Test(dependsOnMethods = {"testUpdateActionUpdatingEndpointUriAndAuthenticationProperties"})
@@ -418,7 +433,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("rule.condition", equalTo("OR"))
                 .body("rule.rules[0].condition", equalTo("AND"))
                 .body("rule.rules[0].expressions[0].field", equalTo("application"))
@@ -460,7 +477,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("rule.condition", equalTo("OR"))
                 .body("rule.rules[0].condition", equalTo("AND"))
                 .body("rule.rules[0].expressions[0].field", equalTo("application"))
@@ -497,7 +516,9 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("$", not(hasKey("rule")));
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordActionSuccessTest.java
@@ -103,7 +103,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_ATTRIBUTES.toArray()));
@@ -147,7 +149,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_ATTRIBUTES.toArray()));
@@ -204,7 +208,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -231,7 +237,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -258,7 +266,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -290,7 +300,7 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue())
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -322,7 +332,7 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue())
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -356,7 +366,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -390,7 +402,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.SHA256_HASHED.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -418,7 +432,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_UPDATED_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -446,7 +462,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing.certificate", equalTo(TEST_CERTIFICATE))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -474,7 +492,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing", not(hasKey(TEST_PROPERTIES_CERTIFICATE_ATTRIBUTE)))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
@@ -501,7 +521,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing", not(hasKey(TEST_PROPERTIES_CERTIFICATE_ATTRIBUTE)))
                 .body("attributes", containsInAnyOrder(TEST_ATTRIBUTES.toArray()));
@@ -528,7 +550,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing", not(hasKey(TEST_PROPERTIES_CERTIFICATE_ATTRIBUTE)))
                 .body("attributes", equalTo(Collections.singletonList(TEST_DUPLICATED_ATTRIBUTES.get(0))));
@@ -614,7 +638,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("passwordSharing.format", equalTo(PasswordSharing.FormatEnum.PLAIN_TEXT.toString()))
                 .body("passwordSharing", not(hasKey(TEST_PROPERTIES_CERTIFICATE_ATTRIBUTE)));
 
@@ -695,7 +721,9 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", equalTo(Collections.singletonList(TEST_DUPLICATED_ATTRIBUTES.get(0))));
 
         deleteAction(PRE_UPDATE_PASSWORD_PATH , responseOfPost.getBody().jsonPath().getString("id"));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileActionSuccessTest.java
@@ -105,7 +105,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_ATTRIBUTES.toArray()));
 
         testActionId = responseOfPost.getBody().jsonPath().getString("id");
@@ -147,7 +149,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_ATTRIBUTES.toArray()));
     }
 
@@ -199,7 +203,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -224,7 +230,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -249,7 +257,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.API_KEY.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_APIKEY_HEADER_AUTH_PROPERTY,
+                        equalTo(TEST_APIKEY_HEADER_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_APIKEY_VALUE_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -279,7 +289,7 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue())
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -309,7 +319,7 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BEARER.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_ACCESS_TOKEN_AUTH_PROPERTY, nullValue())
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -341,7 +351,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_UPDATED_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -373,7 +385,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_UPDATED_ATTRIBUTES.toArray()));
     }
 
@@ -398,7 +412,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", containsInAnyOrder(TEST_ATTRIBUTES.toArray()));
     }
 
@@ -423,7 +439,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", equalTo(Collections.singletonList(TEST_DUPLICATED_ATTRIBUTES.get(0))));
     }
 
@@ -505,7 +523,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", not(hasKey(ATTRIBUTES)));
 
         deleteAction(PRE_UPDATE_PROFILE_PATH, responseOfPost.getBody().jsonPath().getString("id"));
@@ -581,7 +601,9 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
                 .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
                 .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
                 .body("endpoint.authentication.type", equalTo(AuthenticationType.TypeEnum.BASIC.toString()))
-                .body("endpoint.authentication", not(hasKey(TEST_PROPERTIES_AUTH_ATTRIBUTE)))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties", not(hasKey(TEST_PASSWORD_AUTH_PROPERTY)))
                 .body("attributes", equalTo(Collections.singletonList(TEST_DUPLICATED_ATTRIBUTES.get(0))));
 
         deleteAction(PRE_UPDATE_PROFILE_PATH , responseOfPost.getBody().jsonPath().getString("id"));

--- a/pom.xml
+++ b/pom.xml
@@ -2825,7 +2825,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.6.7</identity.server.api.version>
+        <identity.server.api.version>1.6.8</identity.server.api.version>
         <identity.user.api.version>1.5.6</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
- Add integration tests for client credentials–based authentication support in Actions.

- Related Issue: https://github.com/wso2/product-is/issues/27681