### PR TITLE
Bump framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2696,7 +2696,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.93</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.95</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
This pull request makes a small update to the `pom.xml` file, specifically bumping the version of the Carbon Identity Framework dependency from 7.11.93 to 7.11.95.