### PR TITLE
Update local auth SMS OTP and governance versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2717,7 +2717,7 @@
         <carbon.consent.mgt.version>2.9.4</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.16.16</identity.governance.version>
+        <identity.governance.version>1.16.18</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.12.4</identity.carbon.auth.saml2.version>
@@ -2810,7 +2810,7 @@
         <authenticator.magiclink.version>1.2.1</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.2.0</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.2.2</authenticator.local.auth.emailotp.version>
-        <authenticator.local.auth.smsotp.version>1.1.6</authenticator.local.auth.smsotp.version>
+        <authenticator.local.auth.smsotp.version>1.1.7</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.2.0</authenticator.twitter.version>
         <authenticator.x509.version>3.2.2</authenticator.x509.version>
         <identity.extension.utils>1.3.0</identity.extension.utils>


### PR DESCRIPTION
## Changes in this PR
- local auth SMS OTP updated to 1.1.7 to get the changes in https://github.com/wso2-extensions/identity-local-auth-smsotp/pull/73
- identity governance updated to 1.16.18 to get the changes in https://github.com/wso2-extensions/identity-governance/pull/1129