### PR TITLE
Bump framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2691,7 +2691,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.73</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.74</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request updates the version of the Carbon Identity Framework dependency in the `pom.xml` file to ensure the project uses the latest compatible version.

Dependency update:

* Updated the `carbon.identity.framework.version` property from `7.11.73` to `7.11.74` in `pom.xml` to use the latest patch release.