### PR TITLE
Bump framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2696,7 +2696,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.85</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.86</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
Updated the `carbon.identity.framework.version` to `7.11.86`.