### PR TITLE
Introduce agent sharing management API to the product

### DIFF
--- a/modules/api-resources/api-resources-full/pom.xml
+++ b/modules/api-resources/api-resources-full/pom.xml
@@ -572,6 +572,14 @@
             <artifactId>org.wso2.carbon.identity.api.server.organization.user.sharing.management.v2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.organization.agent.sharing.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.organization.agent.sharing.management.v1</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.servlet.mgt</artifactId>
         </dependency>

--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
@@ -64,6 +64,7 @@
                 org.wso2.carbon.identity.api.server.organization.role.management.v1.OrganizationsApi,
                 org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.GuestsApi,
                 org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1.UsersApi,
+                org.wso2.carbon.identity.api.server.organization.agent.sharing.management.v1.AgentsApi,
                 org.wso2.carbon.identity.api.server.organization.configs.v1.OrganizationConfigsApi,
                 org.wso2.carbon.identity.api.expired.password.identification.v1.PasswordExpiredUsersApi,
                 org.wso2.carbon.identity.api.server.api.resource.v1.ApiResourcesApi,

--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -607,6 +607,16 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.agent.sharing.management.common</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.agent.sharing.management.v1</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.flow.management.v1</artifactId>
                 <version>${identity.server.api.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2691,7 +2691,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.74</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.76</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2721,7 +2721,7 @@
         <identity.carbon.auth.rest.version>1.12.11</identity.carbon.auth.rest.version>
 
         <!-- Identity Inbound Versions   -->
-        <identity.inbound.auth.oauth.version>7.5.36</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>7.5.38</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.saml.version>5.12.5</identity.inbound.auth.saml.version>
         <identity.inbound.auth.openid.version>5.13.1</identity.inbound.auth.openid.version>
         <identity.inbound.auth.sts.version>5.14.1</identity.inbound.auth.sts.version>
@@ -2811,7 +2811,7 @@
         <identity.extension.utils>1.3.0</identity.extension.utils>
         <authenticator.auth.otp.commons.version>1.1.2</authenticator.auth.otp.commons.version>
 
-        <identity.org.mgt.version>2.5.3</identity.org.mgt.version>
+        <identity.org.mgt.version>2.5.6</identity.org.mgt.version>
         <identity.org.mgt.core.version>1.5.2</identity.org.mgt.core.version>
         <identity.organization.login.version>1.3.2</identity.organization.login.version>
         <identity.oauth2.grant.organizationswitch.version>1.2.1</identity.oauth2.grant.organizationswitch.version>
@@ -2825,7 +2825,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.6.9</identity.server.api.version>
+        <identity.server.api.version>1.6.10</identity.server.api.version>
         <identity.user.api.version>1.5.6</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
@@ -2863,7 +2863,7 @@
         <carbon.healthcheck.version>1.4.0</carbon.healthcheck.version>
 
         <!-- agent-identity -->
-        <carbon.identity.agent.version>1.1.0</carbon.identity.agent.version>
+        <carbon.identity.agent.version>1.1.1</carbon.identity.agent.version>
 
         <!-- VC Issuance -->
         <carbon.identity.openid4vc.version>1.1.6</carbon.identity.openid4vc.version>


### PR DESCRIPTION
## Purpose
- Add org.wso2.carbon.identity.api.server.organization.agent.sharing.management.v1 to api-resources pom
- Add org.wso2.carbon.identity.api.server.organization.agent.sharing.management.common to api-resources pom
- Bump identity.server.api.version to 1.6.10
- Bump identity.org.mgt.version to 2.5.5

Issue: https://github.com/wso2/product-is/issues/27526
Related: 

- https://github.com/wso2-extensions/identity-organization-management/pull/628
- https://github.com/wso2/identity-api-server/pull/1117
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3228
- https://github.com/wso2/carbon-identity-framework/pull/8089
- https://github.com/wso2-extensions/identity-ai-agent/pull/15
- https://github.com/wso2-extensions/identity-organization-management/pull/633