### PR TITLE
Add integration tests for OAuth 2.0 password grant And client credential based authentication

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/model/AuthenticationType.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/common/model/AuthenticationType.java
@@ -37,7 +37,7 @@ public class AuthenticationType {
     @XmlEnum(String.class)
     public enum TypeEnum {
 
-        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL"));
+        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
         private String value;
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionFailureTest.java
@@ -466,6 +466,178 @@ public class PreIssueAccessTokenActionFailureTest extends ActionTestBase {
                 .body("description", equalTo("Authentication property values cannot be empty."));
     }
 
+    @Test(dependsOnMethods = {"testCreateActionWithClientCredentialEmptyTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialMissingClientId() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                null,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientId"})
+    public void testCreateActionWithPasswordCredentialMissingClientSecret() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                null,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientSecret"})
+    public void testCreateActionWithPasswordCredentialMissingTokenEndpoint() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                null,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialMissingUsername() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                null,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingUsername"})
+    public void testCreateActionWithPasswordCredentialMissingPassword() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                null));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingPassword"})
+    public void testCreateActionWithPasswordCredentialEmptyClientId() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                "",
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientId"})
+    public void testCreateActionWithPasswordCredentialEmptyClientSecret() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                "",
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientSecret"})
+    public void testCreateActionWithPasswordCredentialEmptyTokenEndpoint() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                "",
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialEmptyUsername() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                "",
+                TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyUsername"})
+    public void testCreateActionWithPasswordCredentialEmptyPassword() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE,
+                TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE,
+                ""));
+    }
+
+    private HashMap<String, Object> buildPasswordCredentialProperties(String clientId, String clientSecret,
+                                                                     String tokenEndpoint, String username,
+                                                                     String password) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        if (clientId != null) {
+            properties.put(TEST_CLIENT_ID_AUTH_PROPERTY, clientId);
+        }
+        if (clientSecret != null) {
+            properties.put(TEST_CLIENT_SECRET_AUTH_PROPERTY, clientSecret);
+        }
+        if (tokenEndpoint != null) {
+            properties.put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, tokenEndpoint);
+        }
+        if (username != null) {
+            properties.put(TEST_USERNAME_AUTH_PROPERTY, username);
+        }
+        if (password != null) {
+            properties.put(TEST_PASSWORD_AUTH_PROPERTY, password);
+        }
+        return properties;
+    }
+
+    private void assertPasswordCredentialMissingProperty(HashMap<String, Object> properties) {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(properties)));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    private void assertPasswordCredentialEmptyProperty(HashMap<String, Object> properties) {
+
+        ActionModel action = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(properties)));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(action));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
+    }
+
     private String createActionWithRule() {
 
         ORRule rule = new ORRule()

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueaccesstoken/PreIssueAccessTokenActionSuccessTest.java
@@ -840,4 +840,284 @@ public class PreIssueAccessTokenActionSuccessTest extends PreIssueAccessTokenTes
 
         deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
     }
+
+    @Test(dependsOnMethods = {"testUpdateClientCredentialAuthenticationProperties"})
+    public void testCreateActionWithPasswordCredentialAuthentication() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        String body = toJSONString(passwordCredentialAction);
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("id", notNullValue())
+                .body("name", equalTo(TEST_ACTION_NAME))
+                .body("description", equalTo(TEST_ACTION_DESCRIPTION))
+                .body("version", equalTo(TEST_ACTION_VERSION))
+                .body("status", equalTo(TEST_ACTION_INACTIVE_STATUS))
+                .body("endpoint.uri", equalTo(TEST_ENDPOINT_URI))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        String createdActionId = responseOfPost.getBody().jsonPath().getString("id");
+
+        Response responseOfGet = getResponseOfGet(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthentication"})
+    public void testCreateActionWithPasswordCredentialAuthenticationWithoutScopes() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        String body = toJSONString(passwordCredentialAction);
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, body);
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, responseOfPost.getBody().jsonPath().getString("id"));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthenticationWithoutScopes"})
+    public void testUpdateActionAuthenticationToPasswordCredential() {
+
+        ActionModel basicAuthAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.BASIC)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(basicAuthAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdateActionAuthenticationToPasswordCredential"})
+    public void testUpdatePasswordCredentialAuthenticationProperties() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY,
+                                            TEST_UPDATED_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                                            TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY,
+                                            TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY,
+                                            TEST_UPDATED_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdatePasswordCredentialAuthenticationProperties"})
+    public void testUpdatePasswordCredentialAddScopes() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ACCESS_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(createdActionId))
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE));
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, createdActionId);
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueidtoken/PreIssueIDTokenActionFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueidtoken/PreIssueIDTokenActionFailureTest.java
@@ -270,6 +270,148 @@ public class PreIssueIDTokenActionFailureTest extends ActionTestBase {
         deleteAction(PRE_ISSUE_ID_TOKEN_PATH , testActionId2);
     }
 
+    @Test(dependsOnMethods = {"testDeactivateActionWithInvalidID"})
+    public void testCreateActionWithPasswordCredentialMissingClientId() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                null, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientId"})
+    public void testCreateActionWithPasswordCredentialMissingClientSecret() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, null, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientSecret"})
+    public void testCreateActionWithPasswordCredentialMissingTokenEndpoint() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, null,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialMissingUsername() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, null, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingUsername"})
+    public void testCreateActionWithPasswordCredentialMissingPassword() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, TEST_USERNAME_AUTH_PROPERTY_VALUE, null));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingPassword"})
+    public void testCreateActionWithPasswordCredentialEmptyClientId() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                "", TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientId"})
+    public void testCreateActionWithPasswordCredentialEmptyClientSecret() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, "", TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientSecret"})
+    public void testCreateActionWithPasswordCredentialEmptyTokenEndpoint() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, "",
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialEmptyUsername() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, "", TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyUsername"})
+    public void testCreateActionWithPasswordCredentialEmptyPassword() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, TEST_USERNAME_AUTH_PROPERTY_VALUE, ""));
+    }
+
+    private HashMap<String, Object> buildPasswordCredentialProperties(String clientId, String clientSecret,
+                                                                     String tokenEndpoint, String username,
+                                                                     String password) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        if (clientId != null) {
+            properties.put(TEST_CLIENT_ID_AUTH_PROPERTY, clientId);
+        }
+        if (clientSecret != null) {
+            properties.put(TEST_CLIENT_SECRET_AUTH_PROPERTY, clientSecret);
+        }
+        if (tokenEndpoint != null) {
+            properties.put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, tokenEndpoint);
+        }
+        if (username != null) {
+            properties.put(TEST_USERNAME_AUTH_PROPERTY, username);
+        }
+        if (password != null) {
+            properties.put(TEST_PASSWORD_AUTH_PROPERTY, password);
+        }
+        return properties;
+    }
+
+    private void assertPasswordCredentialMissingProperty(HashMap<String, Object> properties) {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(properties)));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    private void assertPasswordCredentialEmptyProperty(HashMap<String, Object> properties) {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(properties)));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
+    }
+
     /**
      * Create a sample Action.
      *

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueidtoken/PreIssueIDTokenActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preissueidtoken/PreIssueIDTokenActionSuccessTest.java
@@ -563,5 +563,254 @@ public class PreIssueIDTokenActionSuccessTest extends PreIssueIDTokenTestBase {
                 .assertThat()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
+
+    @Test(dependsOnMethods = {"testDeleteAction"})
+    public void testCreateActionWithPasswordCredentialAuthentication() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("id", notNullValue())
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        String createdActionId = responseOfPost.getBody().jsonPath().getString("id");
+
+        Response responseOfGet = getResponseOfGet(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH + "/" + createdActionId);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ID_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthentication"})
+    public void testCreateActionWithPasswordCredentialAuthenticationWithoutScopes() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ID_TOKEN_PATH, responseOfPost.getBody().jsonPath().getString("id"));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthenticationWithoutScopes"})
+    public void testUpdateActionAuthenticationToPasswordCredential() {
+
+        ActionModel basicAuthAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.BASIC)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(basicAuthAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ID_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdateActionAuthenticationToPasswordCredential"})
+    public void testUpdatePasswordCredentialAuthenticationProperties() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY,
+                                            TEST_UPDATED_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                                            TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_UPDATED_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_ISSUE_ID_TOKEN_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdatePasswordCredentialAuthenticationProperties"})
+    public void testUpdatePasswordCredentialAddScopes() {
+
+        ActionModel passwordCredentialAction = new ActionModel()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .endpoint(new Endpoint()
+                        .uri(TEST_ENDPOINT_URI)
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_ISSUE_ID_TOKEN_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE));
+
+        deleteAction(PRE_ISSUE_ID_TOKEN_PATH, createdActionId);
+    }
 }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordActionFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordActionFailureTest.java
@@ -292,6 +292,149 @@ public class PreUpdatePasswordActionFailureTest extends PreUpdatePasswordTestBas
         deleteAction(PRE_UPDATE_PASSWORD_PATH , testActionId2);
     }
 
+    @Test(dependsOnMethods = {"testUpdateActionWithInvalidAttributes"})
+    public void testCreateActionWithPasswordCredentialMissingClientId() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                null, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientId"})
+    public void testCreateActionWithPasswordCredentialMissingClientSecret() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, null, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientSecret"})
+    public void testCreateActionWithPasswordCredentialMissingTokenEndpoint() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, null,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialMissingUsername() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, null, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingUsername"})
+    public void testCreateActionWithPasswordCredentialMissingPassword() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, TEST_USERNAME_AUTH_PROPERTY_VALUE, null));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingPassword"})
+    public void testCreateActionWithPasswordCredentialEmptyClientId() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                "", TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientId"})
+    public void testCreateActionWithPasswordCredentialEmptyClientSecret() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, "", TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientSecret"})
+    public void testCreateActionWithPasswordCredentialEmptyTokenEndpoint() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, "",
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialEmptyUsername() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, "", TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyUsername"})
+    public void testCreateActionWithPasswordCredentialEmptyPassword() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, TEST_USERNAME_AUTH_PROPERTY_VALUE, ""));
+    }
+
+    private HashMap<String, Object> buildPasswordCredentialProperties(String clientId, String clientSecret,
+                                                                     String tokenEndpoint, String username,
+                                                                     String password) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        if (clientId != null) {
+            properties.put(TEST_CLIENT_ID_AUTH_PROPERTY, clientId);
+        }
+        if (clientSecret != null) {
+            properties.put(TEST_CLIENT_SECRET_AUTH_PROPERTY, clientSecret);
+        }
+        if (tokenEndpoint != null) {
+            properties.put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, tokenEndpoint);
+        }
+        if (username != null) {
+            properties.put(TEST_USERNAME_AUTH_PROPERTY, username);
+        }
+        if (password != null) {
+            properties.put(TEST_PASSWORD_AUTH_PROPERTY, password);
+        }
+        return properties;
+    }
+
+    private void assertPasswordCredentialMissingProperty(HashMap<String, Object> properties) {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = buildPasswordCredentialActionWith(properties);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    private void assertPasswordCredentialEmptyProperty(HashMap<String, Object> properties) {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = buildPasswordCredentialActionWith(properties);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
+    }
+
+    private PreUpdatePasswordActionModel buildPasswordCredentialActionWith(HashMap<String, Object> properties) {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = new PreUpdatePasswordActionModel();
+        passwordCredentialAction.setPasswordSharing(
+                new PasswordSharing().format(PasswordSharing.FormatEnum.PLAIN_TEXT));
+        passwordCredentialAction.setName(TEST_ACTION_NAME);
+        passwordCredentialAction.setDescription(TEST_ACTION_DESCRIPTION);
+        passwordCredentialAction.setEndpoint(new Endpoint()
+                .uri(TEST_ENDPOINT_URI)
+                .authentication(new AuthenticationType()
+                        .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                        .properties(properties)));
+        return passwordCredentialAction;
+    }
+
     /**
      * Create a sample Action.
      *

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordActionSuccessTest.java
@@ -728,4 +728,208 @@ public class PreUpdatePasswordActionSuccessTest extends PreUpdatePasswordTestBas
 
         deleteAction(PRE_UPDATE_PASSWORD_PATH , responseOfPost.getBody().jsonPath().getString("id"));
     }
+
+    @Test(dependsOnMethods = {"testCreateActionWithDuplicatedAttributes"})
+    public void testCreateActionWithPasswordCredentialAuthentication() {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = buildPasswordCredentialAction(true);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        String createdActionId = responseOfPost.getBody().jsonPath().getString("id");
+
+        Response responseOfGet = getResponseOfGet(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH + "/" + createdActionId);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PASSWORD_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthentication"})
+    public void testCreateActionWithPasswordCredentialAuthenticationWithoutScopes() {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = buildPasswordCredentialAction(false);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PASSWORD_PATH, responseOfPost.getBody().jsonPath().getString("id"));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthenticationWithoutScopes"})
+    public void testUpdateActionAuthenticationToPasswordCredential() {
+
+        PreUpdatePasswordActionModel basicAuthAction = new PreUpdatePasswordActionModel();
+        basicAuthAction.setPasswordSharing(new PasswordSharing().format(PasswordSharing.FormatEnum.PLAIN_TEXT));
+        basicAuthAction.setName(TEST_ACTION_NAME);
+        basicAuthAction.setDescription(TEST_ACTION_DESCRIPTION);
+        basicAuthAction.setEndpoint(new Endpoint()
+                .uri(TEST_ENDPOINT_URI)
+                .authentication(new AuthenticationType()
+                        .type(AuthenticationType.TypeEnum.BASIC)
+                        .properties(new HashMap<String, Object>() {{
+                            put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                            put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                        }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(basicAuthAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(buildPasswordCredentialAuthType(true)));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PASSWORD_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdateActionAuthenticationToPasswordCredential"})
+    public void testUpdatePasswordCredentialAuthenticationProperties() {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = buildPasswordCredentialAction(true);
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY,
+                                            TEST_UPDATED_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                                            TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_UPDATED_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PASSWORD_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdatePasswordCredentialAuthenticationProperties"})
+    public void testUpdatePasswordCredentialAddScopes() {
+
+        PreUpdatePasswordActionModel passwordCredentialAction = buildPasswordCredentialAction(false);
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(buildPasswordCredentialAuthType(true)));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PASSWORD_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE));
+
+        deleteAction(PRE_UPDATE_PASSWORD_PATH, createdActionId);
+    }
+
+    private PreUpdatePasswordActionModel buildPasswordCredentialAction(boolean includeScopes) {
+
+        PreUpdatePasswordActionModel actionModel = new PreUpdatePasswordActionModel();
+        actionModel.setPasswordSharing(new PasswordSharing().format(PasswordSharing.FormatEnum.PLAIN_TEXT));
+        actionModel.setName(TEST_ACTION_NAME);
+        actionModel.setDescription(TEST_ACTION_DESCRIPTION);
+        actionModel.setEndpoint(new Endpoint()
+                .uri(TEST_ENDPOINT_URI)
+                .authentication(buildPasswordCredentialAuthType(includeScopes)));
+        return actionModel;
+    }
+
+    private AuthenticationType buildPasswordCredentialAuthType(boolean includeScopes) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+        if (includeScopes) {
+            properties.put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+        }
+
+        return new AuthenticationType()
+                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                .properties(properties);
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileActionFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileActionFailureTest.java
@@ -256,6 +256,147 @@ public class PreUpdateProfileActionFailureTest extends PreUpdateProfileTestBase 
         deleteAction(PRE_UPDATE_PROFILE_PATH , testActionId2);
     }
 
+    @Test(dependsOnMethods = {"testUpdateActionWithInvalidAttributes"})
+    public void testCreateActionWithPasswordCredentialMissingClientId() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                null, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientId"})
+    public void testCreateActionWithPasswordCredentialMissingClientSecret() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, null, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingClientSecret"})
+    public void testCreateActionWithPasswordCredentialMissingTokenEndpoint() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, null,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialMissingUsername() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, null, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingUsername"})
+    public void testCreateActionWithPasswordCredentialMissingPassword() {
+
+        assertPasswordCredentialMissingProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, TEST_USERNAME_AUTH_PROPERTY_VALUE, null));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialMissingPassword"})
+    public void testCreateActionWithPasswordCredentialEmptyClientId() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                "", TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientId"})
+    public void testCreateActionWithPasswordCredentialEmptyClientSecret() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, "", TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE,
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyClientSecret"})
+    public void testCreateActionWithPasswordCredentialEmptyTokenEndpoint() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE, "",
+                TEST_USERNAME_AUTH_PROPERTY_VALUE, TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyTokenEndpoint"})
+    public void testCreateActionWithPasswordCredentialEmptyUsername() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, "", TEST_PASSWORD_AUTH_PROPERTY_VALUE));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialEmptyUsername"})
+    public void testCreateActionWithPasswordCredentialEmptyPassword() {
+
+        assertPasswordCredentialEmptyProperty(buildPasswordCredentialProperties(
+                TEST_CLIENT_ID_AUTH_PROPERTY_VALUE, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE,
+                TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE, TEST_USERNAME_AUTH_PROPERTY_VALUE, ""));
+    }
+
+    private HashMap<String, Object> buildPasswordCredentialProperties(String clientId, String clientSecret,
+                                                                     String tokenEndpoint, String username,
+                                                                     String password) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        if (clientId != null) {
+            properties.put(TEST_CLIENT_ID_AUTH_PROPERTY, clientId);
+        }
+        if (clientSecret != null) {
+            properties.put(TEST_CLIENT_SECRET_AUTH_PROPERTY, clientSecret);
+        }
+        if (tokenEndpoint != null) {
+            properties.put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, tokenEndpoint);
+        }
+        if (username != null) {
+            properties.put(TEST_USERNAME_AUTH_PROPERTY, username);
+        }
+        if (password != null) {
+            properties.put(TEST_PASSWORD_AUTH_PROPERTY, password);
+        }
+        return properties;
+    }
+
+    private void assertPasswordCredentialMissingProperty(HashMap<String, Object> properties) {
+
+        PreUpdateProfileActionModel passwordCredentialAction = buildPasswordCredentialActionWith(properties);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Required authentication properties are not " +
+                        "provided or invalid."));
+    }
+
+    private void assertPasswordCredentialEmptyProperty(HashMap<String, Object> properties) {
+
+        PreUpdateProfileActionModel passwordCredentialAction = buildPasswordCredentialActionWith(properties);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat().statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("description", equalTo("Authentication property values cannot be empty."));
+    }
+
+    private PreUpdateProfileActionModel buildPasswordCredentialActionWith(HashMap<String, Object> properties) {
+
+        PreUpdateProfileActionModel passwordCredentialAction = new PreUpdateProfileActionModel();
+        passwordCredentialAction.setName(TEST_ACTION_NAME);
+        passwordCredentialAction.setDescription(TEST_ACTION_DESCRIPTION);
+        passwordCredentialAction.setEndpoint(new Endpoint()
+                .uri(TEST_ENDPOINT_URI)
+                .authentication(new AuthenticationType()
+                        .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                        .properties(properties)));
+        return passwordCredentialAction;
+    }
+
     /**
      * Create a sample Action.
      *

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileActionSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileActionSuccessTest.java
@@ -608,4 +608,206 @@ public class PreUpdateProfileActionSuccessTest extends PreUpdateProfileTestBase 
 
         deleteAction(PRE_UPDATE_PROFILE_PATH , responseOfPost.getBody().jsonPath().getString("id"));
     }
+
+    @Test(dependsOnMethods = {"testCreateActionWithDuplicatedAttributes"})
+    public void testCreateActionWithPasswordCredentialAuthentication() {
+
+        PreUpdateProfileActionModel passwordCredentialAction = buildPasswordCredentialAction(true);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                        equalTo(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        String createdActionId = responseOfPost.getBody().jsonPath().getString("id");
+
+        Response responseOfGet = getResponseOfGet(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH + "/" + createdActionId);
+        responseOfGet.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PROFILE_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthentication"})
+    public void testCreateActionWithPasswordCredentialAuthenticationWithoutScopes() {
+
+        PreUpdateProfileActionModel passwordCredentialAction = buildPasswordCredentialAction(false);
+
+        Response responseOfPost = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(passwordCredentialAction));
+        responseOfPost.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PROFILE_PATH, responseOfPost.getBody().jsonPath().getString("id"));
+    }
+
+    @Test(dependsOnMethods = {"testCreateActionWithPasswordCredentialAuthenticationWithoutScopes"})
+    public void testUpdateActionAuthenticationToPasswordCredential() {
+
+        PreUpdateProfileActionModel basicAuthAction = new PreUpdateProfileActionModel();
+        basicAuthAction.setName(TEST_ACTION_NAME);
+        basicAuthAction.setDescription(TEST_ACTION_DESCRIPTION);
+        basicAuthAction.setEndpoint(new Endpoint()
+                .uri(TEST_ENDPOINT_URI)
+                .authentication(new AuthenticationType()
+                        .type(AuthenticationType.TypeEnum.BASIC)
+                        .properties(new HashMap<String, Object>() {{
+                            put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+                            put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+                        }})));
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(basicAuthAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(buildPasswordCredentialAuthType(true)));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.type",
+                        equalTo(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL.toString()))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PROFILE_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdateActionAuthenticationToPasswordCredential"})
+    public void testUpdatePasswordCredentialAuthenticationProperties() {
+
+        PreUpdateProfileActionModel passwordCredentialAction = buildPasswordCredentialAction(true);
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(new AuthenticationType()
+                                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                                .properties(new HashMap<String, Object>() {{
+                                    put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE);
+                                    put(TEST_CLIENT_SECRET_AUTH_PROPERTY,
+                                            TEST_UPDATED_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+                                    put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY,
+                                            TEST_UPDATED_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+                                    put(TEST_USERNAME_AUTH_PROPERTY, TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE);
+                                    put(TEST_PASSWORD_AUTH_PROPERTY, TEST_UPDATED_PASSWORD_AUTH_PROPERTY_VALUE);
+                                    put(TEST_SCOPES_AUTH_PROPERTY, TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE);
+                                }})));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.properties." + TEST_CLIENT_ID_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_CLIENT_ID_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_USERNAME_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_USERNAME_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_UPDATED_SCOPES_AUTH_PROPERTY_VALUE))
+                .body("endpoint.authentication.properties." + TEST_CLIENT_SECRET_AUTH_PROPERTY, nullValue())
+                .body("endpoint.authentication.properties." + TEST_PASSWORD_AUTH_PROPERTY, nullValue());
+
+        deleteAction(PRE_UPDATE_PROFILE_PATH, createdActionId);
+    }
+
+    @Test(dependsOnMethods = {"testUpdatePasswordCredentialAuthenticationProperties"})
+    public void testUpdatePasswordCredentialAddScopes() {
+
+        PreUpdateProfileActionModel passwordCredentialAction = buildPasswordCredentialAction(false);
+
+        Response createResponse = getResponseOfPost(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH, toJSONString(passwordCredentialAction));
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        String createdActionId = createResponse.getBody().jsonPath().getString("id");
+
+        ActionUpdateModel actionUpdateModel = new ActionUpdateModel()
+                .endpoint(new EndpointUpdateModel()
+                        .authentication(buildPasswordCredentialAuthType(true)));
+
+        Response responseOfPatch = getResponseOfPatch(ACTION_MANAGEMENT_API_BASE_PATH +
+                PRE_UPDATE_PROFILE_PATH + "/" + createdActionId, toJSONString(actionUpdateModel));
+        responseOfPatch.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("endpoint.authentication.properties." + TEST_SCOPES_AUTH_PROPERTY,
+                        equalTo(TEST_SCOPES_AUTH_PROPERTY_VALUE));
+
+        deleteAction(PRE_UPDATE_PROFILE_PATH, createdActionId);
+    }
+
+    private PreUpdateProfileActionModel buildPasswordCredentialAction(boolean includeScopes) {
+
+        PreUpdateProfileActionModel actionModel = new PreUpdateProfileActionModel();
+        actionModel.setName(TEST_ACTION_NAME);
+        actionModel.setDescription(TEST_ACTION_DESCRIPTION);
+        actionModel.setEndpoint(new Endpoint()
+                .uri(TEST_ENDPOINT_URI)
+                .authentication(buildPasswordCredentialAuthType(includeScopes)));
+        return actionModel;
+    }
+
+    private AuthenticationType buildPasswordCredentialAuthType(boolean includeScopes) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(TEST_CLIENT_ID_AUTH_PROPERTY, TEST_CLIENT_ID_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_CLIENT_SECRET_AUTH_PROPERTY, TEST_CLIENT_SECRET_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_TOKEN_ENDPOINT_AUTH_PROPERTY, TEST_TOKEN_ENDPOINT_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_USERNAME_AUTH_PROPERTY, TEST_USERNAME_AUTH_PROPERTY_VALUE);
+        properties.put(TEST_PASSWORD_AUTH_PROPERTY, TEST_PASSWORD_AUTH_PROPERTY_VALUE);
+        if (includeScopes) {
+            properties.put(TEST_SCOPES_AUTH_PROPERTY, TEST_SCOPES_AUTH_PROPERTY_VALUE);
+        }
+
+        return new AuthenticationType()
+                .type(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL)
+                .properties(properties);
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/common/ActionsBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/common/ActionsBaseTestCase.java
@@ -36,9 +36,23 @@ public class ActionsBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
     protected ActionsRestClient actionsRestClient;
     protected static final String USERNAME_PROPERTY = "username";
     protected static final String PASSWORD_PROPERTY = "password";
+    protected static final String CLIENT_ID_PROPERTY = "clientId";
+    protected static final String CLIENT_SECRET_PROPERTY = "clientSecret";
+    protected static final String TOKEN_ENDPOINT_PROPERTY = "tokenEndpoint";
+    protected static final String SCOPES_PROPERTY = "scopes";
     protected static final String MOCK_SERVER_AUTH_BASIC_USERNAME = "test";
     protected static final String MOCK_SERVER_AUTH_BASIC_PASSWORD = "test";
     protected static final String EXTERNAL_SERVICE_URI = "http://localhost:8587/test/action";
+
+    protected static final String MOCK_IDP_TOKEN_ENDPOINT_PATH = "/test/idp/token";
+    protected static final String MOCK_IDP_TOKEN_ENDPOINT_URI =
+            "http://localhost:8587" + MOCK_IDP_TOKEN_ENDPOINT_PATH;
+    protected static final String MOCK_IDP_CLIENT_ID = "test-idp-client-id";
+    protected static final String MOCK_IDP_CLIENT_SECRET = "test-idp-client-secret";
+    protected static final String MOCK_IDP_USERNAME = "test-idp-user";
+    protected static final String MOCK_IDP_PASSWORD = "test-idp-password";
+    protected static final String MOCK_IDP_SCOPES = "send_scope";
+    protected static final String MOCK_IDP_ACCESS_TOKEN = "mock-idp-access-token-value";
 
     /**
      * Initialize the test case.

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/mockservices/ServiceExtensionMockServer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/mockservices/ServiceExtensionMockServer.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -87,5 +88,56 @@ public class ServiceExtensionMockServer {
 
     public void resetRequests() {
         wireMockServer.resetRequests();
+    }
+
+    /**
+     * Stub a token endpoint that returns a Bearer access token only when the request has the
+     * expected Basic auth header and a form body containing the password grant fields.
+     *
+     * @param url             URL of the token endpoint (path).
+     * @param basicAuthHeader Expected Authorization header value (regex-matched).
+     * @param accessToken     Access token to return on a successful match.
+     * @param username        Expected username form value.
+     * @param password        Expected password form value.
+     */
+    public void setupTokenEndpointStub(String url, String basicAuthHeader, String accessToken,
+                                       String username, String password) {
+
+        String responseBody = "{\"access_token\":\"" + accessToken +
+                "\",\"token_type\":\"Bearer\",\"expires_in\":3600}";
+
+        wireMockServer.stubFor(post(urlEqualTo(url))
+                .withHeader("Authorization", matching(basicAuthHeader))
+                .withRequestBody(containing("grant_type=password"))
+                .withRequestBody(containing("username=" + username))
+                .withRequestBody(containing("password=" + password))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("Connection", "Close")
+                        .withBody(responseBody)));
+    }
+
+    /**
+     * Stub a token endpoint that responds with the given status code and body for any POST.
+     * Used in failure tests to simulate an unhealthy IdP.
+     */
+    public void setupTokenEndpointStubWithError(String url, int statusCode, String responseBody) {
+
+        wireMockServer.stubFor(post(urlEqualTo(url))
+                .willReturn(aResponse()
+                        .withStatus(statusCode)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("Connection", "Close")
+                        .withBody(responseBody)));
+    }
+
+    /**
+     * Count the number of POST requests received at the given URL.
+     */
+    public int getReceivedRequestCount(String url) {
+
+        List<LoggedRequest> requestList = wireMockServer.findAll(postRequestedFor(urlEqualTo(url)));
+        return requestList == null ? 0 : requestList.size();
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/mockservices/ServiceExtensionMockServer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/mockservices/ServiceExtensionMockServer.java
@@ -92,7 +92,7 @@ public class ServiceExtensionMockServer {
 
     /**
      * Stub a token endpoint that returns a Bearer access token only when the request has the
-     * expected Basic auth header and a form body containing the password grant fields.
+     * expected Basic auth header and a form body for the OAuth2 password grant.
      *
      * @param url             URL of the token endpoint (path).
      * @param basicAuthHeader Expected Authorization header value (regex-matched).
@@ -100,8 +100,8 @@ public class ServiceExtensionMockServer {
      * @param username        Expected username form value.
      * @param password        Expected password form value.
      */
-    public void setupTokenEndpointStub(String url, String basicAuthHeader, String accessToken,
-                                       String username, String password) {
+    public void setupTokenEndpointStubForPasswordGrant(String url, String basicAuthHeader, String accessToken,
+                                                      String username, String password) {
 
         String responseBody = "{\"access_token\":\"" + accessToken +
                 "\",\"token_type\":\"Bearer\",\"expires_in\":3600}";
@@ -111,6 +111,30 @@ public class ServiceExtensionMockServer {
                 .withRequestBody(containing("grant_type=password"))
                 .withRequestBody(containing("username=" + username))
                 .withRequestBody(containing("password=" + password))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("Connection", "Close")
+                        .withBody(responseBody)));
+    }
+
+    /**
+     * Stub a token endpoint that returns a Bearer access token only when the request has the
+     * expected Basic auth header and a form body for the OAuth2 client_credentials grant.
+     *
+     * @param url             URL of the token endpoint (path).
+     * @param basicAuthHeader Expected Authorization header value (regex-matched).
+     * @param accessToken     Access token to return on a successful match.
+     */
+    public void setupTokenEndpointStubForClientCredentialsGrant(String url, String basicAuthHeader,
+                                                                String accessToken) {
+
+        String responseBody = "{\"access_token\":\"" + accessToken +
+                "\",\"token_type\":\"Bearer\",\"expires_in\":3600}";
+
+        wireMockServer.stubFor(post(urlEqualTo(url))
+                .withHeader("Authorization", matching(basicAuthHeader))
+                .withRequestBody(containing("grant_type=client_credentials"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailureClientCredentialAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailureClientCredentialAuthTestCase.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.ActionModel;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.AuthenticationType;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.Endpoint;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ActionResponse;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ExpectedTokenResponse;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.utils.FileUtils;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
+
+/**
+ * Tests pre-issue access token action failure scenarios driven by an unhealthy / non-conformant
+ * token endpoint when the action endpoint is configured with CLIENT_CREDENTIAL authentication.
+ * Each scenario asserts that the IS server returns a server_error to the client and never invokes
+ * the action endpoint when token acquisition fails.
+ */
+public class PreIssueAccessTokenActionFailureClientCredentialAuthTestCase extends ActionsBaseTestCase {
+
+    private static final String PRE_ISSUE_ACCESS_TOKEN_API_PATH = "preIssueAccessToken";
+    private static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+    private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+    private CloseableHttpClient client;
+    private List<String> requestedScopes;
+    private String clientId;
+    private String clientSecret;
+    private String actionId;
+    private String applicationId;
+    private final TestUserMode userMode;
+    private ServiceExtensionMockServer serviceExtensionMockServer;
+    private final ActionResponse tokenEndpointResponse;
+    private final ExpectedTokenResponse expectedTokenResponse;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public PreIssueAccessTokenActionFailureClientCredentialAuthTestCase(TestUserMode testUserMode,
+                                                                        ActionResponse tokenEndpointResponse,
+                                                                        ExpectedTokenResponse expectedTokenResponse) {
+
+        this.userMode = testUserMode;
+        this.tokenEndpointResponse = tokenEndpointResponse;
+        this.expectedTokenResponse = expectedTokenResponse;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(401, "Unauthorized"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.SUPER_TENANT_USER,
+                        new ActionResponse(400, "{\"error\":\"invalid_client\"}"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.SUPER_TENANT_USER,
+                        new ActionResponse(200, "{\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.TENANT_USER, new ActionResponse(500, "Internal Error"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.TENANT_USER, new ActionResponse(200, "not-json"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+        client = HttpClientBuilder.create().build();
+
+        ApplicationResponseModel application = addApplicationWithGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
+        applicationId = application.getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        clientId = oidcConfig.getClientId();
+        clientSecret = oidcConfig.getClientSecret();
+        actionId = createPreIssueAccessTokenAction();
+
+        requestedScopes = new ArrayList<>(Arrays.asList("scope_1", "scope_2"));
+
+        serviceExtensionMockServer = new ServiceExtensionMockServer();
+        serviceExtensionMockServer.startServer();
+        // Token endpoint always returns the configured failure response.
+        serviceExtensionMockServer.setupTokenEndpointStubWithError(MOCK_IDP_TOKEN_ENDPOINT_PATH,
+                tokenEndpointResponse.getStatusCode(), tokenEndpointResponse.getResponseBody());
+        // Action endpoint stub registered as a guard. If the IS server unexpectedly proceeds to call
+        // the action endpoint despite token acquisition failure, it will be detected by the call-count
+        // assertion below.
+        serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                "Bearer " + MOCK_IDP_ACCESS_TOKEN,
+                FileUtils.readFileInClassPathAsString("actions/response/pre-issue-access-token-response.json"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        serviceExtensionMockServer.stopServer();
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionId);
+        deleteApp(applicationId);
+
+        restClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        client.close();
+
+        serviceExtensionMockServer = null;
+    }
+
+    @Test(groups = "wso2.is", description = "Verify token response when pre-issue access token action fails because " +
+            "the configured token endpoint returns an error or an invalid response, with the action endpoint " +
+            "configured to authenticate via CLIENT_CREDENTIAL.")
+    public void testPreIssueAccessTokenActionFailureOnTokenEndpoint() throws Exception {
+
+        HttpResponse response = sendTokenRequestForClientCredentialsGrant();
+
+        assertNotNull(response);
+        assertEquals(response.getStatusLine().getStatusCode(), expectedTokenResponse.getStatusCode());
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+        assertEquals(jsonResponse.getString("error"), expectedTokenResponse.getErrorMessage());
+        assertEquals(jsonResponse.getString("error_description"), expectedTokenResponse.getErrorDescription());
+
+        Assert.assertTrue(serviceExtensionMockServer.getReceivedRequestCount(MOCK_IDP_TOKEN_ENDPOINT_PATH) >= 1,
+                "Expected at least one call to the configured token endpoint.");
+        Assert.assertEquals(serviceExtensionMockServer.getReceivedRequestCount(MOCK_SERVER_ENDPOINT_RESOURCE_PATH), 0,
+                "Action endpoint must not be called when token acquisition fails.");
+    }
+
+    private HttpResponse sendTokenRequestForClientCredentialsGrant() throws Exception {
+
+        List<NameValuePair> parameters = new ArrayList<>();
+        parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
+
+        String scopes = String.join(" ", requestedScopes);
+        parameters.add(new BasicNameValuePair("scope", scopes));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER, OAuth2Constant.BASIC_HEADER + " " +
+                getBase64EncodedString(clientId, clientSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        return sendPostRequest(client, headers, parameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+    }
+
+    private String createPreIssueAccessTokenAction() throws IOException {
+
+        AuthenticationType authenticationType = new AuthenticationType();
+        authenticationType.setType(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL);
+        Map<String, Object> authProperties = new HashMap<>();
+        authProperties.put(CLIENT_ID_PROPERTY, MOCK_IDP_CLIENT_ID);
+        authProperties.put(CLIENT_SECRET_PROPERTY, MOCK_IDP_CLIENT_SECRET);
+        authProperties.put(TOKEN_ENDPOINT_PROPERTY, MOCK_IDP_TOKEN_ENDPOINT_URI);
+        authenticationType.setProperties(authProperties);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setUri(EXTERNAL_SERVICE_URI);
+        endpoint.setAuthentication(authenticationType);
+        endpoint.addAllowedHeadersItem("testHeader");
+        endpoint.addAllowedParametersItem("testParam");
+
+        ActionModel actionModel = new ActionModel();
+        actionModel.setName("Access Token Pre Issue ClientCredential Failure");
+        actionModel.setDescription("Pre issue access token action with CLIENT_CREDENTIAL authentication " +
+                "and an unhealthy token endpoint");
+        actionModel.setEndpoint(endpoint);
+
+        return createAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionModel);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailurePasswordCredentialAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionFailurePasswordCredentialAuthTestCase.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.ActionModel;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.AuthenticationType;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.Endpoint;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ActionResponse;
+import org.wso2.identity.integration.test.serviceextensions.dataprovider.model.ExpectedTokenResponse;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.utils.FileUtils;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
+
+/**
+ * Tests pre-issue access token action failure scenarios driven by an unhealthy / non-conformant
+ * token endpoint when the action endpoint is configured with PASSWORD_CREDENTIAL authentication.
+ * Each scenario asserts that the IS server returns a server_error to the client and never invokes
+ * the action endpoint when token acquisition fails.
+ */
+public class PreIssueAccessTokenActionFailurePasswordCredentialAuthTestCase extends ActionsBaseTestCase {
+
+    private static final String PRE_ISSUE_ACCESS_TOKEN_API_PATH = "preIssueAccessToken";
+    private static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+    private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+    private CloseableHttpClient client;
+    private List<String> requestedScopes;
+    private String clientId;
+    private String clientSecret;
+    private String actionId;
+    private String applicationId;
+    private final TestUserMode userMode;
+    private ServiceExtensionMockServer serviceExtensionMockServer;
+    private final ActionResponse tokenEndpointResponse;
+    private final ExpectedTokenResponse expectedTokenResponse;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public PreIssueAccessTokenActionFailurePasswordCredentialAuthTestCase(TestUserMode testUserMode,
+                                                                          ActionResponse tokenEndpointResponse,
+                                                                          ExpectedTokenResponse expectedTokenResponse) {
+
+        this.userMode = testUserMode;
+        this.tokenEndpointResponse = tokenEndpointResponse;
+        this.expectedTokenResponse = expectedTokenResponse;
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER, new ActionResponse(401, "Unauthorized"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.SUPER_TENANT_USER,
+                        new ActionResponse(400, "{\"error\":\"invalid_grant\"}"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.SUPER_TENANT_USER,
+                        new ActionResponse(200, "{\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.TENANT_USER, new ActionResponse(500, "Internal Error"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")},
+                {TestUserMode.TENANT_USER, new ActionResponse(200, "not-json"),
+                        new ExpectedTokenResponse(500, "server_error", "Internal Server Error.")}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+        client = HttpClientBuilder.create().build();
+
+        ApplicationResponseModel application = addApplicationWithGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
+        applicationId = application.getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        clientId = oidcConfig.getClientId();
+        clientSecret = oidcConfig.getClientSecret();
+        actionId = createPreIssueAccessTokenAction();
+
+        requestedScopes = new ArrayList<>(Arrays.asList("scope_1", "scope_2"));
+
+        serviceExtensionMockServer = new ServiceExtensionMockServer();
+        serviceExtensionMockServer.startServer();
+        // Token endpoint always returns the configured failure response.
+        serviceExtensionMockServer.setupTokenEndpointStubWithError(MOCK_IDP_TOKEN_ENDPOINT_PATH,
+                tokenEndpointResponse.getStatusCode(), tokenEndpointResponse.getResponseBody());
+        // Action endpoint stub registered as a guard. If the IS server unexpectedly proceeds to call
+        // the action endpoint despite token acquisition failure, it will be detected by the call-count
+        // assertion below.
+        serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                "Bearer " + MOCK_IDP_ACCESS_TOKEN,
+                FileUtils.readFileInClassPathAsString("actions/response/pre-issue-access-token-response.json"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        serviceExtensionMockServer.stopServer();
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionId);
+        deleteApp(applicationId);
+
+        restClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        client.close();
+
+        serviceExtensionMockServer = null;
+    }
+
+    @Test(groups = "wso2.is", description = "Verify token response when pre-issue access token action fails because " +
+            "the configured token endpoint returns an error or an invalid response.")
+    public void testPreIssueAccessTokenActionFailureOnTokenEndpoint() throws Exception {
+
+        HttpResponse response = sendTokenRequestForClientCredentialsGrant();
+
+        assertNotNull(response);
+        assertEquals(response.getStatusLine().getStatusCode(), expectedTokenResponse.getStatusCode());
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+        assertEquals(jsonResponse.getString("error"), expectedTokenResponse.getErrorMessage());
+        assertEquals(jsonResponse.getString("error_description"), expectedTokenResponse.getErrorDescription());
+
+        Assert.assertTrue(serviceExtensionMockServer.getReceivedRequestCount(MOCK_IDP_TOKEN_ENDPOINT_PATH) >= 1,
+                "Expected at least one call to the configured token endpoint.");
+        Assert.assertEquals(serviceExtensionMockServer.getReceivedRequestCount(MOCK_SERVER_ENDPOINT_RESOURCE_PATH), 0,
+                "Action endpoint must not be called when token acquisition fails.");
+    }
+
+    private HttpResponse sendTokenRequestForClientCredentialsGrant() throws Exception {
+
+        List<NameValuePair> parameters = new ArrayList<>();
+        parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
+
+        String scopes = String.join(" ", requestedScopes);
+        parameters.add(new BasicNameValuePair("scope", scopes));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER, OAuth2Constant.BASIC_HEADER + " " +
+                getBase64EncodedString(clientId, clientSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        return sendPostRequest(client, headers, parameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+    }
+
+    private String createPreIssueAccessTokenAction() throws IOException {
+
+        AuthenticationType authenticationType = new AuthenticationType();
+        authenticationType.setType(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL);
+        Map<String, Object> authProperties = new HashMap<>();
+        authProperties.put(CLIENT_ID_PROPERTY, MOCK_IDP_CLIENT_ID);
+        authProperties.put(CLIENT_SECRET_PROPERTY, MOCK_IDP_CLIENT_SECRET);
+        authProperties.put(TOKEN_ENDPOINT_PROPERTY, MOCK_IDP_TOKEN_ENDPOINT_URI);
+        authProperties.put(USERNAME_PROPERTY, MOCK_IDP_USERNAME);
+        authProperties.put(PASSWORD_PROPERTY, MOCK_IDP_PASSWORD);
+        authenticationType.setProperties(authProperties);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setUri(EXTERNAL_SERVICE_URI);
+        endpoint.setAuthentication(authenticationType);
+        endpoint.addAllowedHeadersItem("testHeader");
+        endpoint.addAllowedParametersItem("testParam");
+
+        ActionModel actionModel = new ActionModel();
+        actionModel.setName("Access Token Pre Issue PasswordCredential Failure");
+        actionModel.setDescription("Pre issue access token action with PASSWORD_CREDENTIAL authentication " +
+                "and an unhealthy token endpoint");
+        actionModel.setEndpoint(endpoint);
+
+        return createAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionModel);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessClientCredentialAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessClientCredentialAuthTestCase.java
@@ -84,14 +84,14 @@ import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRA
 
 /**
  * Integration test class for testing the pre issue access token flow when the action endpoint
- * is configured with PASSWORD_CREDENTIAL authentication. The IS server is expected to acquire an
- * access token from the configured token endpoint via OAuth2 password grant and apply it to the
- * action endpoint as a Bearer token. The application-side trigger here is
+ * is configured with CLIENT_CREDENTIAL authentication. The IS server is expected to acquire an
+ * access token from the configured token endpoint via OAuth2 client_credentials grant and apply
+ * it to the action endpoint as a Bearer token. The application-side trigger here is
  * {@code client_credentials}.
  */
-public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase extends ActionsBaseTestCase {
+public class PreIssueAccessTokenActionSuccessClientCredentialAuthTestCase extends ActionsBaseTestCase {
 
-    private static final String EXTERNAL_SERVICE_NAME = "TestExternalServicePasswordCred";
+    private static final String EXTERNAL_SERVICE_NAME = "TestExternalServiceClientCred";
     private static final String PRE_ISSUE_ACCESS_TOKEN_API_PATH = "preIssueAccessToken";
     private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
 
@@ -135,7 +135,7 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
     private ServiceExtensionMockServer serviceExtensionMockServer;
 
     @Factory(dataProvider = "testExecutionContextProvider")
-    public PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase(TestUserMode testUserMode) {
+    public PreIssueAccessTokenActionSuccessClientCredentialAuthTestCase(TestUserMode testUserMode) {
 
         this.userMode = testUserMode;
         this.tenantId = testUserMode == TestUserMode.SUPER_TENANT_USER ? "-1234" : "1";
@@ -203,10 +203,10 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
 
         serviceExtensionMockServer = new ServiceExtensionMockServer();
         serviceExtensionMockServer.startServer();
-        serviceExtensionMockServer.setupTokenEndpointStubForPasswordGrant(
+        serviceExtensionMockServer.setupTokenEndpointStubForClientCredentialsGrant(
                 MOCK_IDP_TOKEN_ENDPOINT_PATH,
                 "Basic " + getBase64EncodedString(MOCK_IDP_CLIENT_ID, MOCK_IDP_CLIENT_SECRET),
-                MOCK_IDP_ACCESS_TOKEN, MOCK_IDP_USERNAME, MOCK_IDP_PASSWORD);
+                MOCK_IDP_ACCESS_TOKEN);
         serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
                 "Bearer " + MOCK_IDP_ACCESS_TOKEN,
                 FileUtils.readFileInClassPathAsString("actions/response/pre-issue-access-token-response.json"));
@@ -232,7 +232,7 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
     }
 
     @Test(groups = "wso2.is", description = "Get access token with client credentials grant which triggers the " +
-            "pre issue access token action configured with PASSWORD_CREDENTIAL authentication")
+            "pre issue access token action configured with CLIENT_CREDENTIAL authentication")
     public void testGetAccessTokenWithClientCredentialsGrant() throws Exception {
 
         List<NameValuePair> parameters = new ArrayList<>();
@@ -263,8 +263,8 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
 
     @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant", description =
             "Verify the IS server requested an access token from the configured token endpoint using OAuth2 " +
-                    "password grant with the configured credentials.")
-    public void testTokenEndpointReceivedPasswordGrantRequest() {
+                    "client_credentials grant.")
+    public void testTokenEndpointReceivedClientCredentialsGrantRequest() {
 
         int callCount = serviceExtensionMockServer.getReceivedRequestCount(MOCK_IDP_TOKEN_ENDPOINT_PATH);
         Assert.assertTrue(callCount >= 1,
@@ -272,14 +272,15 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
 
         String tokenRequestPayload =
                 serviceExtensionMockServer.getReceivedRequestPayload(MOCK_IDP_TOKEN_ENDPOINT_PATH);
-        Assert.assertTrue(tokenRequestPayload.contains("grant_type=password"),
-                "Token endpoint request body did not contain grant_type=password. Body: " + tokenRequestPayload);
-        Assert.assertTrue(tokenRequestPayload.contains("username=" + MOCK_IDP_USERNAME),
-                "Token endpoint request body did not contain username=" + MOCK_IDP_USERNAME +
-                        ". Body: " + tokenRequestPayload);
-        Assert.assertTrue(tokenRequestPayload.contains("password=" + MOCK_IDP_PASSWORD),
-                "Token endpoint request body did not contain password=" + MOCK_IDP_PASSWORD +
-                        ". Body: " + tokenRequestPayload);
+        Assert.assertTrue(tokenRequestPayload.contains("grant_type=client_credentials"),
+                "Token endpoint request body did not contain grant_type=client_credentials. Body: "
+                        + tokenRequestPayload);
+        Assert.assertFalse(tokenRequestPayload.contains("username="),
+                "Token endpoint request body must not contain a username field for client_credentials. Body: "
+                        + tokenRequestPayload);
+        Assert.assertFalse(tokenRequestPayload.contains("password="),
+                "Token endpoint request body must not contain a password field for client_credentials. Body: "
+                        + tokenRequestPayload);
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant", description =
@@ -447,13 +448,11 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
     private String createPreIssueAccessTokenAction() throws IOException {
 
         AuthenticationType authenticationType = new AuthenticationType();
-        authenticationType.setType(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL);
+        authenticationType.setType(AuthenticationType.TypeEnum.CLIENT_CREDENTIAL);
         Map<String, Object> authProperties = new HashMap<>();
         authProperties.put(CLIENT_ID_PROPERTY, MOCK_IDP_CLIENT_ID);
         authProperties.put(CLIENT_SECRET_PROPERTY, MOCK_IDP_CLIENT_SECRET);
         authProperties.put(TOKEN_ENDPOINT_PROPERTY, MOCK_IDP_TOKEN_ENDPOINT_URI);
-        authProperties.put(USERNAME_PROPERTY, MOCK_IDP_USERNAME);
-        authProperties.put(PASSWORD_PROPERTY, MOCK_IDP_PASSWORD);
         authProperties.put(SCOPES_PROPERTY, MOCK_IDP_SCOPES);
         authenticationType.setProperties(authProperties);
 
@@ -464,8 +463,8 @@ public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase exte
         endpoint.addAllowedParametersItem("testParam");
 
         ActionModel actionModel = new ActionModel();
-        actionModel.setName("Access Token Pre Issue PasswordCredential");
-        actionModel.setDescription("Pre issue access token action with PASSWORD_CREDENTIAL authentication");
+        actionModel.setName("Access Token Pre Issue ClientCredential");
+        actionModel.setDescription("Pre issue access token action with CLIENT_CREDENTIAL authentication");
         actionModel.setEndpoint(endpoint);
 
         return createAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionModel);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preissueaccesstoken/PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.ActionModel;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.AuthenticationType;
+import org.wso2.identity.integration.test.rest.api.server.action.management.v1.common.model.Endpoint;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.serviceextensions.common.ActionsBaseTestCase;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.serviceextensions.model.AccessToken;
+import org.wso2.identity.integration.test.serviceextensions.model.ActionType;
+import org.wso2.identity.integration.test.serviceextensions.model.AllowedOperation;
+import org.wso2.identity.integration.test.serviceextensions.model.Operation;
+import org.wso2.identity.integration.test.serviceextensions.model.PreIssueAccessTokenActionRequest;
+import org.wso2.identity.integration.test.serviceextensions.model.PreIssueAccessTokenEvent;
+import org.wso2.identity.integration.test.serviceextensions.model.Tenant;
+import org.wso2.identity.integration.test.serviceextensions.model.TokenRequest;
+import org.wso2.identity.integration.test.utils.CarbonUtils;
+import org.wso2.identity.integration.test.utils.FileUtils;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS;
+
+/**
+ * Integration test class for testing the pre issue access token flow when the action endpoint
+ * is configured with PASSWORD_CREDENTIAL authentication. The IS server is expected to acquire an
+ * access token from the configured token endpoint via OAuth2 password grant and apply it to the
+ * action endpoint as a Bearer token. The application-side trigger here is
+ * {@code client_credentials}.
+ */
+public class PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase extends ActionsBaseTestCase {
+
+    private static final String EXTERNAL_SERVICE_NAME = "TestExternalServicePasswordCred";
+    private static final String PRE_ISSUE_ACCESS_TOKEN_API_PATH = "preIssueAccessToken";
+    private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+
+    private static final String INTERNAL_ORG_USER_MANAGEMENT_LIST = "internal_org_user_mgt_list";
+    private static final String INTERNAL_ORG_USER_MANAGEMENT_VIEW = "internal_org_user_mgt_view";
+    private static final String INTERNAL_ORG_USER_MANAGEMENT_CREATE = "internal_org_user_mgt_create";
+    private static final String INTERNAL_ORG_USER_MANAGEMENT_UPDATE = "internal_org_user_mgt_update";
+    private static final String INTERNAL_ORG_USER_MANAGEMENT_DELETE = "internal_org_user_mgt_delete";
+    private static final String CUSTOM_SCOPE_1 = "test_custom_scope_1";
+    private static final String CUSTOM_SCOPE_2 = "test_custom_scope_2";
+    private static final String CUSTOM_SCOPE_3 = "test_custom_scope_3";
+    private static final String NEW_SCOPE_1 = "new_test_custom_scope_1";
+    private static final String NEW_SCOPE_2 = "new_test_custom_scope_2";
+    private static final String NEW_SCOPE_3 = "new_test_custom_scope_3";
+    private static final String NEW_SCOPE_4 = "replaced_scope";
+
+    private static final String SCIM2_USERS_API = "/o/scim2/Users";
+    private static final String CLAIMS_PATH_PREFIX = "/accessToken/claims/";
+    private static final String SCOPES_PATH_PREFIX = "/accessToken/scopes/";
+    private static final String MOCK_SERVER_ENDPOINT_RESOURCE_PATH = "/test/action";
+
+    private static final int UPDATED_EXPIRY_TIME_PERIOD = 7200;
+    private static final int CURRENT_EXPIRY_TIME_PERIOD = 3600;
+    private Lookup<CookieSpecProvider> cookieSpecRegistry;
+    private RequestConfig requestConfig;
+    private CloseableHttpClient client;
+    private SCIM2RestClient scim2RestClient;
+    private List<String> customScopes;
+    private List<String> requestedScopes;
+    private String accessToken;
+    private String clientId;
+    private String clientSecret;
+    private String subjectType;
+    private String tokenType;
+    private String actionId;
+    private String applicationId;
+    private String domainAPIId;
+    private String tenantId;
+    private JWTClaimsSet jwtClaims;
+    private TestUserMode userMode;
+    private ServiceExtensionMockServer serviceExtensionMockServer;
+
+    @Factory(dataProvider = "testExecutionContextProvider")
+    public PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase(TestUserMode testUserMode) {
+
+        this.userMode = testUserMode;
+        this.tenantId = testUserMode == TestUserMode.SUPER_TENANT_USER ? "-1234" : "1";
+    }
+
+    @DataProvider(name = "testExecutionContextProvider")
+    public static Object[][] getTestExecutionContext() {
+
+        return new Object[][]{
+                {TestUserMode.SUPER_TENANT_USER},
+                {TestUserMode.TENANT_USER}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void testInit() throws Exception {
+
+        super.init(userMode);
+
+        cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, new RFC6265CookieSpecProvider())
+                .build();
+        requestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.DEFAULT)
+                .build();
+        client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setDefaultCookieSpecRegistry(cookieSpecRegistry)
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+
+                        return false;
+                    }
+                }).build();
+
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+
+        customScopes = Arrays.asList(CUSTOM_SCOPE_1, CUSTOM_SCOPE_2, CUSTOM_SCOPE_3);
+
+        ApplicationResponseModel application = addApplicationWithGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
+        applicationId = application.getId();
+        OpenIDConnectConfiguration oidcConfig = getOIDCInboundDetailsOfApplication(applicationId);
+        clientId = oidcConfig.getClientId();
+        clientSecret = oidcConfig.getClientSecret();
+        subjectType = oidcConfig.getSubject().getSubjectType();
+        tokenType = oidcConfig.getAccessToken().getType();
+
+        if (!CarbonUtils.isLegacyAuthzRuntimeEnabled()) {
+            authorizeSystemAPIs(applicationId, Collections.singletonList(SCIM2_USERS_API));
+        }
+        domainAPIId = createDomainAPI(EXTERNAL_SERVICE_NAME, EXTERNAL_SERVICE_URI, customScopes);
+        authorizeDomainAPIs(applicationId, domainAPIId, customScopes);
+
+        requestedScopes = new ArrayList<>();
+        Collections.addAll(requestedScopes,
+                INTERNAL_ORG_USER_MANAGEMENT_LIST,
+                INTERNAL_ORG_USER_MANAGEMENT_VIEW,
+                INTERNAL_ORG_USER_MANAGEMENT_CREATE,
+                INTERNAL_ORG_USER_MANAGEMENT_UPDATE,
+                INTERNAL_ORG_USER_MANAGEMENT_DELETE);
+        requestedScopes.addAll(customScopes);
+
+        actionId = createPreIssueAccessTokenAction();
+
+        serviceExtensionMockServer = new ServiceExtensionMockServer();
+        serviceExtensionMockServer.startServer();
+        serviceExtensionMockServer.setupTokenEndpointStub(
+                MOCK_IDP_TOKEN_ENDPOINT_PATH,
+                "Basic " + getBase64EncodedString(MOCK_IDP_CLIENT_ID, MOCK_IDP_CLIENT_SECRET),
+                MOCK_IDP_ACCESS_TOKEN, MOCK_IDP_USERNAME, MOCK_IDP_PASSWORD);
+        serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
+                "Bearer " + MOCK_IDP_ACCESS_TOKEN,
+                FileUtils.readFileInClassPathAsString("actions/response/pre-issue-access-token-response.json"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        serviceExtensionMockServer.stopServer();
+
+        deleteAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionId);
+        deleteApp(applicationId);
+        deleteDomainAPI(domainAPIId);
+
+        restClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        actionsRestClient.closeHttpClient();
+        client.close();
+
+        serviceExtensionMockServer = null;
+        accessToken = null;
+        jwtClaims = null;
+    }
+
+    @Test(groups = "wso2.is", description = "Get access token with client credentials grant which triggers the " +
+            "pre issue access token action configured with PASSWORD_CREDENTIAL authentication")
+    public void testGetAccessTokenWithClientCredentialsGrant() throws Exception {
+
+        List<NameValuePair> parameters = new ArrayList<>();
+        parameters.add(new BasicNameValuePair("grant_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS));
+
+        String scopes = String.join(" ", requestedScopes);
+        parameters.add(new BasicNameValuePair("scope", scopes));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER, OAuth2Constant.BASIC_HEADER + " " +
+                getBase64EncodedString(clientId, clientSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(client, headers, parameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+
+        assertTrue(jsonResponse.has("access_token"), "Access token not found in the token response.");
+        accessToken = jsonResponse.getString("access_token");
+        assertNotNull(accessToken, "Access token is null.");
+
+        jwtClaims = extractJwtClaims(accessToken);
+        assertNotNull(jwtClaims);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant", description =
+            "Verify the IS server requested an access token from the configured token endpoint using OAuth2 " +
+                    "password grant with the configured credentials.")
+    public void testTokenEndpointReceivedPasswordGrantRequest() {
+
+        int callCount = serviceExtensionMockServer.getReceivedRequestCount(MOCK_IDP_TOKEN_ENDPOINT_PATH);
+        Assert.assertTrue(callCount >= 1,
+                "Expected at least one call to the configured token endpoint, got " + callCount);
+
+        String tokenRequestPayload =
+                serviceExtensionMockServer.getReceivedRequestPayload(MOCK_IDP_TOKEN_ENDPOINT_PATH);
+        Assert.assertTrue(tokenRequestPayload.contains("grant_type=password"),
+                "Token endpoint request body did not contain grant_type=password. Body: " + tokenRequestPayload);
+        Assert.assertTrue(tokenRequestPayload.contains("username=" + MOCK_IDP_USERNAME),
+                "Token endpoint request body did not contain username=" + MOCK_IDP_USERNAME +
+                        ". Body: " + tokenRequestPayload);
+        Assert.assertTrue(tokenRequestPayload.contains("password=" + MOCK_IDP_PASSWORD),
+                "Token endpoint request body did not contain password=" + MOCK_IDP_PASSWORD +
+                        ". Body: " + tokenRequestPayload);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant", description =
+            "Verify that the action endpoint received a request authenticated with the bearer token issued by the " +
+                    "configured token endpoint.")
+    public void testActionEndpointReceivedBearerToken() {
+
+        int callCount = serviceExtensionMockServer.getReceivedRequestCount(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
+        Assert.assertTrue(callCount >= 1,
+                "Expected at least one call to the action endpoint, got " + callCount);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant", description =
+            "Verify the pre issue access token action request payload sent to the action endpoint.")
+    public void testPreIssueAccessTokenActionRequest() throws Exception {
+
+        String actualRequestPayload =
+                serviceExtensionMockServer.getReceivedRequestPayload(MOCK_SERVER_ENDPOINT_RESOURCE_PATH);
+        PreIssueAccessTokenActionRequest actualRequest =
+                new ObjectMapper().readValue(actualRequestPayload, PreIssueAccessTokenActionRequest.class);
+
+        PreIssueAccessTokenActionRequest expectedRequest = getRequest();
+
+        assertEquals(actualRequest, expectedRequest);
+    }
+
+    @Test(groups = "wso2.is", description = "Verify that the access token contains the updated scopes " +
+            "after action execution", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenScopeOperations() throws Exception {
+
+        String[] scopes = jwtClaims.getStringClaim("scope").split("\\s+");
+
+        Assert.assertTrue(ArrayUtils.contains(scopes, NEW_SCOPE_1));
+        Assert.assertTrue(ArrayUtils.contains(scopes, NEW_SCOPE_2));
+        Assert.assertTrue(ArrayUtils.contains(scopes, NEW_SCOPE_3));
+        Assert.assertTrue(ArrayUtils.contains(scopes, NEW_SCOPE_4));
+        Assert.assertFalse(ArrayUtils.contains(scopes, INTERNAL_ORG_USER_MANAGEMENT_DELETE));
+        Assert.assertFalse(ArrayUtils.contains(scopes, INTERNAL_ORG_USER_MANAGEMENT_CREATE));
+    }
+
+    @Test(groups = "wso2.is", description = "Verify that the access token contains the updated 'aud' claims " +
+            "after action execution", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenAUDClaimOperations() throws Exception {
+
+        String[] audValueArray = jwtClaims.getStringArrayClaim("aud");
+
+        Assert.assertTrue(ArrayUtils.contains(audValueArray, "zzz1.com"));
+        Assert.assertTrue(ArrayUtils.contains(audValueArray, "zzz2.com"));
+        Assert.assertTrue(ArrayUtils.contains(audValueArray, "zzz3.com"));
+        Assert.assertTrue(ArrayUtils.contains(audValueArray, "zzzR.com"));
+        Assert.assertFalse(ArrayUtils.contains(audValueArray, clientId));
+    }
+
+    @Test(groups = "wso2.is", description = "Verify the presence of the specified custom string claim in the access " +
+            "token", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenStringClaimAddOperation() throws Exception {
+
+        String claimStr = jwtClaims.getStringClaim("custom_claim_string_1");
+        Assert.assertEquals(claimStr, "testCustomClaim1");
+    }
+
+    @Test(groups = "wso2.is", description = "Verify the presence of the specified custom number claim in the access " +
+            "token", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenNumberClaimAddOperation() throws Exception {
+
+        Number claimValue = jwtClaims.getIntegerClaim("custom_claim_number_1");
+        Assert.assertEquals(claimValue, 78);
+    }
+
+    @Test(groups = "wso2.is", description = "Verify the presence of the specified custom boolean claim in the access " +
+            "token", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenBooleanClaimAddOperation() throws Exception {
+
+        Boolean claimValue = jwtClaims.getBooleanClaim("custom_claim_boolean_1");
+        Assert.assertTrue(claimValue);
+    }
+
+    @Test(groups = "wso2.is", description = "Verify the presence of the specified custom string array claim in the " +
+            "access token", dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenStringArrayClaimAddOperation() throws Exception {
+
+        String[] expectedClaimArrayInToken = {"TestCustomClaim1", "TestCustomClaim2", "TestCustomClaim3"};
+
+        String[] addedClaimArrayToToken = jwtClaims.getStringArrayClaim("custom_claim_string_array_1");
+        Assert.assertEquals(addedClaimArrayToToken, expectedClaimArrayInToken);
+    }
+
+    @Test(groups = "wso2.is", description = "Verify the replacement of the 'expires_in' claim in the access token",
+            dependsOnMethods = "testGetAccessTokenWithClientCredentialsGrant")
+    public void testTokenExpiresInClaimReplaceOperation() throws Exception {
+
+        Date exp = jwtClaims.getDateClaim("exp");
+        Date iat = jwtClaims.getDateClaim("iat");
+        long expiresIn = (exp.getTime() - iat.getTime()) / 1000;
+
+        Assert.assertEquals(expiresIn, UPDATED_EXPIRY_TIME_PERIOD);
+    }
+
+    private PreIssueAccessTokenActionRequest getRequest() {
+
+        TokenRequest tokenRequest = createTokenRequest();
+        AccessToken accessTokenInRequest = createAccessToken();
+
+        Tenant tenant = new Tenant(tenantId, tenantInfo.getDomain());
+
+        PreIssueAccessTokenEvent event = new PreIssueAccessTokenEvent.Builder()
+                .request(tokenRequest)
+                .accessToken(accessTokenInRequest)
+                .tenant(tenant)
+                .organization(null)
+                .build();
+
+        List<AllowedOperation> allowedOperations = Arrays.asList(
+                createAllowedOperation(Operation.ADD, Arrays.asList(CLAIMS_PATH_PREFIX, SCOPES_PATH_PREFIX,
+                        CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.AUD.getName() + "/")),
+                createAllowedOperation(Operation.REMOVE, Arrays.asList(SCOPES_PATH_PREFIX,
+                        CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.AUD.getName() + "/")),
+                createAllowedOperation(Operation.REPLACE, Arrays.asList(SCOPES_PATH_PREFIX,
+                        CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.AUD.getName() + "/",
+                        CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.EXPIRES_IN.getName())));
+
+        return new PreIssueAccessTokenActionRequest.Builder()
+                .actionType(ActionType.PRE_ISSUE_ACCESS_TOKEN)
+                .event(event)
+                .allowedOperations(allowedOperations)
+                .build();
+    }
+
+    private TokenRequest createTokenRequest() {
+
+        return new TokenRequest.Builder()
+                .grantType(OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS)
+                .scopes(requestedScopes)
+                .clientId(clientId)
+                .build();
+    }
+
+    private AccessToken createAccessToken() {
+
+        List<AccessToken.Claim> claims = new ArrayList<>();
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.ISS.getName(),
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain())));
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.CLIENT_ID.getName(), clientId));
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.AUTHORIZED_USER_TYPE.getName(), "APPLICATION"));
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.EXPIRES_IN.getName(), CURRENT_EXPIRY_TIME_PERIOD));
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.AUD.getName(), Collections.singletonList(clientId)));
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.SUBJECT_TYPE.getName(), subjectType));
+        claims.add(new AccessToken.Claim(AccessToken.ClaimNames.SUB.getName(), clientId));
+
+        return new AccessToken.Builder()
+                .tokenType(tokenType)
+                .claims(claims)
+                .scopes(requestedScopes)
+                .build();
+    }
+
+    private AllowedOperation createAllowedOperation(Operation op, List<String> paths) {
+
+        AllowedOperation operation = new AllowedOperation();
+        operation.setOp(op);
+        operation.setPaths(new ArrayList<>(paths));
+        return operation;
+    }
+
+    private String createPreIssueAccessTokenAction() throws IOException {
+
+        AuthenticationType authenticationType = new AuthenticationType();
+        authenticationType.setType(AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL);
+        Map<String, Object> authProperties = new HashMap<>();
+        authProperties.put(CLIENT_ID_PROPERTY, MOCK_IDP_CLIENT_ID);
+        authProperties.put(CLIENT_SECRET_PROPERTY, MOCK_IDP_CLIENT_SECRET);
+        authProperties.put(TOKEN_ENDPOINT_PROPERTY, MOCK_IDP_TOKEN_ENDPOINT_URI);
+        authProperties.put(USERNAME_PROPERTY, MOCK_IDP_USERNAME);
+        authProperties.put(PASSWORD_PROPERTY, MOCK_IDP_PASSWORD);
+        authProperties.put(SCOPES_PROPERTY, MOCK_IDP_SCOPES);
+        authenticationType.setProperties(authProperties);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setUri(EXTERNAL_SERVICE_URI);
+        endpoint.setAuthentication(authenticationType);
+        endpoint.addAllowedHeadersItem("testHeader");
+        endpoint.addAllowedParametersItem("testParam");
+
+        ActionModel actionModel = new ActionModel();
+        actionModel.setName("Access Token Pre Issue PasswordCredential");
+        actionModel.setDescription("Pre issue access token action with PASSWORD_CREDENTIAL authentication");
+        actionModel.setEndpoint(endpoint);
+
+        return createAction(PRE_ISSUE_ACCESS_TOKEN_API_PATH, actionModel);
+    }
+
+    private JWTClaimsSet extractJwtClaims(String jwtToken) throws ParseException {
+
+        SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+        return signedJWT.getJWTClaimsSet();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -145,12 +145,14 @@
             <class name="org.wso2.identity.integration.test.oid4vci.OID4VCIIssuanceTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessPasswordGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessClientCredentialsGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessCodeGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessRefreshTokenGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailureCodeGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailurePasswordGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailureClientCredentialsGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailurePasswordCredentialAuthTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionWithRulesAtPasswordGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionWithRulesAtAuthorizationCodeGrantTestCase"/>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -146,6 +146,7 @@
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessPasswordGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessClientCredentialsGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessPasswordCredentialAuthTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessClientCredentialAuthTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessCodeGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessRefreshTokenGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionSuccessRefreshTokenExpiryTestCase"/>
@@ -153,6 +154,7 @@
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailurePasswordGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailureClientCredentialsGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailurePasswordCredentialAuthTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailureClientCredentialAuthTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionFailureRefreshTokenGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionWithRulesAtPasswordGrantTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preissueaccesstoken.PreIssueAccessTokenActionWithRulesAtAuthorizationCodeGrantTestCase"/>

--- a/pom.xml
+++ b/pom.xml
@@ -2825,7 +2825,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.6.8</identity.server.api.version>
+        <identity.server.api.version>1.6.9</identity.server.api.version>
         <identity.user.api.version>1.5.6</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2691,7 +2691,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.73</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.74</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
## Description

- Add integration tests for OAuth 2.0 password grant And client credential based authentication

## Summary

This pull request adds support and corresponding integration tests for a new `PASSWORD_CREDENTIAL` authentication type in the action management API. The changes include extending the authentication type enumeration and introducing comprehensive negative test cases to validate property requirements for the new authentication method.

**Authentication Type Extension:**

* Added `PASSWORD_CREDENTIAL` as a new value to the `AuthenticationType.TypeEnum` enumeration in `AuthenticationType.java`.

**Integration Test Enhancements:**

* Added a suite of negative test cases in `PreIssueAccessTokenActionFailureTest.java` to verify that all required properties for `PASSWORD_CREDENTIAL` authentication (client ID, client secret, token endpoint, username, password) are validated for presence and non-empty values. Helper methods were introduced to streamline property construction and assertion logic.