### PR TITLE
Add passkey integration for authentication flows

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyAppNativeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyAppNativeTest.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.passkey;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * App-native authentication integration tests for passkey flows.
+ */
+public class PasskeyAppNativeTest extends PasskeyTestBase {
+
+    private static final String APP_NAME = "PasskeyAppNativeTestApp";
+    private static final String MFA_APP_NAME = "PasskeyMFAAppNativeTestApp";
+    private static final String ENROLL_APP_NAME = "PasskeyEnrollmentApp";
+    private static final String CALLBACK_URL = "https://example.com/oidc-callback";
+
+    private static final String FLOW_STATUS_SUCCESS = "SUCCESS_COMPLETED";
+
+    private static final String TEST_USERNAME = "passkey_appnative_user";
+    private static final String TEST_PASSWORD = "Passkey@AppNative123";
+    private static final String TEST_EMAIL = "passkey_appnative_user@wso2.com";
+
+    private static final String MFA_USERNAME = "passkey_mfa_appnative_user";
+    private static final String MFA_PASSWORD = "Passkey@MFAAppNative123";
+    private static final String MFA_EMAIL = "passkey_mfa_appnative_user@wso2.com";
+
+    private String appId;
+    private String appClientId;
+    private String mfaAppId;
+    private String mfaClientId;
+    private String enrollAppId;
+    private String enrollClientId;
+    private String enrollClientSecret;
+    private String testUserId;
+    private String mfaUserId;
+    private SCIM2RestClient scim2RestClient;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public PasskeyAppNativeTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        restClient = new OAuth2RestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        testUserId = createTestUser(scim2RestClient, TEST_USERNAME, TEST_PASSWORD, TEST_EMAIL);
+        mfaUserId = createTestUser(scim2RestClient, MFA_USERNAME, MFA_PASSWORD, MFA_EMAIL);
+
+        // A dedicated app with password grant is used solely to obtain user tokens.
+        enrollAppId = addPasswordGrantApp(ENROLL_APP_NAME, CALLBACK_URL);
+        OpenIDConnectConfiguration enrollConfig = getOIDCInboundDetailsOfApplication(enrollAppId);
+        enrollClientId = enrollConfig.getClientId();
+        enrollClientSecret = enrollConfig.getClientSecret();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() throws Exception {
+
+        if (appId != null) {
+            deleteApp(appId);
+        }
+        if (mfaAppId != null) {
+            deleteApp(mfaAppId);
+        }
+        if (enrollAppId != null) {
+            deleteApp(enrollAppId);
+        }
+        if (testUserId != null) {
+            deleteTestUser(scim2RestClient, testUserId);
+        }
+        if (mfaUserId != null) {
+            deleteTestUser(scim2RestClient, mfaUserId);
+        }
+        setUsernameLessAuthenticationEnabled(true);
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        clearAllCredentials();
+    }
+
+    @Test(description = "Create an OIDC app with passkey as the sole first-factor authenticator.")
+    public void testCreatePasskeyFirstFactorApp() throws Exception {
+
+        setUsernameLessAuthenticationEnabled(true);
+        Assert.assertTrue(isUsernameLessAuthenticationEnabled(),
+                "Username-less authentication should be enabled.");
+
+        appId = addOIDCAppWithPasskeyForAppNative(APP_NAME, CALLBACK_URL);
+        Assert.assertNotNull(appId, "Application ID should not be null after creation.");
+        appClientId = getOIDCInboundDetailsOfApplication(appId).getClientId();
+    }
+
+    @Test(description = "Pre-enroll a passkey for the test user via the My Account WebAuthn API.",
+            dependsOnMethods = "testCreatePasskeyFirstFactorApp")
+    public void testEnrollPasskeyViaMyAccount() throws Exception {
+
+        enrollPasskeyForUser(TEST_USERNAME, TEST_PASSWORD, enrollClientId, enrollClientSecret);
+    }
+
+    @Test(description = "Verify passkey login (usernameless) via app-native authentication.",
+            dependsOnMethods = "testEnrollPasskeyViaMyAccount")
+    public void testPasskeyLoginViaAppNative() throws Exception {
+
+        String origin = serverURL.replaceAll("/$", "");
+        String rpId = new URI(serverURL).getHost();
+
+        // Step 1: Initiate app-native authorization — get flowId and the passkey authenticator info.
+        AuthnState state = initiateAppNativeAuthorization(appClientId);
+
+        // Step 2: Run the WebAuthn assertion ceremony and exchange the result for an auth code.
+        String code = performPasskeyAssertion(state, rpId, origin, TEST_USERNAME);
+        Assert.assertNotNull(code,
+                "Authorization code should be present after successful passkey login.");
+    }
+
+    @Test(description = "Create an OIDC app with passkey configured as the second authentication " +
+            "factor (BasicAuthenticator → FIDOAuthenticator).",
+            dependsOnMethods = "testPasskeyLoginViaAppNative")
+    public void testCreateMFAPasskeyApp() throws Exception {
+
+        mfaAppId = addOIDCAppWithMFAPasskeyForAppNative(MFA_APP_NAME, CALLBACK_URL);
+        Assert.assertNotNull(mfaAppId, "MFA application ID should not be null after creation.");
+        mfaClientId = getOIDCInboundDetailsOfApplication(mfaAppId).getClientId();
+    }
+
+    @Test(description = "Pre-enroll a passkey for the MFA test user via the My Account WebAuthn API.",
+            dependsOnMethods = "testCreateMFAPasskeyApp")
+    public void testEnrollMFAPasskeyViaMyAccount() throws Exception {
+
+        enrollPasskeyForUser(MFA_USERNAME, MFA_PASSWORD, enrollClientId, enrollClientSecret);
+    }
+
+    @Test(description = "Verify MFA passkey login via app-native authentication: the user first " +
+            "completes BasicAuthenticator and then authenticates with a passkey.",
+            dependsOnMethods = "testEnrollMFAPasskeyViaMyAccount")
+    public void testMFAPasskeyLoginViaAppNative() throws Exception {
+
+        String origin = serverURL.replaceAll("/$", "");
+        String rpId = new URI(serverURL).getHost();
+
+        // Step 1: Initiate app-native authorization — first step is BasicAuthenticator.
+        AuthnState state = initiateAppNativeAuthorization(mfaClientId);
+
+        // Step 2: Complete the basic authentication step with username and password.
+        // The response contains the next step's authenticator (FIDOAuthenticator).
+        state = completeBasicAuth(state.flowId, state.authenticatorId, MFA_USERNAME, MFA_PASSWORD);
+
+        // Step 3: Run the WebAuthn assertion ceremony and exchange the result for an auth code.
+        String code = performPasskeyAssertion(state, rpId, origin, MFA_USERNAME);
+        Assert.assertNotNull(code,
+                "Authorization code should be present after successful MFA passkey login.");
+    }
+
+    @Test(description = "Verify that MFA passkey login fails when the passkey credential presented " +
+            "belongs to a different user than the one who completed the basic authentication step.",
+            dependsOnMethods = "testMFAPasskeyLoginViaAppNative")
+    public void testMFAPasskeyLoginWithWrongCredentialViaAppNative() throws Exception {
+
+        String origin = serverURL.replaceAll("/$", "");
+        String rpId = new URI(serverURL).getHost();
+
+        // Step 1: Initiate app-native authorization — first step is BasicAuthenticator.
+        AuthnState state = initiateAppNativeAuthorization(mfaClientId);
+
+        // Step 2: Complete the basic authentication step with MFA_USERNAME credentials.
+        state = completeBasicAuth(state.flowId, state.authenticatorId, MFA_USERNAME, MFA_PASSWORD);
+
+        // Step 3: Decode the challenge and extract request options.
+        byte[] challengeBytes = base64UrlDecode(state.challengeData);
+        JSONObject challengeJson = (JSONObject) new JSONParser()
+                .parse(new String(challengeBytes, StandardCharsets.UTF_8));
+
+        String requestId = (String) challengeJson.get("requestId");
+        JSONObject pkOptions = (JSONObject) challengeJson.get("publicKeyCredentialRequestOptions");
+        String challenge = (String) pkOptions.get("challenge");
+        String resolvedRpId = pkOptions.containsKey("rpId") ? (String) pkOptions.get("rpId") : rpId;
+
+        // Step 4: Intentionally sign with TEST_USERNAME's credential. The credential ID is not in
+        // MFA_USERNAME's allowCredentials list, so the server must reject the assertion.
+        String tokenResponseJson = authenticatePasskey(requestId, challenge, resolvedRpId, origin, TEST_USERNAME);
+        String encodedTokenResponse = Base64.getEncoder()
+                .encodeToString(tokenResponseJson.getBytes(StandardCharsets.UTF_8));
+
+        String body = "{\"flowId\":\"" + state.flowId + "\","
+                + "\"selectedAuthenticator\":{"
+                + "\"authenticatorId\":\"" + state.authenticatorId + "\","
+                + "\"params\":{\"tokenResponse\":\"" + encodedTokenResponse + "\"}}}";
+
+        // Step 5: POST the mismatched assertion and verify the server rejects it.
+        JSONObject response = postToAuthn(body);
+        String flowStatus = (String) response.get("flowStatus");
+        Assert.assertNotEquals(flowStatus, FLOW_STATUS_SUCCESS,
+                "Flow should not succeed when the passkey credential belongs to a different user " +
+                        "than the one who completed the basic authentication step.");
+    }
+
+    /**
+     * POSTs to {@code /oauth2/authorize} with {@code response_mode=direct} to start an app-native
+     * flow. Returns the initial {@link AuthnState} containing the flowId, authenticatorId of the
+     * first authenticator in the response, and optionally the passkey {@code challengeData} if the
+     * server already included it (single-option {@code AUTHENTICATOR_PROMPT} step).
+     */
+    private AuthnState initiateAppNativeAuthorization(String clientId) throws Exception {
+
+        String authorizeUrl = getTenantQualifiedURL(
+                OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain());
+
+        try (CloseableHttpClient client = createTrustAllHttpClient()) {
+            HttpPost post = new HttpPost(authorizeUrl);
+            post.setHeader("Accept", "application/json");
+            post.setHeader("Content-Type", "application/x-www-form-urlencoded");
+
+            List<NameValuePair> params = new ArrayList<>();
+            params.add(new BasicNameValuePair("client_id", clientId));
+            params.add(new BasicNameValuePair("response_type", "code"));
+            params.add(new BasicNameValuePair("redirect_uri", CALLBACK_URL));
+            params.add(new BasicNameValuePair("scope", "openid"));
+            params.add(new BasicNameValuePair("response_mode", "direct"));
+            post.setEntity(new UrlEncodedFormEntity(params));
+
+            HttpResponse response = client.execute(post);
+            String body = EntityUtils.toString(response.getEntity());
+            JSONObject json = (JSONObject) new JSONParser().parse(body);
+
+            String flowId = (String) json.get("flowId");
+            JSONObject nextStep = (JSONObject) json.get("nextStep");
+            Assert.assertNotNull(nextStep,
+                    "Expected 'nextStep' in authorize response but got: " + body);
+            JSONArray authenticators = (JSONArray) nextStep.get("authenticators");
+            JSONObject authenticator = (JSONObject) authenticators.get(0);
+            String authenticatorId = (String) authenticator.get("authenticatorId");
+            String challengeData = extractChallengeData(authenticator);
+
+            return new AuthnState(flowId, authenticatorId, challengeData);
+        }
+    }
+
+    /**
+     * POSTs username and password to {@code /oauth2/authn} to complete the BasicAuthenticator step
+     * in an MFA flow. Returns an {@link AuthnState} representing the next step (FIDOAuthenticator),
+     * including the {@code challengeData} if the server already provided it.
+     */
+    private AuthnState completeBasicAuth(String flowId, String authenticatorId,
+            String username, String password) throws Exception {
+
+        String body = "{\"flowId\":\"" + flowId + "\","
+                + "\"selectedAuthenticator\":{"
+                + "\"authenticatorId\":\"" + authenticatorId + "\","
+                + "\"params\":{\"username\":\"" + username + "\","
+                + "\"password\":\"" + password + "\"}}}";
+        JSONObject response = postToAuthn(body);
+
+        return extractAuthnState(flowId, response);
+    }
+
+    /**
+     * Decodes the {@code challengeData} from the server, runs the virtual WebAuthn assertion
+     * ceremony via {@link #authenticatePasskey}, base64-encodes the result, and POSTs it to
+     * {@code /oauth2/authn} as the {@code tokenResponse}. Returns the authorization code from the
+     * {@code SUCCESS_COMPLETED} response.
+     */
+    private String performPasskeyAssertion(AuthnState state, String rpId, String origin,
+            String username) throws Exception {
+
+        byte[] challengeBytes = base64UrlDecode(state.challengeData);
+        JSONObject challengeJson = (JSONObject) new JSONParser()
+                .parse(new String(challengeBytes, StandardCharsets.UTF_8));
+
+        String requestId = (String) challengeJson.get("requestId");
+        JSONObject pkOptions = (JSONObject) challengeJson.get("publicKeyCredentialRequestOptions");
+        String challenge = (String) pkOptions.get("challenge");
+        String resolvedRpId = pkOptions.containsKey("rpId") ? (String) pkOptions.get("rpId") : rpId;
+
+        String tokenResponseJson = authenticatePasskey(requestId, challenge, resolvedRpId, origin, username);
+        String encodedTokenResponse = Base64.getEncoder()
+                .encodeToString(tokenResponseJson.getBytes(StandardCharsets.UTF_8));
+
+        String body = "{\"flowId\":\"" + state.flowId + "\","
+                + "\"selectedAuthenticator\":{"
+                + "\"authenticatorId\":\"" + state.authenticatorId + "\","
+                + "\"params\":{\"tokenResponse\":\"" + encodedTokenResponse + "\"}}}";
+
+        JSONObject response = postToAuthn(body);
+
+        String flowStatus = (String) response.get("flowStatus");
+        Assert.assertEquals(flowStatus, FLOW_STATUS_SUCCESS,
+                "Flow status should be SUCCESS_COMPLETED after passkey assertion.");
+
+        JSONObject authData = (JSONObject) response.get("authData");
+        Assert.assertNotNull(authData, "authData must be present in the success response.");
+        return (String) authData.get("code");
+    }
+
+    /**
+     * Makes a JSON POST to the tenant-qualified {@code /oauth2/authn/} endpoint.
+     */
+    private JSONObject postToAuthn(String jsonBody) throws Exception {
+
+        String authnUrl = getTenantQualifiedURL(
+                OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                .replaceAll("oauth2/authorize/?$", "oauth2/authn/");
+
+        try (CloseableHttpClient client = createTrustAllHttpClient()) {
+            HttpPost post = new HttpPost(authnUrl);
+            post.setHeader("Content-Type", "application/json");
+            post.setEntity(new StringEntity(jsonBody, StandardCharsets.UTF_8));
+
+            HttpResponse response = client.execute(post);
+            String body = EntityUtils.toString(response.getEntity());
+            return (JSONObject) new JSONParser().parse(body);
+        }
+    }
+
+    /**
+     * Extracts the authenticatorId and challengeData from the {@code nextStep.authenticators[0]}
+     * of an {@code /authn} response.
+     */
+    private AuthnState extractAuthnState(String flowId, JSONObject authnResponse) {
+
+        JSONObject nextStep = (JSONObject) authnResponse.get("nextStep");
+        Assert.assertNotNull(nextStep,
+                "Expected 'nextStep' in authn response but got: " + authnResponse.toJSONString());
+        JSONArray authenticators = (JSONArray) nextStep.get("authenticators");
+        JSONObject authenticator = (JSONObject) authenticators.get(0);
+        String authenticatorId = (String) authenticator.get("authenticatorId");
+        String challengeData = extractChallengeData(authenticator);
+        return new AuthnState(flowId, authenticatorId, challengeData);
+    }
+
+    /**
+     * Returns the {@code challengeData} string from {@code authenticator.metadata.additionalData},
+     * or {@code null} if the metadata or the field is absent.
+     */
+    private String extractChallengeData(JSONObject authenticator) {
+
+        JSONObject metadata = (JSONObject) authenticator.get("metadata");
+        if (metadata == null) {
+            return null;
+        }
+        JSONObject additionalData = (JSONObject) metadata.get("additionalData");
+        if (additionalData == null) {
+            return null;
+        }
+        return (String) additionalData.get("challengeData");
+    }
+
+    /**
+     * Holds the mutable state carried across steps of an app-native authentication flow.
+     */
+    private static class AuthnState {
+
+        final String flowId;
+        final String authenticatorId;
+        final String challengeData;
+
+        AuthnState(String flowId, String authenticatorId, String challengeData) {
+
+            this.flowId = flowId;
+            this.authenticatorId = authenticatorId;
+            this.challengeData = challengeData;
+        }
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyClient.java
@@ -41,10 +41,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+
 /**
  * Base class for passkey integration tests.
  */
-public abstract class PasskeyClient {
+public abstract class PasskeyClient extends OAuth2ServiceAbstractIntegrationTest {
 
     protected static final String WEBAUTHN_CREATE = "webauthn.create";
     protected static final String WEBAUTHN_GET = "webauthn.get";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyClient.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.passkey;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECPoint;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for passkey integration tests.
+ */
+public abstract class PasskeyClient {
+
+    protected static final String WEBAUTHN_CREATE = "webauthn.create";
+    protected static final String WEBAUTHN_GET = "webauthn.get";
+
+    /**
+     * Represents a stored passkey credential in the virtual authenticator.
+     */
+    public static class StoredCredential {
+
+        private final byte[] credentialId;
+        private final KeyPair keyPair;
+        private final byte[] userHandle;
+        private final String userName;
+        private int signCount;
+
+        StoredCredential(byte[] credentialId, KeyPair keyPair, byte[] userHandle, String userName) {
+
+            this.credentialId = credentialId;
+            this.keyPair = keyPair;
+            this.userHandle = userHandle;
+            this.userName = userName;
+            this.signCount = 0;
+        }
+
+        public byte[] getCredentialId() { return credentialId; }
+        public KeyPair getKeyPair() { return keyPair; }
+        public byte[] getUserHandle() { return userHandle; }
+        public String getUserName() { return userName; }
+        public int getSignCount() { return signCount; }
+        int incrementSignCount() { return ++signCount; }
+    }
+
+    private final Map<String, List<StoredCredential>> credentialStore = new LinkedHashMap<>();
+
+    /**
+     * Returns all stored credentials for the given rpId.
+     */
+    protected List<StoredCredential> getCredentialsForRpId(String rpId) {
+
+        return Collections.unmodifiableList(credentialStore.getOrDefault(rpId, Collections.emptyList()));
+    }
+
+    /**
+     * Finds a stored credential by rpId and userName.
+     */
+    protected StoredCredential findCredentialByUser(String rpId, String userName) {
+
+        for (StoredCredential c : credentialStore.getOrDefault(rpId, Collections.emptyList())) {
+            if (userName.equals(c.getUserName())) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds a stored credential by rpId and base64url-encoded credentialId.
+     */
+    protected StoredCredential findCredentialById(String rpId, String credentialId) {
+
+        for (StoredCredential c : credentialStore.getOrDefault(rpId, Collections.emptyList())) {
+            if (base64UrlEncode(c.getCredentialId()).equals(credentialId)) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Removes all stored credentials. Call in test tear-down.
+     */
+    protected void clearAllCredentials() {
+
+        credentialStore.clear();
+    }
+
+    /**
+     * Performs the WebAuthn registration ceremony, stores the credential, and returns
+     * the challengeResponse JSON for FINISH_FIDO_ENROLL.
+     *
+     * @param requestId   from publicKeyCredentialCreationOptions
+     * @param challenge   base64url challenge from creation options
+     * @param rpId        relying party ID (e.g., "localhost")
+     * @param origin      RP origin (e.g., "https://localhost:9443")
+     * @param userName    used to retrieve the credential during authentication
+     * @param userHandle  base64url-decoded user.id from creation options
+     */
+    protected String registerPasskey(String requestId, String challenge, String rpId,
+            String origin, String userName, byte[] userHandle) throws Exception {
+
+        KeyPair keyPair = generateKeyPair();
+        byte[] credentialId = generateCredentialId();
+
+        credentialStore.computeIfAbsent(rpId, k -> new ArrayList<>())
+                .add(new StoredCredential(credentialId, keyPair, userHandle, userName));
+
+        byte[] clientDataJSON = buildClientDataJSON(WEBAUTHN_CREATE, challenge, origin);
+        byte[] authData = buildAuthenticatorDataForRegistration(rpId, credentialId, (ECPublicKey) keyPair.getPublic());
+        byte[] attestationObject = buildAttestationObject(authData);
+        return buildRegistrationChallengeResponse(requestId, credentialId, attestationObject, clientDataJSON);
+    }
+
+    /**
+     * Performs the WebAuthn authentication ceremony using the stored credential for the
+     * given user and returns the tokenResponse JSON.
+     *
+     * @param requestId   from publicKeyCredentialRequestOptions
+     * @param challenge   base64url challenge from request options
+     * @param rpId        relying party ID
+     * @param origin      RP origin
+     * @param userName    identifies which stored credential to use
+     */
+    protected String authenticatePasskey(String requestId, String challenge, String rpId,
+            String origin, String userName) throws Exception {
+
+        StoredCredential credential = findCredentialByUser(rpId, userName);
+        if (credential == null) {
+            throw new IllegalStateException("No stored credential for rpId=" + rpId + ", user=" + userName);
+        }
+        return buildAuthenticationResponse(requestId, challenge, rpId, origin, credential);
+    }
+
+    /**
+     * Builds the clientDataJSON bytes for a WebAuthn ceremony.
+     */
+    protected byte[] buildClientDataJSON(String type, String challenge, String origin) {
+
+        String json = "{\"type\":\"" + type + "\","
+                + "\"challenge\":\"" + challenge + "\","
+                + "\"origin\":\"" + origin + "\","
+                + "\"crossOrigin\":false}";
+        return json.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Builds the binary authenticatorData for registration (includes attested credential data).
+     *
+     * Layout: rpIdHash(32) | flags(1) | signCount(4) | aaguid(16) | credIdLen(2) | credentialId | coseKey
+     */
+    protected byte[] buildAuthenticatorDataForRegistration(String rpId, byte[] credentialId,
+            ECPublicKey publicKey) throws NoSuchAlgorithmException, IOException {
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(sha256(rpId.getBytes(StandardCharsets.UTF_8)));
+        out.write(0x45);                // flags: UP | UV | AT
+        out.write(new byte[]{0, 0, 0, 0}); // signCount
+        out.write(new byte[16]);           // aaguid (zeros)
+        out.write((byte) ((credentialId.length >> 8) & 0xff));
+        out.write((byte) (credentialId.length & 0xff));
+        out.write(credentialId);
+        out.write(encodeCosePublicKey(publicKey));
+        return out.toByteArray();
+    }
+
+    /**
+     * Builds the binary authenticatorData for an assertion (no attested credential data).
+     *
+     * Layout: rpIdHash(32) | flags(1) | signCount(4)
+     */
+    protected byte[] buildAuthenticatorDataForAssertion(String rpId, int signCount)
+            throws NoSuchAlgorithmException, IOException {
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(sha256(rpId.getBytes(StandardCharsets.UTF_8)));
+        out.write(0x05);                // flags: UP | UV
+        out.write((signCount >> 24) & 0xff);
+        out.write((signCount >> 16) & 0xff);
+        out.write((signCount >> 8) & 0xff);
+        out.write(signCount & 0xff);
+        return out.toByteArray();
+    }
+
+    /**
+     * CBOR-encodes an EC P-256 public key as a COSE_Key map: {1:2, 3:-7, -1:1, -2:x, -3:y}.
+     */
+    protected byte[] encodeCosePublicKey(ECPublicKey publicKey) throws IOException {
+
+        ECPoint w = publicKey.getW();
+        byte[] x = toFixedLengthUnsignedBytes(w.getAffineX().toByteArray(), 32);
+        byte[] y = toFixedLengthUnsignedBytes(w.getAffineY().toByteArray(), 32);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0xa5);
+        out.write(0x01); out.write(0x02); // kty: EC2
+        out.write(0x03); out.write(0x26); // alg: ES256
+        out.write(0x20); out.write(0x01); // crv: P-256
+        out.write(0x21); writeCborBytes(out, x); // x
+        out.write(0x22); writeCborBytes(out, y); // y
+        return out.toByteArray();
+    }
+
+    /**
+     * Builds an attestationObject with fmt="none".
+     *
+     * CBOR map: {"fmt":"none","attStmt":{},"authData":{@code authenticatorData}}
+     */
+    protected byte[] buildAttestationObject(byte[] authenticatorData) throws IOException {
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(0xa3);
+        writeCborText(out, "fmt");     writeCborText(out, "none");
+        writeCborText(out, "attStmt"); out.write(0xa0);
+        writeCborText(out, "authData"); writeCborBytes(out, authenticatorData);
+        return out.toByteArray();
+    }
+
+    /**
+     * Signs {@code authenticatorData || SHA-256(clientDataJSON)} with the credential's private key.
+     */
+    protected byte[] signAssertion(byte[] authenticatorData, byte[] clientDataJSON, PrivateKey privateKey)
+            throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+
+        byte[] data = concat(authenticatorData, sha256(clientDataJSON));
+        Signature sig = Signature.getInstance("SHA256withECDSA");
+        sig.initSign(privateKey);
+        sig.update(data);
+        return sig.sign();
+    }
+
+    /**
+     * Builds the challengeResponse JSON for scenario=FINISH_FIDO_ENROLL.
+     */
+    protected String buildRegistrationChallengeResponse(String requestId, byte[] credentialId,
+            byte[] attestationObject, byte[] clientDataJSON) {
+
+        return "{\"requestId\":\"" + requestId + "\","
+                + "\"credential\":{"
+                + "\"id\":\"" + base64UrlEncode(credentialId) + "\","
+                + "\"response\":{"
+                + "\"attestationObject\":\"" + base64UrlEncode(attestationObject) + "\","
+                + "\"clientDataJSON\":\"" + base64UrlEncode(clientDataJSON) + "\"},"
+                + "\"clientExtensionResults\":{\"credProps\":{\"rk\":true}},"
+                + "\"type\":\"public-key\"}}";
+    }
+
+    /**
+     * Builds the tokenResponse JSON for passkey authentication.
+     */
+    protected String buildLoginTokenResponse(String requestId, byte[] credentialId,
+            byte[] authenticatorData, byte[] clientDataJSON, byte[] signature, byte[] userHandle) {
+
+        return "{\"requestId\":\"" + requestId + "\","
+                + "\"credential\":{"
+                + "\"id\":\"" + base64UrlEncode(credentialId) + "\","
+                + "\"response\":{"
+                + "\"authenticatorData\":\"" + base64UrlEncode(authenticatorData) + "\","
+                + "\"clientDataJSON\":\"" + base64UrlEncode(clientDataJSON) + "\","
+                + "\"signature\":\"" + base64UrlEncode(signature) + "\","
+                + "\"userHandle\":\"" + base64UrlEncode(userHandle) + "\"},"
+                + "\"clientExtensionResults\":{},"
+                + "\"type\":\"public-key\"}}";
+    }
+
+    protected KeyPair generateKeyPair() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
+        gen.initialize(new ECGenParameterSpec("secp256r1"), new SecureRandom());
+        return gen.generateKeyPair();
+    }
+
+    protected byte[] generateCredentialId() {
+
+        byte[] id = new byte[16];
+        new SecureRandom().nextBytes(id);
+        return id;
+    }
+
+    protected String base64UrlEncode(byte[] data) {
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    protected byte[] base64UrlDecode(String data) {
+
+        return Base64.getUrlDecoder().decode(data);
+    }
+
+    protected byte[] sha256(byte[] data) throws NoSuchAlgorithmException {
+
+        return MessageDigest.getInstance("SHA-256").digest(data);
+    }
+
+    private String buildAuthenticationResponse(String requestId, String challenge, String rpId,
+            String origin, StoredCredential credential) throws Exception {
+
+        int signCount = credential.incrementSignCount();
+        byte[] clientDataJSON = buildClientDataJSON(WEBAUTHN_GET, challenge, origin);
+        byte[] authData = buildAuthenticatorDataForAssertion(rpId, signCount);
+        byte[] signature = signAssertion(authData, clientDataJSON, credential.getKeyPair().getPrivate());
+        return buildLoginTokenResponse(requestId, credential.getCredentialId(),
+                authData, clientDataJSON, signature, credential.getUserHandle());
+    }
+
+    private void writeCborBytes(ByteArrayOutputStream out, byte[] data) throws IOException {
+
+        if (data.length <= 23) {
+            out.write(0x40 | data.length);
+        } else if (data.length <= 0xff) {
+            out.write(0x58);
+            out.write(data.length);
+        } else {
+            out.write(0x59);
+            out.write((data.length >> 8) & 0xff);
+            out.write(data.length & 0xff);
+        }
+        out.write(data);
+    }
+
+    private void writeCborText(ByteArrayOutputStream out, String text) throws IOException {
+
+        byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= 23) {
+            out.write(0x60 | bytes.length);
+        } else {
+            out.write(0x78);
+            out.write(bytes.length);
+        }
+        out.write(bytes);
+    }
+
+    private byte[] toFixedLengthUnsignedBytes(byte[] signed, int length) {
+
+        byte[] result = new byte[length];
+        if (signed.length <= length) {
+            System.arraycopy(signed, 0, result, length - signed.length, signed.length);
+        } else {
+            System.arraycopy(signed, signed.length - length, result, 0, length);
+        }
+        return result;
+    }
+
+    private byte[] concat(byte[] a, byte[] b) {
+
+        byte[] result = new byte[a.length + b.length];
+        System.arraycopy(a, 0, result, 0, a.length);
+        System.arraycopy(b, 0, result, a.length, b.length);
+        return result;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyRedirectBasedTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyRedirectBasedTest.java
@@ -66,8 +66,13 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
     private static final String TEST_PASSWORD = "Passkey@Test123";
     private static final String TEST_EMAIL = "passkey_test_user@wso2.com";
 
+    private static final String SECOND_TEST_USERNAME = "passkey_test_user2";
+    private static final String SECOND_TEST_PASSWORD = "Passkey@Test456";
+    private static final String SECOND_TEST_EMAIL = "passkey_test_user2@wso2.com";
+
     private String appId;
     private String testUserId;
+    private String secondTestUserId;
     private SCIM2RestClient scim2RestClient;
 
     @Factory(dataProvider = "restAPIUserConfigProvider")
@@ -91,6 +96,8 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
         restClient = new OAuth2RestClient(serverURL, tenantInfo);
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
         testUserId = createTestUser(scim2RestClient, TEST_USERNAME, TEST_PASSWORD, TEST_EMAIL);
+        secondTestUserId = createTestUser(scim2RestClient, SECOND_TEST_USERNAME, SECOND_TEST_PASSWORD,
+                SECOND_TEST_EMAIL);
     }
 
     @AfterClass(alwaysRun = true)
@@ -101,6 +108,9 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
         }
         if (testUserId != null) {
             deleteTestUser(scim2RestClient, testUserId);
+        }
+        if (secondTestUserId != null) {
+            deleteTestUser(scim2RestClient, secondTestUserId);
         }
         setPasskeyProgressiveEnrollmentEnabled(false);
         setUsernameLessAuthenticationEnabled(true);
@@ -306,6 +316,316 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
                     "Final redirect should target the configured callback URL.");
             Assert.assertTrue(callbackWithCode.contains("code="),
                     "Authorization code should be present in the callback URL.");
+        }
+    }
+
+    @Test(description = "Disable username-less authentication to verify the IDF username step is enforced.",
+            dependsOnMethods = "testPasskeyLoginWithRegisteredCredential")
+    public void testDisableUsernameLessAuthentication() throws Exception {
+
+        setUsernameLessAuthenticationEnabled(false);
+        Assert.assertFalse(isUsernameLessAuthenticationEnabled(),
+                "Passkey username-less authentication should be disabled.");
+    }
+
+    @Test(description = "Verify passkey login when username-less authentication is disabled: " +
+            "an IDF username step must be completed before the WebAuthn assertion.",
+            dependsOnMethods = "testDisableUsernameLessAuthentication")
+    public void testPasskeyLoginWithUsernameLessDisabled() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page.
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Select the FIDOAuthenticator to start the passkey authentication flow.
+            List<NameValuePair> selectPasskeyParams = new ArrayList<>();
+            selectPasskeyParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            selectPasskeyParams.add(new BasicNameValuePair("authenticator", "FIDOAuthenticator"));
+            selectPasskeyParams.add(new BasicNameValuePair("idp", "LOCAL"));
+            response = sendPostRequestWithParameters(httpClient, selectPasskeyParams, commonAuthUrl);
+            Header fidoPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            if (fidoPageHeader != null) {
+                response = sendGetRequest(httpClient, fidoPageHeader.getValue());
+                EntityUtils.consume(response.getEntity());
+            }
+
+            // Step 4: Submit the username via the IDF step. When username-less authentication is disabled
+            // the server requires the username before it can issue a WebAuthn challenge.
+            List<NameValuePair> idfParams = new ArrayList<>();
+            idfParams.add(new BasicNameValuePair("username", TEST_USERNAME));
+            idfParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            idfParams.add(new BasicNameValuePair("scenario", "INIT_FIDO_AUTH"));
+            idfParams.add(new BasicNameValuePair("authType", "idf"));
+            response = sendPostRequestWithParameters(httpClient, idfParams, commonAuthUrl);
+
+            // Step 5: Parse the WebAuthn request options from the fido2-auth.jsp redirect URL.
+            Header fidoAuthPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            Assert.assertNotNull(fidoAuthPageHeader,
+                    "Expected a redirect to fido2-auth.jsp after submitting the username in IDF step.");
+            String fidoAuthJspUrl = fidoAuthPageHeader.getValue();
+
+            JSONObject requestData = extractRequestOptionsFromUrl(fidoAuthJspUrl);
+            String requestId = (String) requestData.get("requestId");
+            JSONObject pkOptions = (JSONObject) requestData.get("publicKeyCredentialRequestOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = pkOptions.containsKey("rpId")
+                    ? (String) pkOptions.get("rpId")
+                    : new URI(serverURL).getHost();
+
+            // Step 6: Perform the WebAuthn authentication ceremony using the stored credential.
+            String tokenResponse = authenticatePasskey(requestId, challenge, rpId, origin, TEST_USERNAME);
+
+            // Step 7: POST the assertion response to complete the passkey login.
+            List<NameValuePair> finishLoginParams = new ArrayList<>();
+            finishLoginParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishLoginParams.add(new BasicNameValuePair("tokenResponse", tokenResponse));
+            response = sendPostRequestWithParameters(httpClient, finishLoginParams, commonAuthUrl);
+
+            // Step 8: Follow the redirect chain until the callback URL with an authorization code appears.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL after successful passkey login.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Final redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("code="),
+                    "Authorization code should be present in the callback URL.");
+        }
+    }
+
+    @Test(description = "Register a passkey for the second test user via progressive enrollment.",
+            dependsOnMethods = "testPasskeyLoginWithUsernameLessDisabled")
+    public void testPasskeyRegistrationForSecondUser() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page.
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Select the FIDOAuthenticator from the multi-option login page.
+            List<NameValuePair> selectPasskeyParams = new ArrayList<>();
+            selectPasskeyParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            selectPasskeyParams.add(new BasicNameValuePair("authenticator", "FIDOAuthenticator"));
+            selectPasskeyParams.add(new BasicNameValuePair("idp", "LOCAL"));
+            response = sendPostRequestWithParameters(httpClient, selectPasskeyParams, commonAuthUrl);
+            Header fidoPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            if (fidoPageHeader != null) {
+                response = sendGetRequest(httpClient, fidoPageHeader.getValue());
+                EntityUtils.consume(response.getEntity());
+            }
+
+            // Step 4: POST INIT_FIDO_ENROLL to trigger the passkey progressive enrollment flow.
+            // Since username-less authentication is disabled, the username and authType=idf are required
+            // so the server can identify the user before initiating the enrollment ceremony.
+            List<NameValuePair> initEnrollParams = new ArrayList<>();
+            initEnrollParams.add(new BasicNameValuePair("username", SECOND_TEST_USERNAME));
+            initEnrollParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            initEnrollParams.add(new BasicNameValuePair("scenario", "INIT_FIDO_ENROLL"));
+            initEnrollParams.add(new BasicNameValuePair("authType", "idf"));
+            response = sendPostRequestWithParameters(httpClient, initEnrollParams, commonAuthUrl);
+            Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            if (locationHeader != null) {
+                response = sendGetRequest(httpClient, locationHeader.getValue());
+                EntityUtils.consume(response.getEntity());
+            }
+
+            // Step 5: POST the second user's credentials to identify them for enrollment.
+            List<NameValuePair> credentialParams = new ArrayList<>();
+            credentialParams.add(new BasicNameValuePair("username", SECOND_TEST_USERNAME));
+            credentialParams.add(new BasicNameValuePair("password", SECOND_TEST_PASSWORD));
+            credentialParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            response = sendPostRequestWithParameters(httpClient, credentialParams, commonAuthUrl);
+
+            // Step 6: Extract the WebAuthn creation options from the fido2-enroll.jsp redirect URL.
+            locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            Assert.assertNotNull(locationHeader,
+                    "Expected a redirect to fido2-enroll.jsp from the authorize endpoint.");
+            String enrollJspUrl = locationHeader.getValue();
+            EntityUtils.consume(response.getEntity());
+
+            JSONObject creationData = extractCreationOptionsFromUrl(enrollJspUrl);
+            String requestId = (String) creationData.get("requestId");
+            JSONObject pkOptions = (JSONObject) creationData.get("publicKeyCredentialCreationOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = (String) ((JSONObject) pkOptions.get("rp")).get("id");
+            byte[] userHandle = base64UrlDecode((String) ((JSONObject) pkOptions.get("user")).get("id"));
+
+            // Step 7: Perform the WebAuthn registration ceremony for the second user.
+            String challengeResponse = registerPasskey(requestId, challenge, rpId, origin,
+                    SECOND_TEST_USERNAME, userHandle);
+
+            // Step 8: POST FINISH_FIDO_ENROLL to complete enrollment.
+            List<NameValuePair> finishEnrollParams = new ArrayList<>();
+            finishEnrollParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishEnrollParams.add(new BasicNameValuePair("challengeResponse", challengeResponse));
+            finishEnrollParams.add(new BasicNameValuePair("scenario", "FINISH_FIDO_ENROLL"));
+            finishEnrollParams.add(new BasicNameValuePair("displayName", SECOND_TEST_USERNAME));
+            response = sendPostRequestWithParameters(httpClient, finishEnrollParams, commonAuthUrl);
+
+            // Step 9: Follow the redirect chain to the callback URL and verify enrollment succeeded.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL after successful passkey registration.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Final redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("code="),
+                    "Authorization code should be present in the callback URL.");
+        }
+    }
+
+    @Test(description = "Verify that passkey login fails when the credential presented belongs to a different " +
+            "user than the one submitted in the IDF username step.",
+            dependsOnMethods = "testPasskeyRegistrationForSecondUser")
+    public void testPasskeyLoginWithMismatchedCredential() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page.
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Select the FIDOAuthenticator to start the passkey authentication flow.
+            List<NameValuePair> selectPasskeyParams = new ArrayList<>();
+            selectPasskeyParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            selectPasskeyParams.add(new BasicNameValuePair("authenticator", "FIDOAuthenticator"));
+            selectPasskeyParams.add(new BasicNameValuePair("idp", "LOCAL"));
+            response = sendPostRequestWithParameters(httpClient, selectPasskeyParams, commonAuthUrl);
+            Header fidoPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            if (fidoPageHeader != null) {
+                response = sendGetRequest(httpClient, fidoPageHeader.getValue());
+                EntityUtils.consume(response.getEntity());
+            }
+
+            // Step 4: Submit the second user's username in the IDF step. The server will issue a WebAuthn
+            // challenge scoped to the second user's registered credentials.
+            List<NameValuePair> idfParams = new ArrayList<>();
+            idfParams.add(new BasicNameValuePair("username", SECOND_TEST_USERNAME));
+            idfParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            idfParams.add(new BasicNameValuePair("scenario", "INIT_FIDO_AUTH"));
+            idfParams.add(new BasicNameValuePair("authType", "idf"));
+            response = sendPostRequestWithParameters(httpClient, idfParams, commonAuthUrl);
+
+            // Step 5: Parse the WebAuthn request options from the fido2-auth.jsp redirect URL.
+            Header fidoAuthPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            Assert.assertNotNull(fidoAuthPageHeader,
+                    "Expected a redirect to fido2-auth.jsp after submitting the username in IDF step.");
+            String fidoAuthJspUrl = fidoAuthPageHeader.getValue();
+
+            JSONObject requestData = extractRequestOptionsFromUrl(fidoAuthJspUrl);
+            String requestId = (String) requestData.get("requestId");
+            JSONObject pkOptions = (JSONObject) requestData.get("publicKeyCredentialRequestOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = pkOptions.containsKey("rpId")
+                    ? (String) pkOptions.get("rpId")
+                    : new URI(serverURL).getHost();
+
+            // Step 6: Intentionally sign the challenge using the first user's credential. The credential ID
+            // is not in the second user's allowCredentials list, so the server must reject the assertion.
+            String tokenResponse = authenticatePasskey(requestId, challenge, rpId, origin, TEST_USERNAME);
+
+            // Step 7: POST the mismatched assertion response.
+            List<NameValuePair> finishLoginParams = new ArrayList<>();
+            finishLoginParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishLoginParams.add(new BasicNameValuePair("tokenResponse", tokenResponse));
+            response = sendPostRequestWithParameters(httpClient, finishLoginParams, commonAuthUrl);
+
+            // Step 8: Verify that no authorization code is issued — the server must reject the assertion.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL with an error response.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Error redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("error="),
+                    "Callback URL should contain an error parameter when login fails.");
+            Assert.assertFalse(callbackWithCode.contains("code="),
+                    "No authorization code should be issued when the asserted credential belongs " +
+                            "to a different user than the one identified in the IDF step.");
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyRedirectBasedTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyRedirectBasedTest.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.passkey;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.utils.DataExtractUtil;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Redirect-based integration tests for the passkey authentication flow.
+ */
+public class PasskeyRedirectBasedTest extends PasskeyTestBase {
+
+    private static final String APP_NAME = "PasskeyRedirectTestApp";
+    private static final String CALLBACK_URL = "https://example.com/oidc-callback";
+    private static final int MAX_REDIRECTS = 10;
+
+    private static final String TEST_USERNAME = "passkey_test_user";
+    private static final String TEST_PASSWORD = "Passkey@Test123";
+    private static final String TEST_EMAIL = "passkey_test_user@wso2.com";
+
+    private String appId;
+    private String testUserId;
+    private SCIM2RestClient scim2RestClient;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public PasskeyRedirectBasedTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+    }
+
+    @DataProvider(name = "restAPIUserConfigProvider")
+    public static Object[][] restAPIUserConfigProvider() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_ADMIN},
+                {TestUserMode.TENANT_ADMIN}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        restClient = new OAuth2RestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        testUserId = createTestUser(scim2RestClient, TEST_USERNAME, TEST_PASSWORD, TEST_EMAIL);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void testConclude() throws Exception {
+
+        if (appId != null) {
+            deleteApp(appId);
+        }
+        if (testUserId != null) {
+            deleteTestUser(scim2RestClient, testUserId);
+        }
+        setPasskeyProgressiveEnrollmentEnabled(false);
+        setUsernameLessAuthenticationEnabled(true);
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        clearAllCredentials();
+    }
+
+    @Test(description = "Verify app creation with passkey as first factor and progressive enrollment enabled.")
+    public void testCreateAppWithPasskeyProgressiveEnrollment() throws Exception {
+
+        setPasskeyProgressiveEnrollmentEnabled(true);
+        Assert.assertTrue(isPasskeyProgressiveEnrollmentEnabled(),
+                "Passkey progressive enrollment should be enabled.");
+
+        setUsernameLessAuthenticationEnabled(true);
+        Assert.assertTrue(isUsernameLessAuthenticationEnabled(),
+                "Passkey username-less authentication should be enabled.");
+
+        appId = addOIDCAppWithPasskeyProgressiveEnrollment(APP_NAME, CALLBACK_URL);
+        Assert.assertNotNull(appId, "Application ID should not be null after creation.");
+    }
+
+    @Test(description = "Verify passkey registration via the created app with progressive enrollment.",
+            dependsOnMethods = "testCreateAppWithPasskeyProgressiveEnrollment")
+    public void testPasskeyRegistrationWithProgressiveEnrollment() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+        String userName = TEST_USERNAME;
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page.
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Select the FIDOAuthenticator from the multi-option login page so that the
+            // server routes subsequent requests to it rather than to BasicAuthenticator.
+            List<NameValuePair> selectPasskeyParams = new ArrayList<>();
+            selectPasskeyParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            selectPasskeyParams.add(new BasicNameValuePair("authenticator", "FIDOAuthenticator"));
+            selectPasskeyParams.add(new BasicNameValuePair("idp", "LOCAL"));
+            response = sendPostRequestWithParameters(httpClient, selectPasskeyParams, commonAuthUrl);
+            Header fidoPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            if (fidoPageHeader != null) {
+                response = sendGetRequest(httpClient, fidoPageHeader.getValue());
+                EntityUtils.consume(response.getEntity());
+            }
+
+            // Step 4: POST INIT_FIDO_ENROLL to trigger the passkey progressive enrollment flow.
+            List<NameValuePair> initEnrollParams = new ArrayList<>();
+            initEnrollParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            initEnrollParams.add(new BasicNameValuePair("tokenResponse", "tmp val"));
+            initEnrollParams.add(new BasicNameValuePair("scenario", "INIT_FIDO_ENROLL"));
+            response = sendPostRequestWithParameters(httpClient, initEnrollParams, commonAuthUrl);
+
+            // Follow the redirect back to the basic auth page to maintain the session context.
+            Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            if (locationHeader != null) {
+                response = sendGetRequest(httpClient, locationHeader.getValue());
+                EntityUtils.consume(response.getEntity());
+            }
+
+            // Step 5: POST user credentials to identify the user for enrollment.
+            List<NameValuePair> credentialParams = new ArrayList<>();
+            credentialParams.add(new BasicNameValuePair("usernameUserInput", userName));
+            credentialParams.add(new BasicNameValuePair("username", userName));
+            credentialParams.add(new BasicNameValuePair("password", TEST_PASSWORD));
+            credentialParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            response = sendPostRequestWithParameters(httpClient, credentialParams, commonAuthUrl);
+
+            // Step 6: Extract the WebAuthn creation options from the redirect to fido2-enroll.jsp.
+            locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            Assert.assertNotNull(locationHeader,
+                    "Expected a redirect to fido2-enroll.jsp from the authorize endpoint.");
+            String enrollJspUrl = locationHeader.getValue();
+            EntityUtils.consume(response.getEntity());
+
+            JSONObject creationData = extractCreationOptionsFromUrl(enrollJspUrl);
+            String requestId = (String) creationData.get("requestId");
+            JSONObject pkOptions = (JSONObject) creationData.get("publicKeyCredentialCreationOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = (String) ((JSONObject) pkOptions.get("rp")).get("id");
+            byte[] userHandle = base64UrlDecode((String) ((JSONObject) pkOptions.get("user")).get("id"));
+
+            // Step 7: Perform the WebAuthn registration ceremony using the virtual authenticator.
+            String challengeResponse = registerPasskey(requestId, challenge, rpId, origin, userName, userHandle);
+
+            // Step 8: POST FINISH_FIDO_ENROLL with the registration credential to complete enrollment.
+            List<NameValuePair> finishEnrollParams = new ArrayList<>();
+            finishEnrollParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishEnrollParams.add(new BasicNameValuePair("challengeResponse", challengeResponse));
+            finishEnrollParams.add(new BasicNameValuePair("scenario", "FINISH_FIDO_ENROLL"));
+            finishEnrollParams.add(new BasicNameValuePair("displayName", userName));
+            response = sendPostRequestWithParameters(httpClient, finishEnrollParams, commonAuthUrl);
+
+            // Step 9: Follow the redirect chain until the callback URL with an authorization code appears.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL after successful passkey registration.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Final redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("code="),
+                    "Authorization code should be present in the callback URL.");
+        }
+    }
+
+    @Test(description = "Verify passkey login with a previously registered passkey credential.",
+            dependsOnMethods = "testPasskeyRegistrationWithProgressiveEnrollment")
+    public void testPasskeyLoginWithRegisteredCredential() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(appId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page.
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Select the FIDOAuthenticator to start the passkey assertion flow.
+            List<NameValuePair> selectPasskeyParams = new ArrayList<>();
+            selectPasskeyParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            selectPasskeyParams.add(new BasicNameValuePair("authenticator", "FIDOAuthenticator"));
+            selectPasskeyParams.add(new BasicNameValuePair("idp", "LOCAL"));
+            response = sendPostRequestWithParameters(httpClient, selectPasskeyParams, commonAuthUrl);
+            Header fidoAuthPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            Assert.assertNotNull(fidoAuthPageHeader,
+                    "Expected a redirect to fido2-auth.jsp after selecting the FIDOAuthenticator.");
+            String fidoAuthJspUrl = fidoAuthPageHeader.getValue();
+
+            // Step 4: Parse the WebAuthn request options from the fido2-auth.jsp redirect URL.
+            JSONObject requestData = extractRequestOptionsFromUrl(fidoAuthJspUrl);
+            String requestId = (String) requestData.get("requestId");
+            JSONObject pkOptions = (JSONObject) requestData.get("publicKeyCredentialRequestOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = pkOptions.containsKey("rpId") ? (String) pkOptions.get("rpId") : new URI(serverURL).getHost();
+
+            // Step 5: Perform the WebAuthn authentication ceremony using the stored credential.
+            String tokenResponse = authenticatePasskey(requestId, challenge, rpId, origin, TEST_USERNAME);
+
+            // Step 6: POST the assertion response to complete the passkey login.
+            List<NameValuePair> finishLoginParams = new ArrayList<>();
+            finishLoginParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishLoginParams.add(new BasicNameValuePair("tokenResponse", tokenResponse));
+            response = sendPostRequestWithParameters(httpClient, finishLoginParams, commonAuthUrl);
+
+            // Step 7: Follow the redirect chain until the callback URL with an authorization code appears.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL after successful passkey login.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Final redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("code="),
+                    "Authorization code should be present in the callback URL.");
+        }
+    }
+
+    /**
+     * Follows HTTP redirects until a non-redirect (2xx) response is received — the login page HTML.
+     */
+    private HttpResponse followRedirectsUntilLoginPage(CloseableHttpClient httpClient, HttpResponse response)
+            throws Exception {
+
+        for (int i = 0; i < MAX_REDIRECTS; i++) {
+            int status = response.getStatusLine().getStatusCode();
+            if (status < 300 || status >= 400) {
+                return response;
+            }
+            Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            if (locationHeader == null) {
+                return response;
+            }
+            EntityUtils.consume(response.getEntity());
+            response = sendGetRequest(httpClient, locationHeader.getValue());
+        }
+        return response;
+    }
+
+    /**
+     * Follows GET redirects until a URL starting with the callback URL is encountered, then returns it.
+     * Returns null if the callback URL is not reached within the redirect limit.
+     */
+    private String followRedirectsToCallback(CloseableHttpClient httpClient, HttpResponse response)
+            throws Exception {
+
+        for (int i = 0; i < MAX_REDIRECTS; i++) {
+            Header locationHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            if (locationHeader == null) {
+                break;
+            }
+            String location = locationHeader.getValue();
+            EntityUtils.consume(response.getEntity());
+            if (location.startsWith(CALLBACK_URL)) {
+                return location;
+            }
+            response = sendGetRequest(httpClient, location);
+        }
+        EntityUtils.consume(response.getEntity());
+        return null;
+    }
+
+    /**
+     * Parses the WebAuthn creation options JSON from the {@code data} query parameter
+     * of the fido2-enroll.jsp redirect URL.
+     */
+    private JSONObject extractCreationOptionsFromUrl(String url) throws Exception {
+
+        List<NameValuePair> params = URLEncodedUtils.parse(new URI(url), StandardCharsets.UTF_8);
+        for (NameValuePair param : params) {
+            if ("data".equals(param.getName())) {
+                return (JSONObject) new JSONParser().parse(param.getValue());
+            }
+        }
+        throw new IllegalStateException("'data' parameter not found in fido2-enroll.jsp URL: " + url);
+    }
+
+    /**
+     * Parses the WebAuthn request options JSON from the {@code data} query parameter
+     * of the fido2-auth.jsp redirect URL.
+     */
+    private JSONObject extractRequestOptionsFromUrl(String url) throws Exception {
+
+        List<NameValuePair> params = URLEncodedUtils.parse(new URI(url), StandardCharsets.UTF_8);
+        for (NameValuePair param : params) {
+            if ("data".equals(param.getName())) {
+                return (JSONObject) new JSONParser().parse(param.getValue());
+            }
+        }
+        throw new IllegalStateException("'data' parameter not found in fido2-auth.jsp URL: " + url);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyRedirectBasedTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyRedirectBasedTest.java
@@ -59,6 +59,7 @@ import java.util.Map;
 public class PasskeyRedirectBasedTest extends PasskeyTestBase {
 
     private static final String APP_NAME = "PasskeyRedirectTestApp";
+    private static final String MFA_APP_NAME = "PasskeyMFARedirectTestApp";
     private static final String CALLBACK_URL = "https://example.com/oidc-callback";
     private static final int MAX_REDIRECTS = 10;
 
@@ -70,9 +71,15 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
     private static final String SECOND_TEST_PASSWORD = "Passkey@Test456";
     private static final String SECOND_TEST_EMAIL = "passkey_test_user2@wso2.com";
 
+    private static final String MFA_ENROLL_USERNAME = "passkey_mfa_enroll_user";
+    private static final String MFA_ENROLL_PASSWORD = "Passkey@MFAEnroll123";
+    private static final String MFA_ENROLL_EMAIL = "passkey_mfa_enroll_user@wso2.com";
+
     private String appId;
+    private String mfaAppId;
     private String testUserId;
     private String secondTestUserId;
+    private String mfaEnrollUserId;
     private SCIM2RestClient scim2RestClient;
 
     @Factory(dataProvider = "restAPIUserConfigProvider")
@@ -98,6 +105,8 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
         testUserId = createTestUser(scim2RestClient, TEST_USERNAME, TEST_PASSWORD, TEST_EMAIL);
         secondTestUserId = createTestUser(scim2RestClient, SECOND_TEST_USERNAME, SECOND_TEST_PASSWORD,
                 SECOND_TEST_EMAIL);
+        mfaEnrollUserId = createTestUser(scim2RestClient, MFA_ENROLL_USERNAME, MFA_ENROLL_PASSWORD,
+                MFA_ENROLL_EMAIL);
     }
 
     @AfterClass(alwaysRun = true)
@@ -106,11 +115,17 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
         if (appId != null) {
             deleteApp(appId);
         }
+        if (mfaAppId != null) {
+            deleteApp(mfaAppId);
+        }
         if (testUserId != null) {
             deleteTestUser(scim2RestClient, testUserId);
         }
         if (secondTestUserId != null) {
             deleteTestUser(scim2RestClient, secondTestUserId);
+        }
+        if (mfaEnrollUserId != null) {
+            deleteTestUser(scim2RestClient, mfaEnrollUserId);
         }
         setPasskeyProgressiveEnrollmentEnabled(false);
         setUsernameLessAuthenticationEnabled(true);
@@ -626,6 +641,195 @@ public class PasskeyRedirectBasedTest extends PasskeyTestBase {
             Assert.assertFalse(callbackWithCode.contains("code="),
                     "No authorization code should be issued when the asserted credential belongs " +
                             "to a different user than the one identified in the IDF step.");
+        }
+    }
+
+    @Test(description = "Verify app creation with passkey configured as the second authentication factor (MFA).",
+            dependsOnMethods = "testPasskeyLoginWithMismatchedCredential")
+    public void testCreateAppWithPasskeyAsMFA() throws Exception {
+
+        mfaAppId = addOIDCAppWithMFAPasskey(MFA_APP_NAME, CALLBACK_URL);
+        Assert.assertNotNull(mfaAppId, "MFA application ID should not be null after creation.");
+    }
+
+    @Test(description = "Verify passkey enrollment through the MFA app: after the user completes the first " +
+            "factor (BasicAuthenticator), the server redirects a user with no registered passkey to " +
+            "fido2-passkey-status.jsp. From there, an INIT_FIDO_ENROLL request triggers the WebAuthn " +
+            "registration ceremony and FINISH_FIDO_ENROLL completes the enrollment and login.",
+            dependsOnMethods = "testCreateAppWithPasskeyAsMFA")
+    public void testPasskeyMFAEnrollmentForNewUser() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(mfaAppId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page (BasicAuthenticator form).
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Submit username and password to complete the first authentication step.
+            // Because the user has no registered passkey the server redirects to fido2-passkey-status.jsp
+            // instead of fido2-auth.jsp.
+            List<NameValuePair> credentialParams = new ArrayList<>();
+            credentialParams.add(new BasicNameValuePair("username", MFA_ENROLL_USERNAME));
+            credentialParams.add(new BasicNameValuePair("password", MFA_ENROLL_PASSWORD));
+            credentialParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            response = sendPostRequestWithParameters(httpClient, credentialParams, commonAuthUrl);
+
+            // Step 4: Follow the redirect to fido2-passkey-status.jsp and consume the page.
+            Header statusPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            Assert.assertNotNull(statusPageHeader,
+                    "Expected a redirect to fido2-passkey-status.jsp for a user with no registered passkey.");
+            Assert.assertTrue(statusPageHeader.getValue().contains("fido2-passkey-status.jsp"),
+                    "Redirect target should be fido2-passkey-status.jsp.");
+            response = sendGetRequest(httpClient, statusPageHeader.getValue());
+            EntityUtils.consume(response.getEntity());
+
+            // Step 5: POST INIT_FIDO_ENROLL to initiate the WebAuthn registration ceremony.
+            List<NameValuePair> initEnrollParams = new ArrayList<>();
+            initEnrollParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            initEnrollParams.add(new BasicNameValuePair("scenario", "INIT_FIDO_ENROLL"));
+            response = sendPostRequestWithParameters(httpClient, initEnrollParams, commonAuthUrl);
+
+            // Step 6: Extract the WebAuthn creation options from the fido2-enroll.jsp redirect URL.
+            Header enrollJspHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            Assert.assertNotNull(enrollJspHeader,
+                    "Expected a redirect to fido2-enroll.jsp after INIT_FIDO_ENROLL.");
+            String enrollJspUrl = enrollJspHeader.getValue();
+            EntityUtils.consume(response.getEntity());
+
+            JSONObject creationData = extractCreationOptionsFromUrl(enrollJspUrl);
+            String requestId = (String) creationData.get("requestId");
+            JSONObject pkOptions = (JSONObject) creationData.get("publicKeyCredentialCreationOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = (String) ((JSONObject) pkOptions.get("rp")).get("id");
+            byte[] userHandle = base64UrlDecode((String) ((JSONObject) pkOptions.get("user")).get("id"));
+
+            // Step 7: Perform the WebAuthn registration ceremony using the virtual authenticator.
+            String challengeResponse = registerPasskey(requestId, challenge, rpId, origin,
+                    MFA_ENROLL_USERNAME, userHandle);
+
+            // Step 8: POST FINISH_FIDO_ENROLL to complete the enrollment and finish the login.
+            List<NameValuePair> finishEnrollParams = new ArrayList<>();
+            finishEnrollParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishEnrollParams.add(new BasicNameValuePair("challengeResponse", challengeResponse));
+            finishEnrollParams.add(new BasicNameValuePair("scenario", "FINISH_FIDO_ENROLL"));
+            finishEnrollParams.add(new BasicNameValuePair("displayName", MFA_ENROLL_USERNAME));
+            response = sendPostRequestWithParameters(httpClient, finishEnrollParams, commonAuthUrl);
+
+            // Step 9: Follow the redirect chain until the callback URL with an authorization code appears.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL after successful MFA passkey enrollment.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Final redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("code="),
+                    "Authorization code should be present in the callback URL.");
+        }
+    }
+
+    @Test(description = "Verify passkey MFA login for a user who enrolled a passkey through the MFA app: " +
+            "step 1 (BasicAuthenticator) followed by step 2 (FIDOAuthenticator) assertion.",
+            dependsOnMethods = "testPasskeyMFAEnrollmentForNewUser")
+    public void testPasskeyMFALoginForEnrolledUser() throws Exception {
+
+        String clientId = getOIDCInboundDetailsOfApplication(mfaAppId).getClientId();
+        String commonAuthUrl = getTenantQualifiedURL(OAuth2Constant.COMMON_AUTH_URL, tenantInfo.getDomain());
+        String origin = serverURL.replaceAll("/$", "");
+
+        Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider()).build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build();
+
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .build()) {
+
+            // Step 1: Initiate the authorization code flow and follow redirects to the login page.
+            String authorizeUrl = getTenantQualifiedURL(OAuth2Constant.AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain())
+                    + "?response_type=code&client_id=" + clientId
+                    + "&redirect_uri=" + CALLBACK_URL
+                    + "&scope=openid";
+            HttpResponse response = sendGetRequest(httpClient, authorizeUrl);
+            response = followRedirectsUntilLoginPage(httpClient, response);
+
+            // Step 2: Extract sessionDataKey from the login page (BasicAuthenticator form).
+            Map<String, Integer> keyPositionMap = new HashMap<>();
+            keyPositionMap.put("name=\"sessionDataKey\"", 1);
+            List<DataExtractUtil.KeyValue> keyValues =
+                    DataExtractUtil.extractDataFromResponse(response, keyPositionMap);
+            Assert.assertNotNull(keyValues, "sessionDataKey not found on the login page.");
+            String sessionDataKey = keyValues.get(0).getValue();
+            Assert.assertNotNull(sessionDataKey, "sessionDataKey must not be null.");
+            EntityUtils.consume(response.getEntity());
+
+            // Step 3: Submit username and password to complete the first authentication step.
+            // The user now has a registered passkey so the server redirects to fido2-auth.jsp.
+            List<NameValuePair> credentialParams = new ArrayList<>();
+            credentialParams.add(new BasicNameValuePair("username", MFA_ENROLL_USERNAME));
+            credentialParams.add(new BasicNameValuePair("password", MFA_ENROLL_PASSWORD));
+            credentialParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            response = sendPostRequestWithParameters(httpClient, credentialParams, commonAuthUrl);
+
+            // Step 4: Parse the WebAuthn request options from the fido2-auth.jsp redirect URL.
+            Header fidoAuthPageHeader = response.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+            EntityUtils.consume(response.getEntity());
+            Assert.assertNotNull(fidoAuthPageHeader,
+                    "Expected a redirect to fido2-auth.jsp after completing the first authentication step.");
+            String fidoAuthJspUrl = fidoAuthPageHeader.getValue();
+
+            JSONObject requestData = extractRequestOptionsFromUrl(fidoAuthJspUrl);
+            String requestId = (String) requestData.get("requestId");
+            JSONObject pkOptions = (JSONObject) requestData.get("publicKeyCredentialRequestOptions");
+            String challenge = (String) pkOptions.get("challenge");
+            String rpId = pkOptions.containsKey("rpId")
+                    ? (String) pkOptions.get("rpId")
+                    : new URI(serverURL).getHost();
+
+            // Step 5: Perform the WebAuthn authentication ceremony using the enrolled credential.
+            String tokenResponse = authenticatePasskey(requestId, challenge, rpId, origin, MFA_ENROLL_USERNAME);
+
+            // Step 6: POST the assertion response to complete the second-factor passkey authentication.
+            List<NameValuePair> finishLoginParams = new ArrayList<>();
+            finishLoginParams.add(new BasicNameValuePair("sessionDataKey", sessionDataKey));
+            finishLoginParams.add(new BasicNameValuePair("tokenResponse", tokenResponse));
+            response = sendPostRequestWithParameters(httpClient, finishLoginParams, commonAuthUrl);
+
+            // Step 7: Follow the redirect chain until the callback URL with an authorization code appears.
+            String callbackWithCode = followRedirectsToCallback(httpClient, response);
+            Assert.assertNotNull(callbackWithCode,
+                    "Expected a redirect to the callback URL after successful MFA passkey login.");
+            Assert.assertTrue(callbackWithCode.startsWith(CALLBACK_URL),
+                    "Final redirect should target the configured callback URL.");
+            Assert.assertTrue(callbackWithCode.contains("code="),
+                    "Authorization code should be present in the callback URL.");
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyTestBase.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.passkey;
+
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
+import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Base class for passkey integration tests.
+ */
+public abstract class PasskeyTestBase extends OAuth2ServiceAbstractIntegrationTest {
+
+    private static final String PASSKEY_MFA_CATEGORY_ID = "TXVsdGkgRmFjdG9yIEF1dGhlbnRpY2F0b3Jz";
+    private static final String PASSKEY_CONNECTOR_ID = "RklET0F1dGhlbnRpY2F0b3I";
+
+    /**
+     * Enables or disables username-less authentication for passkeys via the identity governance API.
+     *
+     * @param enable Whether to enable username-less authentication.
+     * @throws IOException If an error occurred while updating the connector property.
+     */
+    protected void setUsernameLessAuthenticationEnabled(boolean enable) throws IOException {
+
+        updatePasskeyConnectorProperty("FIDO.EnableUsernameLessAuthentication", String.valueOf(enable));
+    }
+
+    /**
+     * Enables or disables passkey progressive enrollment via the identity governance API.
+     *
+     * @param enable Whether to enable passkey progressive enrollment.
+     * @throws IOException If an error occurred while updating the connector property.
+     */
+    protected void setPasskeyProgressiveEnrollmentEnabled(boolean enable) throws IOException {
+
+        updatePasskeyConnectorProperty("FIDO.EnablePasskeyProgressiveEnrollment", String.valueOf(enable));
+    }
+
+    private void updatePasskeyConnectorProperty(String name, String value) throws IOException {
+
+        PropertyReq property = new PropertyReq();
+        property.setName(name);
+        property.setValue(value);
+
+        ConnectorsPatchReq connectorPatchRequest = new ConnectorsPatchReq();
+        connectorPatchRequest.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
+        connectorPatchRequest.addProperties(property);
+
+        IdentityGovernanceRestClient governanceClient =
+                new IdentityGovernanceRestClient(serverURL, tenantInfo);
+        try {
+            governanceClient.updateConnectors(PASSKEY_MFA_CATEGORY_ID, PASSKEY_CONNECTOR_ID,
+                    connectorPatchRequest);
+        } finally {
+            governanceClient.closeHttpClient();
+        }
+    }
+
+    /**
+     * Creates an OIDC application with authorization code grant configured for password-less login
+     * using passkey with progressive enrollment.
+     *
+     * @param appName     Name of the application.
+     * @param callbackUrl Redirect callback URL.
+     * @return ID of the created application.
+     * @throws Exception If an error occurred while creating the application.
+     */
+    protected String addOIDCAppWithPasskeyProgressiveEnrollment(String appName, String callbackUrl)
+            throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName(appName);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(Collections.singletonList("authorization_code"));
+        oidcConfig.setCallbackURLs(Collections.singletonList(callbackUrl));
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+
+        Authenticator basicAuthenticator = new Authenticator();
+        basicAuthenticator.setIdp("LOCAL");
+        basicAuthenticator.setAuthenticator("BasicAuthenticator");
+
+        Authenticator passkeyAuthenticator = new Authenticator();
+        passkeyAuthenticator.setIdp("LOCAL");
+        passkeyAuthenticator.setAuthenticator("FIDOAuthenticator");
+
+        AuthenticationStep step = new AuthenticationStep();
+        step.setId(1);
+        step.addOptionsItem(basicAuthenticator);
+        step.addOptionsItem(passkeyAuthenticator);
+
+        String script = "var onLoginRequest = function(context) {\n" +
+                "    executeStep(1, {\n" +
+                "        onFail: function(context) {\n" +
+                "            var authenticatorStatus = context.request.params.scenario;\n" +
+                "\n" +
+                "            // Passkey progressive enrollment flow trigger\n" +
+                "            if (authenticatorStatus != null && authenticatorStatus[0] == 'INIT_FIDO_ENROLL') {\n" +
+                "                var filteredAuthenticationOptions = filterAuthenticators(context.steps[1].options, 'FIDOAuthenticator');\n" +
+                "                executeStep(1, {\n" +
+                "                    stepOptions: {\n" +
+                "                        markAsSubjectIdentifierStep: 'true',\n" +
+                "                        markAsSubjectAttributeStep: 'true'\n" +
+                "                    },\n" +
+                "                    authenticationOptions: filteredAuthenticationOptions\n" +
+                "                }, {\n" +
+                "                    onSuccess: function(context) {\n" +
+                "                        // Trigger FIDO Authenticator for Passkey enrollment\n" +
+                "                        executeStep(1, {\n" +
+                "                            stepOptions: {\n" +
+                "                                forceAuth: 'true'\n" +
+                "                            },\n" +
+                "                            authenticationOptions: [{\n" +
+                "                                authenticator: 'FIDOAuthenticator'\n" +
+                "                            }]\n" +
+                "                        }, {});\n" +
+                "                    },\n" +
+                "                });\n" +
+                "            }\n" +
+                "        }\n" +
+                "    });\n" +
+                "};";
+
+        AuthenticationSequence authSequence = new AuthenticationSequence();
+        authSequence.setType(AuthenticationSequence.TypeEnum.USER_DEFINED);
+        authSequence.addStepsItem(step);
+        authSequence.setSubjectStepId(1);
+        authSequence.setScript(script);
+
+        application.setAuthenticationSequence(authSequence);
+
+        return addApplication(application);
+    }
+
+    /**
+     * Creates an OIDC application with authorization code grant configured for MFA using passkey.
+     *
+     * @param appName     Name of the application.
+     * @param callbackUrl Redirect callback URL.
+     * @return ID of the created application.
+     * @throws Exception If an error occurred while creating the application.
+     */
+    protected String addOIDCAppWithMFAPasskey(String appName, String callbackUrl)
+            throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName(appName);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(Collections.singletonList("authorization_code"));
+        oidcConfig.setCallbackURLs(Collections.singletonList(callbackUrl));
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+
+        Authenticator basicAuthenticator = new Authenticator();
+        basicAuthenticator.setIdp("LOCAL");
+        basicAuthenticator.setAuthenticator("BasicAuthenticator");
+
+        AuthenticationStep firstStep = new AuthenticationStep();
+        firstStep.setId(1);
+        firstStep.addOptionsItem(basicAuthenticator);
+
+        Authenticator passkeyAuthenticator = new Authenticator();
+        passkeyAuthenticator.setIdp("LOCAL");
+        passkeyAuthenticator.setAuthenticator("FIDOAuthenticator");
+
+        AuthenticationStep secondStep = new AuthenticationStep();
+        secondStep.setId(2);
+        secondStep.addOptionsItem(passkeyAuthenticator);
+
+        AuthenticationSequence authSequence = new AuthenticationSequence();
+        authSequence.setType(AuthenticationSequence.TypeEnum.USER_DEFINED);
+        authSequence.addStepsItem(firstStep);
+        authSequence.addStepsItem(secondStep);
+        authSequence.setSubjectStepId(1);
+
+        application.setAuthenticationSequence(authSequence);
+
+        return addApplication(application);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyTestBase.java
@@ -18,16 +18,20 @@
 
 package org.wso2.identity.integration.test.passkey;
 
-import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
 import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -35,7 +39,7 @@ import java.util.Collections;
 /**
  * Base class for passkey integration tests.
  */
-public abstract class PasskeyTestBase extends OAuth2ServiceAbstractIntegrationTest {
+public abstract class PasskeyTestBase extends PasskeyClient  {
 
     private static final String PASSKEY_MFA_CATEGORY_ID = "TXVsdGkgRmFjdG9yIEF1dGhlbnRpY2F0b3Jz";
     private static final String PASSKEY_CONNECTOR_ID = "RklET0F1dGhlbnRpY2F0b3I";
@@ -48,7 +52,7 @@ public abstract class PasskeyTestBase extends OAuth2ServiceAbstractIntegrationTe
      */
     protected void setUsernameLessAuthenticationEnabled(boolean enable) throws IOException {
 
-        updatePasskeyConnectorProperty("FIDO.EnableUsernameLessAuthentication", String.valueOf(enable));
+        updatePasskeyConnectorProperty("FIDO.EnableUsernamelessAuthentication", String.valueOf(enable));
     }
 
     /**
@@ -60,6 +64,47 @@ public abstract class PasskeyTestBase extends OAuth2ServiceAbstractIntegrationTe
     protected void setPasskeyProgressiveEnrollmentEnabled(boolean enable) throws IOException {
 
         updatePasskeyConnectorProperty("FIDO.EnablePasskeyProgressiveEnrollment", String.valueOf(enable));
+    }
+
+    /**
+     * Returns whether username-less authentication for passkeys is currently enabled.
+     *
+     * @return true if enabled, false otherwise.
+     * @throws Exception If an error occurred while retrieving the connector property.
+     */
+    protected boolean isUsernameLessAuthenticationEnabled() throws Exception {
+
+        return Boolean.parseBoolean(getPasskeyConnectorProperty("FIDO.EnableUsernamelessAuthentication"));
+    }
+
+    /**
+     * Returns whether passkey progressive enrollment is currently enabled.
+     *
+     * @return true if enabled, false otherwise.
+     * @throws Exception If an error occurred while retrieving the connector property.
+     */
+    protected boolean isPasskeyProgressiveEnrollmentEnabled() throws Exception {
+
+        return Boolean.parseBoolean(getPasskeyConnectorProperty("FIDO.EnablePasskeyProgressiveEnrollment"));
+    }
+
+    private String getPasskeyConnectorProperty(String name) throws Exception {
+
+        IdentityGovernanceRestClient governanceClient =
+                new IdentityGovernanceRestClient(serverURL, tenantInfo);
+        try {
+            JSONObject connector = governanceClient.getConnector(PASSKEY_MFA_CATEGORY_ID, PASSKEY_CONNECTOR_ID);
+            JSONArray properties = (JSONArray) connector.get("properties");
+            for (Object item : properties) {
+                JSONObject property = (JSONObject) item;
+                if (name.equals(property.get("name"))) {
+                    return (String) property.get("value");
+                }
+            }
+            throw new IllegalStateException("Connector property not found: " + name);
+        } finally {
+            governanceClient.closeHttpClient();
+        }
     }
 
     private void updatePasskeyConnectorProperty(String name, String value) throws IOException {
@@ -208,5 +253,37 @@ public abstract class PasskeyTestBase extends OAuth2ServiceAbstractIntegrationTe
         application.setAuthenticationSequence(authSequence);
 
         return addApplication(application);
+    }
+
+    /**
+     * Creates a test user via the SCIM2 REST API and returns the user ID.
+     *
+     * @param scim2RestClient SCIM2 client to use for the request.
+     * @param username        Username for the new user.
+     * @param password        Password for the new user.
+     * @param email           Email address for the new user.
+     * @return ID of the created user.
+     * @throws Exception If an error occurred while creating the user.
+     */
+    protected String createTestUser(SCIM2RestClient scim2RestClient, String username, String password,
+            String email) throws Exception {
+
+        UserObject user = new UserObject();
+        user.setUserName(username);
+        user.setPassword(password);
+        user.addEmail(new Email().value(email));
+        return scim2RestClient.createUser(user);
+    }
+
+    /**
+     * Deletes a test user via the SCIM2 REST API.
+     *
+     * @param scim2RestClient SCIM2 client to use for the request.
+     * @param userId          ID of the user to delete.
+     * @throws Exception If an error occurred while deleting the user.
+     */
+    protected void deleteTestUser(SCIM2RestClient scim2RestClient, String userId) throws Exception {
+
+        scim2RestClient.deleteUser(userId);
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/passkey/PasskeyTestBase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.integration.test.passkey;
 
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
@@ -26,15 +27,32 @@ import org.wso2.identity.integration.test.rest.api.server.application.management
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
 import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
 import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Base class for passkey integration tests.
@@ -256,6 +274,62 @@ public abstract class PasskeyTestBase extends PasskeyClient  {
     }
 
     /**
+     * Creates an OIDC application configured for app-native authentication with passkey as the
+     * second factor (BasicAuthenticator → FIDOAuthenticator). The application is registered as a
+     * public client with API-based authentication enabled.
+     *
+     * @param appName     Name of the application.
+     * @param callbackUrl Redirect callback URL.
+     * @return ID of the created application.
+     * @throws Exception If an error occurred while creating the application.
+     */
+    protected String addOIDCAppWithMFAPasskeyForAppNative(String appName, String callbackUrl)
+            throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName(appName);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(Collections.singletonList("authorization_code"));
+        oidcConfig.setCallbackURLs(Collections.singletonList(callbackUrl));
+        oidcConfig.setPublicClient(true);
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+
+        AdvancedApplicationConfiguration advancedConfig = new AdvancedApplicationConfiguration();
+        advancedConfig.setEnableAPIBasedAuthentication(true);
+        application.setAdvancedConfigurations(advancedConfig);
+
+        Authenticator basicAuthenticator = new Authenticator();
+        basicAuthenticator.setIdp("LOCAL");
+        basicAuthenticator.setAuthenticator("BasicAuthenticator");
+
+        AuthenticationStep firstStep = new AuthenticationStep();
+        firstStep.setId(1);
+        firstStep.addOptionsItem(basicAuthenticator);
+
+        Authenticator passkeyAuthenticator = new Authenticator();
+        passkeyAuthenticator.setIdp("LOCAL");
+        passkeyAuthenticator.setAuthenticator("FIDOAuthenticator");
+
+        AuthenticationStep secondStep = new AuthenticationStep();
+        secondStep.setId(2);
+        secondStep.addOptionsItem(passkeyAuthenticator);
+
+        AuthenticationSequence authSequence = new AuthenticationSequence();
+        authSequence.setType(AuthenticationSequence.TypeEnum.USER_DEFINED);
+        authSequence.addStepsItem(firstStep);
+        authSequence.addStepsItem(secondStep);
+        authSequence.setSubjectStepId(1);
+
+        application.setAuthenticationSequence(authSequence);
+
+        return addApplication(application);
+    }
+
+    /**
      * Creates a test user via the SCIM2 REST API and returns the user ID.
      *
      * @param scim2RestClient SCIM2 client to use for the request.
@@ -285,5 +359,226 @@ public abstract class PasskeyTestBase extends PasskeyClient  {
     protected void deleteTestUser(SCIM2RestClient scim2RestClient, String userId) throws Exception {
 
         scim2RestClient.deleteUser(userId);
+    }
+
+    /**
+     * Enrolls a passkey for the given user via the My Account WebAuthn API, simulating
+     * the full registration ceremony with a virtual authenticator.
+     *
+     * @param username     Username of the user.
+     * @param password     Password of the user.
+     * @param clientId     OAuth2 client ID of an application with password grant enabled.
+     * @param clientSecret OAuth2 client secret of the application.
+     * @throws Exception If passkey enrollment fails at any step.
+     */
+    protected void enrollPasskeyForUser(String username, String password, String clientId,
+            String clientSecret) throws Exception {
+
+        String tenantDomain = tenantInfo.getDomain();
+        String origin = serverURL.replaceAll("/$", "");
+        String tokenEndpoint = getTenantQualifiedURL(serverURL + "oauth2/token", tenantDomain);
+        String startRegUrl = getTenantQualifiedURL(
+                serverURL + "api/users/v2/me/webauthn/start-usernameless-registration", tenantDomain);
+        String finishRegUrl = getTenantQualifiedURL(
+                serverURL + "api/users/v2/me/webauthn/finish-registration", tenantDomain);
+
+        String accessToken = getUserAccessTokenViaPasswordGrant(
+                username, password, clientId, clientSecret, tokenEndpoint);
+
+        JSONObject creationOptions = startWebAuthnRegistration(accessToken, startRegUrl, origin);
+
+        String requestId = (String) creationOptions.get("requestId");
+        JSONObject publicKeyOptions = (JSONObject) creationOptions.get("publicKeyCredentialCreationOptions");
+        String challenge = (String) publicKeyOptions.get("challenge");
+        String rpId = (String) ((JSONObject) publicKeyOptions.get("rp")).get("id");
+        byte[] userHandle = base64UrlDecode((String) ((JSONObject) publicKeyOptions.get("user")).get("id"));
+
+        String challengeResponse = registerPasskey(requestId, challenge, rpId, origin, username, userHandle);
+
+        finishWebAuthnRegistration(accessToken, finishRegUrl, challengeResponse);
+    }
+
+    private String getUserAccessTokenViaPasswordGrant(String username, String password,
+            String clientId, String clientSecret, String tokenEndpoint) throws Exception {
+
+        try (CloseableHttpClient client = createTrustAllHttpClient()) {
+            HttpPost post = new HttpPost(tokenEndpoint);
+            String credentials = Base64.getEncoder()
+                    .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+            post.setHeader("Authorization", "Basic " + credentials);
+
+            List<NameValuePair> params = new ArrayList<>();
+            params.add(new BasicNameValuePair("grant_type", "password"));
+            params.add(new BasicNameValuePair("username", username));
+            params.add(new BasicNameValuePair("password", password));
+            params.add(new BasicNameValuePair("scope", "internal_login"));
+            post.setEntity(new UrlEncodedFormEntity(params));
+
+            HttpResponse response = client.execute(post);
+            String body = EntityUtils.toString(response.getEntity());
+            JSONObject json = (JSONObject) new JSONParser().parse(body);
+            String accessToken = (String) json.get("access_token");
+            if (accessToken == null) {
+                throw new IllegalStateException("Failed to obtain access token for user '" + username + "': " + body);
+            }
+            return accessToken;
+        }
+    }
+
+    private JSONObject startWebAuthnRegistration(String accessToken, String startRegUrl,
+            String origin) throws Exception {
+
+        try (CloseableHttpClient client = createTrustAllHttpClient()) {
+            HttpPost post = new HttpPost(startRegUrl);
+            post.setHeader("Authorization", "Bearer " + accessToken);
+
+            List<NameValuePair> params = new ArrayList<>();
+            params.add(new BasicNameValuePair("appId", origin));
+            post.setEntity(new UrlEncodedFormEntity(params));
+
+            HttpResponse response = client.execute(post);
+            String body = EntityUtils.toString(response.getEntity());
+            return (JSONObject) new JSONParser().parse(body);
+        }
+    }
+
+    private void finishWebAuthnRegistration(String accessToken, String finishRegUrl,
+            String challengeResponse) throws Exception {
+
+        try (CloseableHttpClient client = createTrustAllHttpClient()) {
+            HttpPost post = new HttpPost(finishRegUrl);
+            post.setHeader("Authorization", "Bearer " + accessToken);
+            post.setHeader("Content-Type", "application/json");
+            post.setEntity(new StringEntity(challengeResponse, StandardCharsets.UTF_8));
+
+            HttpResponse response = client.execute(post);
+            int status = response.getStatusLine().getStatusCode();
+            EntityUtils.consume(response.getEntity());
+            if (status < 200 || status >= 300) {
+                throw new IllegalStateException("Passkey finish-registration failed with HTTP " + status);
+            }
+        }
+    }
+
+    /**
+     * Creates an OIDC application with authorization code grant configured with passkey as the sole
+     * first-factor authenticator. Suitable for passwordless passkey-first login flows.
+     *
+     * @param appName     Name of the application.
+     * @param callbackUrl Redirect callback URL.
+     * @return ID of the created application.
+     * @throws Exception If an error occurred while creating the application.
+     */
+    protected String addOIDCAppWithPasskeyAsFirstFactor(String appName, String callbackUrl)
+            throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName(appName);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(Collections.singletonList("authorization_code"));
+        oidcConfig.setCallbackURLs(Collections.singletonList(callbackUrl));
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+
+        Authenticator passkeyAuthenticator = new Authenticator();
+        passkeyAuthenticator.setIdp("LOCAL");
+        passkeyAuthenticator.setAuthenticator("FIDOAuthenticator");
+
+        AuthenticationStep step = new AuthenticationStep();
+        step.setId(1);
+        step.addOptionsItem(passkeyAuthenticator);
+
+        AuthenticationSequence authSequence = new AuthenticationSequence();
+        authSequence.setType(AuthenticationSequence.TypeEnum.USER_DEFINED);
+        authSequence.addStepsItem(step);
+        authSequence.setSubjectStepId(1);
+
+        application.setAuthenticationSequence(authSequence);
+        return addApplication(application);
+    }
+
+    /**
+     * Creates an OIDC application configured for app-native authentication with passkey as the sole
+     * first-factor authenticator. The application is registered as a public client with
+     * API-based authentication enabled.
+     *
+     * @param appName     Name of the application.
+     * @param callbackUrl Redirect callback URL.
+     * @return ID of the created application.
+     * @throws Exception If an error occurred while creating the application.
+     */
+    protected String addOIDCAppWithPasskeyForAppNative(String appName, String callbackUrl)
+            throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName(appName);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(Collections.singletonList("authorization_code"));
+        oidcConfig.setCallbackURLs(Collections.singletonList(callbackUrl));
+        oidcConfig.setPublicClient(true);
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+
+        AdvancedApplicationConfiguration advancedConfig = new AdvancedApplicationConfiguration();
+        advancedConfig.setEnableAPIBasedAuthentication(true);
+        application.setAdvancedConfigurations(advancedConfig);
+
+        Authenticator passkeyAuthenticator = new Authenticator();
+        passkeyAuthenticator.setIdp("LOCAL");
+        passkeyAuthenticator.setAuthenticator("FIDOAuthenticator");
+
+        AuthenticationStep step = new AuthenticationStep();
+        step.setId(1);
+        step.addOptionsItem(passkeyAuthenticator);
+
+        AuthenticationSequence authSequence = new AuthenticationSequence();
+        authSequence.setType(AuthenticationSequence.TypeEnum.USER_DEFINED);
+        authSequence.addStepsItem(step);
+        authSequence.setSubjectStepId(1);
+
+        application.setAuthenticationSequence(authSequence);
+        return addApplication(application);
+    }
+
+    /**
+     * Creates a minimal OIDC application with both authorization_code and password grant types.
+     * Intended for test helper use (e.g., obtaining user tokens for API calls).
+     *
+     * @param appName     Name of the application.
+     * @param callbackUrl Redirect callback URL.
+     * @return ID of the created application.
+     * @throws Exception If an error occurred while creating the application.
+     */
+    protected String addPasswordGrantApp(String appName, String callbackUrl) throws Exception {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName(appName);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(List.of("authorization_code", "password"));
+        oidcConfig.setCallbackURLs(Collections.singletonList(callbackUrl));
+
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        application.setInboundProtocolConfiguration(inboundProtocols);
+
+        return addApplication(application);
+    }
+
+    protected CloseableHttpClient createTrustAllHttpClient() throws Exception {
+
+        SSLContext sslContext = SSLContextBuilder.create()
+                .loadTrustMaterial(null, (chain, authType) -> true)
+                .build();
+        return HttpClientBuilder.create()
+                .setSSLContext(sslContext)
+                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                .build();
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdentityGovernanceRestClient.java
@@ -90,6 +90,26 @@ public class IdentityGovernanceRestClient extends RestBaseClient {
     }
 
     /**
+     * Get a governance connector.
+     *
+     * @param categoryId  Connector category id.
+     * @param connectorId Connector id.
+     * @return JSON object representing the governance connector.
+     * @throws Exception If an error occurred while retrieving the governance connector.
+     */
+    public JSONObject getConnector(String categoryId, String connectorId) throws Exception {
+
+        String endPointUrl = identityGovernanceApiBasePath + PATH_SEPARATOR + categoryId +
+                CONNECTORS_BASE_PATH + PATH_SEPARATOR + connectorId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpGet(endPointUrl, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Connector retrieval failed");
+            return getJSONObject(EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    /**
      * Get a governance connector in sub-organization.
      *
      * @param categoryId       Connector category id.

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -193,6 +193,8 @@
             <class name="org.wso2.identity.integration.test.inheritance.ConfigInheritanceTestCase"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.compatibilitysettings.CompatibilitySettingsDeploymentConfigTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.EnhancedOrgAuthenticationDirectPathTestCase"/>
+            <class name="org.wso2.identity.integration.test.passkey.PasskeyRedirectBasedTest"/>
+            <class name="org.wso2.identity.integration.test.passkey.PasskeyAppNativeTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
### Purpose

Add integration test coverage for passkey authentication flows in WSO2 Identity Server. This includes end-to-end tests for passkey registration and login across redirect-based, app-native, and MFA scenarios.

### Related Issue

- https://github.com/wso2/product-is/issues/27757

### What's included

**New test classes:**
- `PasskeyTestBase.java` — Shared setup/teardown logic, user and application provisioning, and passkey configuration helpers used across all passkey test suites.
- `PasskeyClient.java` — HTTP client abstraction for driving the WebAuthn/passkey API (credential creation, assertion, and authenticator simulation).
- `PasskeyRedirectBasedTest.java` — Integration tests for the browser redirect-based passkey login flow, covering standard login, usernameless login, and the case where usernameless is disabled.
- `PasskeyAppNativeTest.java` — Integration tests for the app-native (API-based) passkey authentication flow.

**Test scenarios covered:**
- Passkey registration and login (redirect-based)
- Usernameless passkey login (redirect-based)
- Usernameless login when the feature is disabled (negative case)
- Passkey as a second factor in an MFA flow
- Passkey registration and login via the app-native API

**Supporting changes:**
- `IdentityGovernanceRestClient.java` — Extended to support reading and updating passkey-related governance connector configurations.
- `testng.xml` — Registered the new passkey test classes into the integration test suite.