### PR TITLE
Improve test data for attribute counts in the pre-update password and profile actions

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdatepassword/PreUpdatePasswordTestBase.java
@@ -84,8 +84,19 @@ public class PreUpdatePasswordTestBase extends ActionTestBase {
     protected static final List<String> TEST_UPDATED_ATTRIBUTES = Arrays.asList("http://wso2.org/claims/country",
             "http://wso2.org/claims/created");
 
-    protected static final List<String> INVALID_TEST_ATTRIBUTES_COUNT =  Collections.nCopies(11,
-            "http://wso2.org/claims/active");
+    protected static final List<String> INVALID_TEST_ATTRIBUTES_COUNT =  Arrays.asList(
+            "http://wso2.org/claims/externalid",
+            "http://wso2.org/claims/userType",
+            "http://wso2.org/claims/username",
+            "http://wso2.org/claims/givenname",
+            "http://wso2.org/claims/displayName",
+            "http://wso2.org/claims/emailaddress",
+            "http://wso2.org/claims/identity/lastLoginTime",
+            "http://wso2.org/claims/active",
+            "http://wso2.org/claims/identity/lastPasswordUpdateTime",
+            "http://wso2.org/claims/identity/isLiteUser",
+            "http://wso2.org/claims/identity/accountState");
+
     protected static final List<String> TEST_DUPLICATED_ATTRIBUTES =  Collections.nCopies(2,
             "http://wso2.org/claims/active");
     public static final List<String> INVALID_TEST_ATTRIBUTES = Collections.singletonList("invalidattribute");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/action/management/v1/preupdateprofile/PreUpdateProfileTestBase.java
@@ -37,8 +37,18 @@ public class PreUpdateProfileTestBase extends ActionTestBase {
     protected static final List<String> TEST_UPDATED_ATTRIBUTES = Arrays.asList("http://wso2.org/claims/country",
             "http://wso2.org/claims/created");
 
-    protected static final List<String> INVALID_TEST_ATTRIBUTES_COUNT =  Collections.nCopies(11,
-            "http://wso2.org/claims/active");
+    protected static final List<String> INVALID_TEST_ATTRIBUTES_COUNT =  Arrays.asList(
+            "http://wso2.org/claims/externalid",
+            "http://wso2.org/claims/userType",
+            "http://wso2.org/claims/username",
+            "http://wso2.org/claims/givenname",
+            "http://wso2.org/claims/displayName",
+            "http://wso2.org/claims/emailaddress",
+            "http://wso2.org/claims/identity/lastLoginTime",
+            "http://wso2.org/claims/active",
+            "http://wso2.org/claims/identity/lastPasswordUpdateTime",
+            "http://wso2.org/claims/identity/isLiteUser",
+            "http://wso2.org/claims/identity/accountState");
 
     protected static final List<String> TEST_DUPLICATED_ATTRIBUTES =  Collections.nCopies(2,
             "http://wso2.org/claims/active");


### PR DESCRIPTION
This pull request updates the test data for invalid attribute counts in the pre-update password and profile integration tests. Instead of using a repeated single attribute, the tests now use a list of distinct attribute claim URIs to better simulate real-world scenarios.

Test improvements:

* Replaced the `INVALID_TEST_ATTRIBUTES_COUNT` list in both `PreUpdatePasswordTestBase` and `PreUpdateProfileTestBase` to use 11 unique claim URIs instead of 11 copies of the same claim.