### PR TITLE
Add Integration Tests for Service Based Custom Authenticators

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/AuthenticationType.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/idp/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,7 +37,7 @@ public class AuthenticationType  {
     @XmlEnum(String.class)
     public enum TypeEnum {
 
-        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+        @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
         private String value;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/CustomAuthenticatorManagementClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/CustomAuthenticatorManagementClient.java
@@ -24,8 +24,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
-import org.wso2.carbon.identity.api.server.authenticators.v1.model.AuthenticationType;
 import org.wso2.carbon.identity.api.server.authenticators.v1.model.UserDefinedLocalAuthenticatorCreation;
 import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedLocalAuthenticatorConfig;
@@ -35,9 +35,10 @@ import org.wso2.identity.integration.test.rest.api.server.authenticator.manageme
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * This class provides methods to manage custom authenticators via REST API.
@@ -46,6 +47,28 @@ public class CustomAuthenticatorManagementClient extends RestBaseClient {
 
     private static final String AUTHENTICATOR_CUSTOM_API_BASE_PATH = "/authenticators/custom";
     private static final String PATH_SEPARATOR = "/";
+
+    // Endpoint authentication type identifiers used on the wire. These mirror the framework's
+    // AuthenticationType.TypeEnum string values. Strings are used directly so this client compiles
+    // both before and after the api-server PR that adds CLIENT_CREDENTIAL/PASSWORD_CREDENTIAL to
+    // the published enum.
+    public static final String AUTH_TYPE_BASIC = "BASIC";
+    public static final String AUTH_TYPE_BEARER = "BEARER";
+    public static final String AUTH_TYPE_API_KEY = "API_KEY";
+    public static final String AUTH_TYPE_CLIENT_CREDENTIAL = "CLIENT_CREDENTIAL";
+    public static final String AUTH_TYPE_PASSWORD_CREDENTIAL = "PASSWORD_CREDENTIAL";
+
+    // Endpoint authentication property keys (must match the framework's Authentication builders).
+    public static final String USERNAME_PROPERTY = "username";
+    public static final String PASSWORD_PROPERTY = "password";
+    public static final String ACCESS_TOKEN_PROPERTY = "accessToken";
+    public static final String API_KEY_HEADER_PROPERTY = "apiKeyHeader";
+    public static final String API_KEY_VALUE_PROPERTY = "apiKeyValue";
+    public static final String CLIENT_ID_PROPERTY = "clientId";
+    public static final String CLIENT_SECRET_PROPERTY = "clientSecret";
+    public static final String TOKEN_ENDPOINT_PROPERTY = "tokenEndpoint";
+    public static final String SCOPES_PROPERTY = "scopes";
+
     private final String username;
     private final String password;
 
@@ -61,28 +84,104 @@ public class CustomAuthenticatorManagementClient extends RestBaseClient {
 
     }
 
+    /**
+     * Create a user-defined local custom authenticator with BASIC endpoint authentication.
+     */
+    public String createCustomAuthWithBasicEndpointAuth(String authenticatorName, String displayName,
+                                                        String endpointUri, String endpointAuthUsername,
+                                                        String endpointAuthPassword) throws Exception {
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put(USERNAME_PROPERTY, endpointAuthUsername);
+        properties.put(PASSWORD_PROPERTY, endpointAuthPassword);
+        return createCustomAuthenticator(authenticatorName, displayName, endpointUri,
+                AUTH_TYPE_BASIC, properties);
+    }
+
+    /**
+     * Create a user-defined local custom authenticator with BEARER endpoint authentication.
+     */
+    public String createCustomAuthWithBearerEndpointAuth(String authenticatorName, String displayName,
+                                                         String endpointUri, String accessToken) throws Exception {
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put(ACCESS_TOKEN_PROPERTY, accessToken);
+        return createCustomAuthenticator(authenticatorName, displayName, endpointUri,
+                AUTH_TYPE_BEARER, properties);
+    }
+
+    /**
+     * Create a user-defined local custom authenticator with API_KEY endpoint authentication.
+     */
+    public String createCustomAuthWithApiKeyEndpointAuth(String authenticatorName, String displayName,
+                                                         String endpointUri, String apiKeyHeader,
+                                                         String apiKeyValue) throws Exception {
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put(API_KEY_HEADER_PROPERTY, apiKeyHeader);
+        properties.put(API_KEY_VALUE_PROPERTY, apiKeyValue);
+        return createCustomAuthenticator(authenticatorName, displayName, endpointUri,
+                AUTH_TYPE_API_KEY, properties);
+    }
+
+    /**
+     * Create a user-defined local custom authenticator with OAuth2 CLIENT_CREDENTIAL endpoint authentication.
+     */
+    public String createCustomAuthWithClientCredentialEndpointAuth(String authenticatorName, String displayName,
+                                                                   String endpointUri, String clientId,
+                                                                   String clientSecret, String tokenEndpoint,
+                                                                   String scopes) throws Exception {
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put(CLIENT_ID_PROPERTY, clientId);
+        properties.put(CLIENT_SECRET_PROPERTY, clientSecret);
+        properties.put(TOKEN_ENDPOINT_PROPERTY, tokenEndpoint);
+        properties.put(SCOPES_PROPERTY, scopes);
+        return createCustomAuthenticator(authenticatorName, displayName, endpointUri,
+                AUTH_TYPE_CLIENT_CREDENTIAL, properties);
+    }
+
+    /**
+     * Create a user-defined local custom authenticator with OAuth2 PASSWORD_CREDENTIAL endpoint authentication.
+     */
+    public String createCustomAuthWithPasswordCredentialEndpointAuth(String authenticatorName, String displayName,
+                                                                     String endpointUri, String clientId,
+                                                                     String clientSecret, String tokenEndpoint,
+                                                                     String endpointAuthUsername,
+                                                                     String endpointAuthPassword,
+                                                                     String scopes) throws Exception {
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put(CLIENT_ID_PROPERTY, clientId);
+        properties.put(CLIENT_SECRET_PROPERTY, clientSecret);
+        properties.put(TOKEN_ENDPOINT_PROPERTY, tokenEndpoint);
+        properties.put(USERNAME_PROPERTY, endpointAuthUsername);
+        properties.put(PASSWORD_PROPERTY, endpointAuthPassword);
+        properties.put(SCOPES_PROPERTY, scopes);
+        return createCustomAuthenticator(authenticatorName, displayName, endpointUri,
+                AUTH_TYPE_PASSWORD_CREDENTIAL, properties);
+    }
+
+    /**
+     * Backwards-compatible wrapper that delegates to {@link #createCustomAuthWithBasicEndpointAuth}.
+     */
     public String createCustomInternalUserAuthenticator(String authenticatorName, String displayName,
                                                         String endpointUri,
                                                         String endpointAuthUsername, String endpointAuthPassword)
             throws Exception {
 
-        UserDefinedLocalAuthenticatorConfig testAuthenticatorConfig =
-                createUserDefinedInternalUserAuthenticator(authenticatorName, displayName, endpointUri,
-                        endpointAuthUsername, endpointAuthPassword);
-        UserDefinedLocalAuthenticatorCreation authenticatorCreationPayload = UserDefinedLocalAuthenticatorPayload
-                .getBasedUserDefinedLocalAuthenticatorCreation(testAuthenticatorConfig);
+        return createCustomAuthWithBasicEndpointAuth(authenticatorName, displayName, endpointUri,
+                endpointAuthUsername, endpointAuthPassword);
+    }
 
-        try {
-            String jsonRequestBody =
-                    UserDefinedLocalAuthenticatorPayload.convertToJasonPayload(authenticatorCreationPayload);
+    /**
+     * Retrieve the JSON representation of a custom authenticator.
+     */
+    public String getCustomAuthenticator(String authenticatorId) throws Exception {
 
-            try (CloseableHttpResponse response = getResponseOfHttpPost(customAuthenticatorAPIBasePath, jsonRequestBody,
-                    getHeaders())) {
-                String[] locationElements = response.getHeaders(LOCATION_HEADER)[0].toString().split(PATH_SEPARATOR);
-                return locationElements[locationElements.length - 1];
-            }
-        } catch (JsonProcessingException e) {
-            throw new Exception("Error while creating custom internal user authenticator request payload.", e);
+        String apiEndpoint = customAuthenticatorAPIBasePath + PATH_SEPARATOR + authenticatorId;
+        try (CloseableHttpResponse response = getResponseOfHttpGet(apiEndpoint, getHeaders())) {
+            return EntityUtils.toString(response.getEntity());
         }
     }
 
@@ -103,11 +202,9 @@ public class CustomAuthenticatorManagementClient extends RestBaseClient {
         client.close();
     }
 
-    private UserDefinedLocalAuthenticatorConfig createUserDefinedInternalUserAuthenticator(String name,
-                                                                                           String displayName,
-                                                                                           String endpointUri,
-                                                                                           String username,
-                                                                                           String password) {
+    private String createCustomAuthenticator(String name, String displayName, String endpointUri,
+                                             String authType,
+                                             Map<String, String> authProperties) throws Exception {
 
         UserDefinedLocalAuthenticatorConfig config = new UserDefinedLocalAuthenticatorConfig(
                 AuthenticatorPropertyConstants.AuthenticationType.IDENTIFICATION);
@@ -118,15 +215,26 @@ public class CustomAuthenticatorManagementClient extends RestBaseClient {
         UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder endpointConfig =
                 new UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder();
         endpointConfig.uri(endpointUri);
-        endpointConfig.authenticationType(String.valueOf(AuthenticationType.TypeEnum.BASIC));
-        endpointConfig.authenticationProperties(new HashMap<String, String>() {{
-            put("username", username);
-            put("password", password);
-        }});
-        endpointConfig.allowedParameters((new ArrayList<>(Collections.singletonList("testParam"))));
+        endpointConfig.authenticationType(authType);
+        endpointConfig.authenticationProperties(new HashMap<>(authProperties));
+        endpointConfig.allowedParameters(new ArrayList<>(Collections.singletonList("testParam")));
         config.setEndpointConfig(endpointConfig.build());
 
-        return config;
+        UserDefinedLocalAuthenticatorCreation authenticatorCreationPayload = UserDefinedLocalAuthenticatorPayload
+                .getBasedUserDefinedLocalAuthenticatorCreation(config);
+
+        try {
+            String jsonRequestBody =
+                    UserDefinedLocalAuthenticatorPayload.convertToJasonPayload(authenticatorCreationPayload);
+
+            try (CloseableHttpResponse response = getResponseOfHttpPost(customAuthenticatorAPIBasePath, jsonRequestBody,
+                    getHeaders())) {
+                String[] locationElements = response.getHeaders(LOCATION_HEADER)[0].toString().split(PATH_SEPARATOR);
+                return locationElements[locationElements.length - 1];
+            }
+        } catch (JsonProcessingException e) {
+            throw new Exception("Error while creating custom authenticator request payload.", e);
+        }
     }
 
     private String getCustomAuthenticatorAPIBasePath(String serverUrl, String tenantDomain) {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdpMgtRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/IdpMgtRestClient.java
@@ -66,8 +66,21 @@ public class IdpMgtRestClient extends RestBaseClient {
      */
     public String createIdentityProvider(IdentityProviderPOSTRequest idpCreateReqObj) throws Exception {
         String jsonRequest = toJSONString(idpCreateReqObj);
-        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(IDENTITY_PROVIDER_BASE_PATH, tenantDomain);
+        return createIdentityProviderFromJson(jsonRequest);
+    }
 
+    /**
+     * Create an Identity Provider from a raw JSON body. Useful when the IdP needs a payload shape
+     * that isn't easily expressed via {@link IdentityProviderPOSTRequest} (e.g. user-defined
+     * federated authenticator endpoint configs).
+     *
+     * @param jsonRequest Raw JSON request body.
+     * @return The created IdP's id.
+     */
+    public String createIdentityProviderFromJson(String jsonRequest) throws Exception {
+
+        String endPointUrl = serverUrl + ISIntegrationTest.getTenantedRelativePath(IDENTITY_PROVIDER_BASE_PATH,
+                tenantDomain);
         try (CloseableHttpResponse response = getResponseOfHttpPost(endPointUrl, jsonRequest, getHeaders())) {
             Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_CREATED,
                     "Idp creation failed");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthFederatedBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthFederatedBaseTestCase.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.apache.poi.util.StringUtil;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.test.integration.service.dao.Attribute;
+import org.wso2.carbon.identity.test.integration.service.dao.UserDTO;
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+import org.wso2.identity.integration.test.oidc.OIDCUtilTest;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AccessTokenConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.RequestedClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.util.UserDefinedAuthenticatorPayload;
+import org.wso2.identity.integration.test.restclients.IdpMgtRestClient;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomFederatedAuthenticatorPayloadBuilder.DEFAULT_FEDERATED_AUTHENTICATOR_ID;
+import static org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService.API_AUTHENTICATE_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.COMMON_AUTH_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
+
+/**
+ * Concrete base for end-to-end integration tests that exercise a user-defined
+ * <strong>federated</strong> custom authenticator (configured via the IdP API). Each instance is
+ * parameterised by a {@link TestUserMode} and an {@link EndpointAuthScenario} so a single test
+ * class can drive every supported endpoint authentication mode via TestNG {@code @Factory}.
+ */
+public abstract class CustomAuthEndpointAuthFederatedBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    protected static final String FEDERATED_USER_FIRST_NAME = "Fiona";
+    protected static final String FEDERATED_USER_LAST_NAME = "Federated";
+    protected static final String FEDERATED_USER_EMAIL = "fiona.federated@example.com";
+
+    public static final String GIVEN_NAME_ATTRIBUTE_NAME = "given_name";
+    public static final String EMAIL_ATTRIBUTE_NAME = "email";
+    public static final String FAMILY_NAME_ATTRIBUTE_NAME = "family_name";
+
+    private static final String FEDERATED_AUTHENTICATOR_ID_PLACEHOLDER = "<FEDERATED_AUTHENTICATOR_ID>";
+    private static final String FEDERATED_AUTHENTICATOR_PLACEHOLDER = "\"<FEDERATED_AUTHENTICATOR>\"";
+    private static final String IDP_NAME_PLACEHOLDER = "<IDP_NAME>";
+
+    /**
+     * Inline IdP-create template (mirrors {@code add-idp-with-custom-fed-auth.json}). Inlined so
+     * the test family is self-contained.
+     */
+    private static final String IDP_CREATE_PAYLOAD_TEMPLATE = "{" +
+            "\"name\":\"<IDP_NAME>\"," +
+            "\"description\":\"IdP with user defined federated authenticator (endpoint-auth test)\"," +
+            "\"image\":\"https://example.com/image\"," +
+            "\"isPrimary\":false," +
+            "\"isFederationHub\":false," +
+            "\"homeRealmIdentifier\":\"localhost\"," +
+            "\"alias\":\"https://localhost:9444/oauth2/token\"," +
+            "\"claims\":{" +
+            "  \"userIdClaim\":{\"uri\":\"http://wso2.org/claims/username\"}," +
+            "  \"roleClaim\":{\"uri\":\"http://wso2.org/claims/role\"}," +
+            "  \"provisioningClaims\":[" +
+            "    {\"claim\":{\"uri\":\"http://wso2.org/claims/username\"}," +
+            "     \"defaultValue\":\"" + FEDERATED_USER_EMAIL + "\"}" +
+            "  ]" +
+            "}," +
+            "\"federatedAuthenticators\":{" +
+            "  \"defaultAuthenticatorId\":\"<FEDERATED_AUTHENTICATOR_ID>\"," +
+            "  \"authenticators\":[\"<FEDERATED_AUTHENTICATOR>\"]" +
+            "}," +
+            "\"provisioning\":{\"jit\":{\"isEnabled\":true,\"scheme\":\"PROVISION_SILENTLY\",\"userstore\":\"PRIMARY\"}}" +
+            "}";
+
+    protected OAuth2RestClient oAuth2RestClient;
+    protected SCIM2RestClient scim2RestClient;
+    protected IdpMgtRestClient idpMgtRestClient;
+
+    protected String consumerKey;
+    protected String consumerSecret;
+    protected String applicationId;
+    protected String idpId;
+    protected String idpName;
+    protected String federatedAuthenticatorDisplayName;
+    protected String requestedScopes;
+    protected String authorizationCode;
+    protected UserDTO federatedUser;
+
+    protected CloseableHttpClient httpClient;
+    protected MockCustomAuthenticatorService mockCustomAuthenticatorService;
+    protected ServiceExtensionMockServer serviceExtensionMockServer;
+
+    protected final TestUserMode userMode;
+    protected final EndpointAuthScenario scenario;
+
+    protected CustomAuthEndpointAuthFederatedBaseTestCase(TestUserMode testUserMode, EndpointAuthScenario scenario) {
+
+        this.userMode = testUserMode;
+        this.scenario = scenario;
+    }
+
+    /**
+     * Distinguishes success / failure subclasses so IdP names don't collide when both are wired
+     * into the same testng suite.
+     */
+    protected abstract String variantSuffix();
+
+    /**
+     * Subclasses install either a success or failure stub on the token endpoint.
+     */
+    protected abstract void installTokenEndpointStubs(ServiceExtensionMockServer server) throws IOException;
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.init(userMode);
+
+        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        idpMgtRestClient = new IdpMgtRestClient(serverURL, tenantInfo);
+
+        httpClient = HttpClientBuilder.create()
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+
+                        return false;
+                    }
+                }).build();
+        requestedScopes = String.join(" ", OAuth2Constant.OAUTH2_SCOPE_OPENID, OAuth2Constant.OAUTH2_SCOPE_EMAIL,
+                OAuth2Constant.OAUTH2_SCOPE_PROFILE);
+
+        federatedUser = buildFederatedUserSnapshot();
+
+        if (scenario.requiresTokenEndpoint()) {
+            serviceExtensionMockServer = new ServiceExtensionMockServer();
+            serviceExtensionMockServer.startServer();
+            installTokenEndpointStubs(serviceExtensionMockServer);
+        }
+
+        mockCustomAuthenticatorService = new MockCustomAuthenticatorService();
+        startMockAuthenticatorService();
+
+        idpName = buildIdpName();
+        federatedAuthenticatorDisplayName = decodeFederatedAuthenticatorDisplayName();
+        UserDefinedAuthenticatorPayload payload = scenario.buildFederatedPayload(
+                mockCustomAuthenticatorService.getCustomAuthenticatorURL() + API_AUTHENTICATE_ENDPOINT);
+        idpId = createIdentityProvider(idpName, payload);
+        assertNotNull(idpId, "Failed to create the IdP with custom federated authenticator.");
+
+        applicationId = setupApplication();
+        retrieveApplicationDetails();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        if (mockCustomAuthenticatorService != null) {
+            mockCustomAuthenticatorService.stop();
+        }
+        if (serviceExtensionMockServer != null) {
+            serviceExtensionMockServer.stopServer();
+        }
+
+        if (applicationId != null && oAuth2RestClient != null) {
+            oAuth2RestClient.deleteApplication(applicationId);
+        }
+        if (idpId != null && idpMgtRestClient != null) {
+            idpMgtRestClient.deleteIdp(idpId);
+        }
+        // Best-effort cleanup of any JIT-provisioned federated user (looked up by userName).
+        if (scim2RestClient != null) {
+            try {
+                org.json.simple.JSONObject filterResponse = scim2RestClient.filterUsers(
+                        "userName eq " + FEDERATED_USER_EMAIL);
+                Object resources = filterResponse == null ? null : filterResponse.get("Resources");
+                if (resources instanceof org.json.simple.JSONArray
+                        && !((org.json.simple.JSONArray) resources).isEmpty()) {
+                    org.json.simple.JSONObject userJson =
+                            (org.json.simple.JSONObject) ((org.json.simple.JSONArray) resources).get(0);
+                    Object jitUserId = userJson.get("id");
+                    if (jitUserId != null) {
+                        scim2RestClient.deleteUser(jitUserId.toString());
+                    }
+                }
+            } catch (Exception ignored) {
+                // Cleanup is best-effort.
+            }
+        }
+
+        consumerKey = null;
+        consumerSecret = null;
+        applicationId = null;
+        idpId = null;
+        mockCustomAuthenticatorService = null;
+        serviceExtensionMockServer = null;
+
+        if (httpClient != null) {
+            httpClient.close();
+        }
+        if (oAuth2RestClient != null) {
+            oAuth2RestClient.closeHttpClient();
+        }
+        if (scim2RestClient != null) {
+            scim2RestClient.closeHttpClient();
+        }
+        if (idpMgtRestClient != null) {
+            idpMgtRestClient.closeHttpClient();
+        }
+    }
+
+    // -- Internal setup --------------------------------------------------------------------------
+
+    private String buildIdpName() {
+
+        return "FedCustomAuth-" + scenario.name().replace('_', '-') + "-" + variantSuffix() + "-IDP";
+    }
+
+    private void startMockAuthenticatorService() {
+
+        String idpAuthURL = getTenantQualifiedURL(COMMON_AUTH_URL, tenantInfo.getDomain());
+        mockCustomAuthenticatorService.startForFederated(idpAuthURL, federatedUser,
+                scenario.expectedInboundHeaderName(), scenario.expectedInboundHeaderValue());
+    }
+
+    private String createIdentityProvider(String idpName, UserDefinedAuthenticatorPayload payload) throws Exception {
+
+        String body = IDP_CREATE_PAYLOAD_TEMPLATE.replace(FEDERATED_AUTHENTICATOR_ID_PLACEHOLDER,
+                payload.getAuthenticatorId());
+        body = body.replace(FEDERATED_AUTHENTICATOR_PLACEHOLDER, payload.convertToJasonPayload());
+        body = body.replace(IDP_NAME_PLACEHOLDER, idpName);
+        return idpMgtRestClient.createIdentityProviderFromJson(body);
+    }
+
+    private String setupApplication() throws JSONException, IOException {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName("Federated SP for " + idpName);
+
+        List<String> grantTypes = new ArrayList<>();
+        Collections.addAll(grantTypes, OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
+
+        List<String> callBackUrls = new ArrayList<>();
+        Collections.addAll(callBackUrls, OAuth2Constant.CALLBACK_URL);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(grantTypes);
+        oidcConfig.setCallbackURLs(callBackUrls);
+
+        RequestedClaimConfiguration requestedClaimLastName = new RequestedClaimConfiguration();
+        requestedClaimLastName.setClaim(new Claim().uri(OIDCUtilTest.lastNameClaimUri));
+
+        RequestedClaimConfiguration requestedClaimFirstName = new RequestedClaimConfiguration();
+        requestedClaimFirstName.setClaim(new Claim().uri(OIDCUtilTest.firstNameClaimUri));
+
+        RequestedClaimConfiguration requestedClaimEmail = new RequestedClaimConfiguration();
+        requestedClaimEmail.setClaim(new Claim().uri(OIDCUtilTest.emailClaimUri));
+
+        ClaimConfiguration claimConfiguration = new ClaimConfiguration();
+        claimConfiguration.addRequestedClaimsItem(requestedClaimLastName);
+        claimConfiguration.addRequestedClaimsItem(requestedClaimFirstName);
+        claimConfiguration.addRequestedClaimsItem(requestedClaimEmail);
+
+        application.setClaimConfiguration(claimConfiguration);
+
+        AccessTokenConfiguration accessTokenConfig = new AccessTokenConfiguration().type("JWT");
+        accessTokenConfig.setUserAccessTokenExpiryInSeconds(3600L);
+        accessTokenConfig.setApplicationAccessTokenExpiryInSeconds(3600L);
+        oidcConfig.setAccessToken(accessTokenConfig);
+
+        InboundProtocols inboundProtocolsConfig = new InboundProtocols();
+        inboundProtocolsConfig.setOidc(oidcConfig);
+
+        application.setInboundProtocolConfiguration(inboundProtocolsConfig);
+
+        AuthenticationSequence authenticationSequence = new AuthenticationSequence()
+                .type(AuthenticationSequence.TypeEnum.USER_DEFINED)
+                .addStepsItem(new AuthenticationStep()
+                        .id(1)
+                        .addOptionsItem(new Authenticator()
+                                .idp(idpName)
+                                .authenticator(federatedAuthenticatorDisplayName)));
+
+        application.authenticationSequence(authenticationSequence);
+        application.advancedConfigurations(
+                new AdvancedApplicationConfiguration().skipLoginConsent(true).skipLogoutConsent(true));
+
+        return oAuth2RestClient.createApplication(application);
+    }
+
+    private void retrieveApplicationDetails() throws Exception {
+
+        ApplicationResponseModel applicationResponse = oAuth2RestClient.getApplication(applicationId);
+        assertNotNull(applicationResponse,
+                "Failed to retrieve the created application with federated custom authenticator");
+
+        OpenIDConnectConfiguration oidcInboundConfig = oAuth2RestClient.getOIDCInboundDetails(applicationId);
+        consumerKey = oidcInboundConfig.getClientId();
+        assertNotNull(consumerKey);
+        consumerSecret = oidcInboundConfig.getClientSecret();
+        assertNotNull(consumerSecret);
+    }
+
+    private UserDTO buildFederatedUserSnapshot() {
+
+        UserDTO user = new UserDTO();
+        user.setUserID(MockCustomAuthenticatorService.FEDERATED_USER_EXTERNAL_ID);
+
+        List<Attribute> userAttributes = new ArrayList<>();
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/username", FEDERATED_USER_EMAIL));
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/emailaddress", FEDERATED_USER_EMAIL));
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/lastname", FEDERATED_USER_LAST_NAME));
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/givenname", FEDERATED_USER_FIRST_NAME));
+        user.setAttributes(userAttributes.toArray(new Attribute[0]));
+        return user;
+    }
+
+    private Attribute createUserAttribute(String attributeName, String attributeValue) {
+
+        Attribute attribute = new Attribute();
+        attribute.setAttributeName(attributeName);
+        attribute.setAttributeValue(attributeValue);
+        return attribute;
+    }
+
+    private String decodeFederatedAuthenticatorDisplayName() {
+
+        return new String(Base64.getDecoder().decode(DEFAULT_FEDERATED_AUTHENTICATOR_ID),
+                StandardCharsets.UTF_8);
+    }
+
+    // -- Flow helpers (exposed to subclasses) ----------------------------------------------------
+
+    protected String drivePinAuthenticationFlow() throws Exception {
+
+        String customAuthenticatorPageUrl = authorizeApplication();
+        Document customAuthenticatorPage = fetchCustomAuthenticatorPage(customAuthenticatorPageUrl);
+        String commonAuthUrl = submitCredentialsToCustomAuthenticator(customAuthenticatorPage);
+        return handleCommonAuthRequest(commonAuthUrl);
+    }
+
+    protected HttpResponse drivePinAuthenticationFlowExpectingFailure() throws Exception {
+
+        String customAuthenticatorPageUrl = authorizeApplication();
+        HttpResponse pageResponse = sendGetRequest(httpClient, customAuthenticatorPageUrl);
+        // When the token endpoint is stubbed to fail, IS may short-circuit before serving the
+        // authenticator form. Return the early response so the caller can verify no authorization
+        // code was issued without requiring the full pin flow to complete.
+        Document customAuthenticatorPage = parsePageOrNull(pageResponse);
+        if (customAuthenticatorPage == null || customAuthenticatorPage.selectFirst("input[name=flowId]") == null) {
+            return pageResponse;
+        }
+        String commonAuthUrl = submitCredentialsToCustomAuthenticator(customAuthenticatorPage);
+        return sendGetRequest(httpClient, commonAuthUrl);
+    }
+
+    private Document parsePageOrNull(HttpResponse response) throws IOException {
+
+        if (response == null || response.getStatusLine().getStatusCode() != 200
+                || response.getEntity() == null) {
+            return null;
+        }
+        Header contentType = response.getFirstHeader("Content-Type");
+        if (contentType == null || !contentType.getValue().contains("text/html")) {
+            EntityUtils.consume(response.getEntity());
+            return null;
+        }
+        Document doc = Jsoup.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+        return doc;
+    }
+
+    private String authorizeApplication() throws Exception {
+
+        List<NameValuePair> urlParameters = buildOAuth2Parameters(consumerKey);
+        urlParameters.add(new BasicNameValuePair("testParam", "123_abc"));
+        HttpResponse authorizeRequest = sendPostRequestWithParameters(httpClient, urlParameters,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
+        assertNotNull(authorizeRequest, "Authorization request failed. Authorized response is null.");
+        assertEquals(authorizeRequest.getStatusLine().getStatusCode(), 302);
+
+        Header locationHeader = authorizeRequest.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "Authorization request failed. Authorized response header is null");
+        EntityUtils.consume(authorizeRequest.getEntity());
+
+        String customAuthenticatorPageUrl = locationHeader.getValue();
+        assertTrue(StringUtil.isNotBlank(customAuthenticatorPageUrl),
+                "Custom authenticator page URL is blank or null.");
+        return customAuthenticatorPageUrl;
+    }
+
+    private Document fetchCustomAuthenticatorPage(String customAuthenticatorPageUrl) throws Exception {
+
+        HttpResponse customAuthenticatorPageRequest = sendGetRequest(httpClient, customAuthenticatorPageUrl);
+        assertEquals(customAuthenticatorPageRequest.getStatusLine().getStatusCode(), 200);
+        assertTrue(customAuthenticatorPageRequest.containsHeader("Content-Type"));
+        assertTrue(customAuthenticatorPageRequest.getHeaders("Content-Type")[0].getValue().contains("text/html"),
+                "Response is not HTML");
+
+        Document doc = Jsoup.parse(EntityUtils.toString(customAuthenticatorPageRequest.getEntity()));
+        EntityUtils.consume(customAuthenticatorPageRequest.getEntity());
+        assertNotNull(doc, "Custom authenticator page is null.");
+        return doc;
+    }
+
+    private String submitCredentialsToCustomAuthenticator(Document customAuthenticatorPage) throws Exception {
+
+        Element form = customAuthenticatorPage.selectFirst("form");
+        String customAuthenticatorAuthUrl = mockCustomAuthenticatorService.getCustomAuthenticatorURL();
+        if (form != null) {
+            String actionUrl = form.attr("action");
+            assertTrue(StringUtil.isNotBlank(actionUrl));
+            customAuthenticatorAuthUrl = customAuthenticatorAuthUrl + actionUrl;
+        }
+
+        Element flowIdElement = customAuthenticatorPage.selectFirst("input[name=flowId]");
+        String flowId = (flowIdElement != null) ? flowIdElement.attr("value") : null;
+        assertTrue(StringUtil.isNotBlank(flowId));
+
+        HttpPost customAuthenticatorLoginRequest = buildCustomAuthenticatorLoginRequest(customAuthenticatorAuthUrl,
+                flowId);
+        HttpResponse customAuthenticatorLoginResponse = httpClient.execute(customAuthenticatorLoginRequest);
+        assertNotNull(customAuthenticatorLoginResponse);
+        assertEquals(customAuthenticatorLoginResponse.getStatusLine().getStatusCode(), 200);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(EntityUtils.toString(customAuthenticatorLoginResponse.getEntity()));
+        EntityUtils.consume(customAuthenticatorLoginResponse.getEntity());
+
+        String commonAuthUrl = jsonNode.get("redirectingTo").asText();
+        assertTrue(StringUtil.isNotBlank(commonAuthUrl));
+        return commonAuthUrl;
+    }
+
+    private String handleCommonAuthRequest(String commonAuthUrl) throws Exception {
+
+        HttpResponse commonAuthResponse = sendGetRequest(httpClient, commonAuthUrl);
+        assertNotNull(commonAuthResponse);
+
+        Header locationHeader = commonAuthResponse.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Location header expected post login, is not available.");
+        EntityUtils.consume(commonAuthResponse.getEntity());
+
+        HttpResponse authorizedResponse = sendGetRequest(httpClient, locationHeader.getValue());
+        locationHeader = authorizedResponse.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Redirection URL to the application with authorization code is null.");
+        EntityUtils.consume(authorizedResponse.getEntity());
+
+        return getAuthorizationCodeFromURL(locationHeader.getValue());
+    }
+
+    private HttpPost buildCustomAuthenticatorLoginRequest(String customAuthenticatorAuthUrl, String flowId)
+            throws UnsupportedEncodingException {
+
+        HttpPost customAuthenticatorLoginRequest = new HttpPost(customAuthenticatorAuthUrl);
+        customAuthenticatorLoginRequest.setHeader("Content-Type", "application/json");
+        customAuthenticatorLoginRequest.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
+        String jsonBody = "{"
+                + "\"flowId\": \"" + flowId + "\","
+                + "\"username\": \"" + FEDERATED_USER_EMAIL + "\","
+                + "\"pin\": \"1234\""
+                + "}";
+
+        customAuthenticatorLoginRequest.setEntity(new StringEntity(jsonBody));
+        return customAuthenticatorLoginRequest;
+    }
+
+    protected String getAuthorizationCodeFromURL(String location) {
+
+        URI uri = URI.create(location);
+        return URLEncodedUtils.parse(uri, StandardCharsets.UTF_8).stream()
+                .filter(param -> "code".equals(param.getName()))
+                .map(NameValuePair::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    protected List<NameValuePair> buildOAuth2Parameters(String consumerKey) {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", OAuth2Constant.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("scope", requestedScopes));
+        return urlParameters;
+    }
+
+    // -- Token exchange + claim assertions -------------------------------------------------------
+
+    protected HttpResponse exchangeAuthorizationCodeForTokens() throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("code", authorizationCode));
+        urlParameters.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", OAuth2Constant.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
+        urlParameters.add(new BasicNameValuePair("scope", requestedScopes));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER,
+                OAuth2Constant.BASIC_HEADER + " " + getBase64EncodedString(consumerKey, consumerSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(httpClient, headers, urlParameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+        assertNotNull(response, "Failed to receive a response for access token request.");
+        return response;
+    }
+
+    protected void assertExpectedTokenClaims(HttpResponse response) throws Exception {
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+
+        assertTrue(jsonResponse.has(OAuth2Constant.ACCESS_TOKEN), "Access token not found in the token response.");
+        String accessToken = jsonResponse.getString(OAuth2Constant.ACCESS_TOKEN);
+        assertNotNull(accessToken, "Access token is null.");
+        assertNotNull(extractJwtClaims(accessToken));
+
+        assertTrue(jsonResponse.has(OAuth2Constant.ID_TOKEN), "ID token not found in the token response.");
+        String idToken = jsonResponse.getString(OAuth2Constant.ID_TOKEN);
+        assertNotNull(idToken, "Id token is null.");
+
+        JWTClaimsSet jwtClaimsOfIdToken = extractJwtClaims(idToken);
+        assertNotNull(jwtClaimsOfIdToken);
+
+        // For federated authenticators the id_token's subject is the JIT-provisioned user. We
+        // assert the federated user's claims propagate through to the token.
+        assertNotNull(jwtClaimsOfIdToken.getClaim(GIVEN_NAME_ATTRIBUTE_NAME));
+        assertEquals(jwtClaimsOfIdToken.getClaim(GIVEN_NAME_ATTRIBUTE_NAME).toString(), FEDERATED_USER_FIRST_NAME);
+
+        assertNotNull(jwtClaimsOfIdToken.getClaim(FAMILY_NAME_ATTRIBUTE_NAME));
+        assertEquals(jwtClaimsOfIdToken.getClaim(FAMILY_NAME_ATTRIBUTE_NAME).toString(), FEDERATED_USER_LAST_NAME);
+
+        assertNotNull(jwtClaimsOfIdToken.getClaim(EMAIL_ATTRIBUTE_NAME));
+        assertEquals(jwtClaimsOfIdToken.getClaim(EMAIL_ATTRIBUTE_NAME).toString(), FEDERATED_USER_EMAIL);
+    }
+
+    protected JWTClaimsSet extractJwtClaims(String jwtToken) throws ParseException {
+
+        SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+        return signedJWT.getJWTClaimsSet();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthFederatedFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthFederatedFailureTestCase.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * End-to-end failure tests for user-defined federated custom authenticators configured with an
+ * OAuth2 endpoint authentication mode (CLIENT_CREDENTIAL, PASSWORD_CREDENTIAL). The token endpoint
+ * is stubbed to return HTTP 500.
+ *
+ * One TestNG instance per (tenant, OAuth2-scenario) pair via {@link Factory}.
+ */
+public class CustomAuthEndpointAuthFederatedFailureTestCase extends CustomAuthEndpointAuthFederatedBaseTestCase {
+
+    @Factory(dataProvider = "scenarioProvider")
+    public CustomAuthEndpointAuthFederatedFailureTestCase(TestUserMode testUserMode, EndpointAuthScenario scenario) {
+
+        super(testUserMode, scenario);
+    }
+
+    @DataProvider(name = "scenarioProvider")
+    public static Object[][] scenarioProvider() {
+
+        TestUserMode[] userModes = {TestUserMode.SUPER_TENANT_USER, TestUserMode.TENANT_USER};
+        List<Object[]> combinations = new ArrayList<>();
+        for (TestUserMode mode : userModes) {
+            for (EndpointAuthScenario scenario : EndpointAuthScenario.values()) {
+                if (scenario.requiresTokenEndpoint()) {
+                    combinations.add(new Object[]{mode, scenario});
+                }
+            }
+        }
+        return combinations.toArray(new Object[0][]);
+    }
+
+    @Override
+    protected String variantSuffix() {
+
+        return "failure";
+    }
+
+    @Override
+    protected void installTokenEndpointStubs(ServiceExtensionMockServer server) throws IOException {
+
+        scenario.installFailureTokenEndpointStub(server);
+    }
+
+    @Test(groups = "wso2.is", description = "When the OAuth2 token endpoint fails, the federated authorize " +
+            "flow must not yield an authorization code.")
+    public void testAuthorizeFlowFailsWhenTokenEndpointFails() throws Exception {
+
+        Thread.sleep(5000);
+
+        HttpResponse response = drivePinAuthenticationFlowExpectingFailure();
+        assertNotNull(response, "Expected a response from the commonauth endpoint when token acquisition fails.");
+
+        String authorizationCodeIfAny = null;
+        if (response.getFirstHeader("Location") != null) {
+            String location = response.getFirstHeader("Location").getValue();
+            HttpResponse next = sendGetRequest(httpClient, location);
+            String maybeCodeUrl = next.getFirstHeader("Location") != null
+                    ? next.getFirstHeader("Location").getValue()
+                    : location;
+            EntityUtils.consume(next.getEntity());
+            authorizationCodeIfAny = getAuthorizationCodeFromURL(maybeCodeUrl);
+        }
+        EntityUtils.consume(response.getEntity());
+
+        Assert.assertNull(authorizationCodeIfAny,
+                "Authorization code must not be issued when the token endpoint fails.");
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testAuthorizeFlowFailsWhenTokenEndpointFails",
+            description = "When the OAuth2 token endpoint fails, IS must not invoke the second " +
+                    "/api/authenticate call against the custom authenticator endpoint.")
+    public void testCustomAuthenticatorEndpointNotInvokedPostFailure() {
+
+        int callCount = WireMock.findAll(WireMock.postRequestedFor(
+                WireMock.urlEqualTo(MockCustomAuthenticatorService.API_AUTHENTICATE_ENDPOINT))).size();
+        Assert.assertTrue(callCount <= 1,
+                "Expected at most one /api/authenticate call when token endpoint fails, got " + callCount);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthFederatedSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthFederatedSuccessTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import org.apache.http.HttpResponse;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService.API_AUTHENTICATE_ENDPOINT;
+
+/**
+ * End-to-end success tests for user-defined <strong>federated</strong> custom authenticators
+ * (configured via the IdP API) across every supported endpoint authentication mode.
+ * One TestNG instance per (tenant, auth-type) pair via {@link Factory}.
+ */
+public class CustomAuthEndpointAuthFederatedSuccessTestCase extends CustomAuthEndpointAuthFederatedBaseTestCase {
+
+    @Factory(dataProvider = "scenarioProvider")
+    public CustomAuthEndpointAuthFederatedSuccessTestCase(TestUserMode testUserMode, EndpointAuthScenario scenario) {
+
+        super(testUserMode, scenario);
+    }
+
+    @DataProvider(name = "scenarioProvider")
+    public static Object[][] scenarioProvider() {
+
+        TestUserMode[] userModes = {TestUserMode.SUPER_TENANT_USER, TestUserMode.TENANT_USER};
+        EndpointAuthScenario[] scenarios = EndpointAuthScenario.values();
+        List<Object[]> combinations = new ArrayList<>();
+        for (TestUserMode mode : userModes) {
+            for (EndpointAuthScenario scenario : scenarios) {
+                combinations.add(new Object[]{mode, scenario});
+            }
+        }
+        return combinations.toArray(new Object[0][]);
+    }
+
+    @Override
+    protected String variantSuffix() {
+
+        return "success";
+    }
+
+    @Override
+    protected void installTokenEndpointStubs(ServiceExtensionMockServer server) throws IOException {
+
+        scenario.installSuccessTokenEndpointStub(server);
+    }
+
+    @Test(groups = "wso2.is", description = "Drive the federated OAuth authorize-code flow and confirm the " +
+            "mock authenticator endpoint receives the configured inbound credentials for the scenario.")
+    public void testInitAuthorizeRequestWithCustomAuthentication() throws Exception {
+
+        Thread.sleep(5000);
+        authorizationCode = drivePinAuthenticationFlow();
+        assertNotNull(authorizationCode);
+
+        verify(postRequestedFor(urlEqualTo(API_AUTHENTICATE_ENDPOINT))
+                .withHeader(scenario.expectedInboundHeaderName(), equalTo(scenario.expectedInboundHeaderValue())));
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testInitAuthorizeRequestWithCustomAuthentication",
+            description = "For OAuth2-based endpoint authentication modes, verify the configured token endpoint " +
+                    "received the expected grant request. Skipped for scenarios that don't use a token endpoint.")
+    public void testTokenEndpointReceivedExpectedGrantRequest() {
+
+        if (!scenario.requiresTokenEndpoint()) {
+            throw new SkipException("Not applicable for endpoint auth scenario: " + scenario.name());
+        }
+        scenario.verifyTokenEndpointReceivedGrantRequest(serviceExtensionMockServer);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testInitAuthorizeRequestWithCustomAuthentication",
+            description = "Exchange the authorization code for tokens and verify the JIT-provisioned " +
+                    "federated user's claims surface in the id_token.")
+    public void testGetAccessTokenWithAuthCodeGrant() throws Exception {
+
+        HttpResponse response = exchangeAuthorizationCodeForTokens();
+        assertExpectedTokenClaims(response);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthLocalBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthLocalBaseTestCase.java
@@ -1,0 +1,555 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.apache.poi.util.StringUtil;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.identity.test.integration.service.dao.Attribute;
+import org.wso2.carbon.identity.test.integration.service.dao.UserDTO;
+import org.wso2.identity.integration.test.oauth2.OAuth2ServiceAbstractIntegrationTest;
+import org.wso2.identity.integration.test.oidc.OIDCUtilTest;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AccessTokenConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AdvancedApplicationConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationResponseModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationSequence;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthenticationStep;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Authenticator;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.Claim;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.RequestedClaimConfiguration;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.CustomAuthenticatorManagementClient;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService.API_AUTHENTICATE_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.ACCESS_TOKEN_ENDPOINT;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZATION_HEADER;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.AUTHORIZE_ENDPOINT_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.COMMON_AUTH_URL;
+import static org.wso2.identity.integration.test.utils.OAuth2Constant.OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
+
+/**
+ * Concrete base for end-to-end integration tests that exercise a user-defined <strong>local</strong>
+ * custom authenticator. Each instance is parameterised by a {@link TestUserMode} and an
+ * {@link EndpointAuthScenario} so a single test class can drive every supported endpoint
+ * authentication mode via TestNG {@code @Factory}.
+ *
+ * Subclasses choose between success or failure stub installation via
+ * {@link #installTokenEndpointStubs(ServiceExtensionMockServer)}.
+ */
+public abstract class CustomAuthEndpointAuthLocalBaseTestCase extends OAuth2ServiceAbstractIntegrationTest {
+
+    public static final String TEST_USER_FIRST_NAME = "Emily";
+    public static final String TEST_USER_LAST_NAME = "Ellon";
+    public static final String TEST_USER_EMAIL = "emily@aol.com";
+    private static final String TEST_WSO2 = "Test@wso2";
+
+    public static final String GIVEN_NAME_ATTRIBUTE_NAME = "given_name";
+    public static final String EMAIL_ATTRIBUTE_NAME = "email";
+    public static final String FAMILY_NAME_ATTRIBUTE_NAME = "family_name";
+
+    protected OAuth2RestClient oAuth2RestClient;
+    protected SCIM2RestClient scim2RestClient;
+    protected CustomAuthenticatorManagementClient customAuthenticatorManagementClient;
+
+    protected String consumerKey;
+    protected String consumerSecret;
+    protected String applicationId;
+    protected String authenticatorId;
+    protected String requestedScopes;
+    protected String authorizationCode;
+    protected UserDTO internalUser;
+
+    protected CloseableHttpClient httpClient;
+    protected MockCustomAuthenticatorService mockCustomAuthenticatorService;
+    protected ServiceExtensionMockServer serviceExtensionMockServer;
+
+    protected final TestUserMode userMode;
+    protected final EndpointAuthScenario scenario;
+    protected final String authenticatorName;
+
+    protected CustomAuthEndpointAuthLocalBaseTestCase(TestUserMode testUserMode, EndpointAuthScenario scenario) {
+
+        this.userMode = testUserMode;
+        this.scenario = scenario;
+        this.authenticatorName = "custom-internal-auth-" + scenario.name().toLowerCase(Locale.ROOT).replace('_', '-')
+                + "-" + variantSuffix();
+    }
+
+    /**
+     * Distinguishes success / failure subclasses so the authenticator name doesn't collide when
+     * both are wired into the same testng suite.
+     */
+    protected abstract String variantSuffix();
+
+    /**
+     * Subclasses install either a success or failure stub on the token endpoint via
+     * {@link EndpointAuthScenario#installSuccessTokenEndpointStub(ServiceExtensionMockServer)} or
+     * {@link EndpointAuthScenario#installFailureTokenEndpointStub(ServiceExtensionMockServer)}.
+     */
+    protected abstract void installTokenEndpointStubs(ServiceExtensionMockServer server) throws IOException;
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.init(userMode);
+
+        oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        customAuthenticatorManagementClient = new CustomAuthenticatorManagementClient(serverURL, tenantInfo);
+
+        httpClient = HttpClientBuilder.create()
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+
+                        return false;
+                    }
+                }).build();
+        requestedScopes = String.join(" ", OAuth2Constant.OAUTH2_SCOPE_OPENID, OAuth2Constant.OAUTH2_SCOPE_EMAIL,
+                OAuth2Constant.OAUTH2_SCOPE_PROFILE);
+
+        internalUser = createInternalUser();
+
+        if (scenario.requiresTokenEndpoint()) {
+            serviceExtensionMockServer = new ServiceExtensionMockServer();
+            serviceExtensionMockServer.startServer();
+            installTokenEndpointStubs(serviceExtensionMockServer);
+        }
+
+        mockCustomAuthenticatorService = new MockCustomAuthenticatorService();
+        startMockAuthenticatorService();
+
+        authenticatorId = scenario.createLocalAuthenticator(customAuthenticatorManagementClient, authenticatorName,
+                "Custom Auth " + scenario.name(),
+                mockCustomAuthenticatorService.getCustomAuthenticatorURL() + API_AUTHENTICATE_ENDPOINT);
+        assertNotNull(authenticatorId);
+        applicationId = setupApplication();
+        retrieveApplicationDetails();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        if (mockCustomAuthenticatorService != null) {
+            mockCustomAuthenticatorService.stop();
+        }
+        if (serviceExtensionMockServer != null) {
+            serviceExtensionMockServer.stopServer();
+        }
+
+        if (internalUser != null && internalUser.getUserID() != null && scim2RestClient != null) {
+            scim2RestClient.deleteUser(internalUser.getUserID());
+        }
+        if (applicationId != null && oAuth2RestClient != null) {
+            oAuth2RestClient.deleteApplication(applicationId);
+        }
+        if (authenticatorId != null && customAuthenticatorManagementClient != null) {
+            customAuthenticatorManagementClient.deleteCustomAuthenticator(authenticatorId);
+        }
+
+        consumerKey = null;
+        consumerSecret = null;
+        applicationId = null;
+        authenticatorId = null;
+        mockCustomAuthenticatorService = null;
+        serviceExtensionMockServer = null;
+
+        if (httpClient != null) {
+            httpClient.close();
+        }
+        if (oAuth2RestClient != null) {
+            oAuth2RestClient.closeHttpClient();
+        }
+        if (scim2RestClient != null) {
+            scim2RestClient.closeHttpClient();
+        }
+        if (customAuthenticatorManagementClient != null) {
+            customAuthenticatorManagementClient.closeHttpClient();
+        }
+    }
+
+    // -- Internal setup --------------------------------------------------------------------------
+
+    private void startMockAuthenticatorService() {
+
+        String idpAuthURL = getTenantQualifiedURL(COMMON_AUTH_URL, tenantInfo.getDomain());
+        mockCustomAuthenticatorService.start(idpAuthURL, internalUser,
+                scenario.expectedInboundHeaderName(), scenario.expectedInboundHeaderValue());
+    }
+
+    private String setupApplication() throws JSONException, IOException {
+
+        ApplicationModel application = new ApplicationModel();
+        application.setName("App for " + authenticatorName);
+
+        List<String> grantTypes = new ArrayList<>();
+        Collections.addAll(grantTypes, OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE,
+                OAuth2Constant.OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS);
+
+        List<String> callBackUrls = new ArrayList<>();
+        Collections.addAll(callBackUrls, OAuth2Constant.CALLBACK_URL);
+
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(grantTypes);
+        oidcConfig.setCallbackURLs(callBackUrls);
+
+        RequestedClaimConfiguration requestedClaimLastName = new RequestedClaimConfiguration();
+        requestedClaimLastName.setClaim(new Claim().uri(OIDCUtilTest.lastNameClaimUri));
+
+        RequestedClaimConfiguration requestedClaimFirstName = new RequestedClaimConfiguration();
+        requestedClaimFirstName.setClaim(new Claim().uri(OIDCUtilTest.firstNameClaimUri));
+
+        RequestedClaimConfiguration requestedClaimEmail = new RequestedClaimConfiguration();
+        requestedClaimEmail.setClaim(new Claim().uri(OIDCUtilTest.emailClaimUri));
+
+        ClaimConfiguration claimConfiguration = new ClaimConfiguration();
+        claimConfiguration.addRequestedClaimsItem(requestedClaimLastName);
+        claimConfiguration.addRequestedClaimsItem(requestedClaimFirstName);
+        claimConfiguration.addRequestedClaimsItem(requestedClaimEmail);
+
+        application.setClaimConfiguration(claimConfiguration);
+
+        AccessTokenConfiguration accessTokenConfig = new AccessTokenConfiguration().type("JWT");
+        accessTokenConfig.setUserAccessTokenExpiryInSeconds(3600L);
+        accessTokenConfig.setApplicationAccessTokenExpiryInSeconds(3600L);
+        oidcConfig.setAccessToken(accessTokenConfig);
+
+        InboundProtocols inboundProtocolsConfig = new InboundProtocols();
+        inboundProtocolsConfig.setOidc(oidcConfig);
+
+        application.setInboundProtocolConfiguration(inboundProtocolsConfig);
+
+        AuthenticationSequence authenticationSequence = new AuthenticationSequence()
+                .type(AuthenticationSequence.TypeEnum.USER_DEFINED)
+                .addStepsItem(new AuthenticationStep()
+                        .id(1)
+                        .addOptionsItem(new Authenticator().idp("LOCAL").authenticator(authenticatorName)));
+
+        application.authenticationSequence(authenticationSequence);
+        application.advancedConfigurations(
+                new AdvancedApplicationConfiguration().skipLoginConsent(true).skipLogoutConsent(true));
+
+        return oAuth2RestClient.createApplication(application);
+    }
+
+    private void retrieveApplicationDetails() throws Exception {
+
+        ApplicationResponseModel applicationResponse = oAuth2RestClient.getApplication(applicationId);
+        assertNotNull(applicationResponse, "Failed to retrieve the created application with custom authenticator");
+
+        OpenIDConnectConfiguration oidcInboundConfig = oAuth2RestClient.getOIDCInboundDetails(applicationId);
+        consumerKey = oidcInboundConfig.getClientId();
+        assertNotNull(consumerKey);
+        consumerSecret = oidcInboundConfig.getClientSecret();
+        assertNotNull(consumerSecret);
+    }
+
+    private UserDTO createInternalUser() throws Exception {
+
+        UserObject userInfo = new UserObject();
+        userInfo.setUserName(TEST_USER_EMAIL);
+        userInfo.setPassword(TEST_WSO2);
+        userInfo.setName(new Name().givenName(TEST_USER_FIRST_NAME));
+        userInfo.getName().setFamilyName(TEST_USER_LAST_NAME);
+        userInfo.addEmail(new Email().value(TEST_USER_EMAIL));
+
+        String userId = scim2RestClient.createUser(userInfo);
+
+        UserDTO user = new UserDTO();
+        user.setUserID(userId);
+
+        List<Attribute> userAttributes = new ArrayList<>();
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/username", TEST_USER_EMAIL));
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/emailaddress", TEST_USER_EMAIL));
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/lastname", TEST_USER_LAST_NAME));
+        userAttributes.add(createUserAttribute("http://wso2.org/claims/givenname", TEST_USER_FIRST_NAME));
+        user.setAttributes(userAttributes.toArray(new Attribute[0]));
+
+        assertNotNull(user);
+        assertTrue(StringUtil.isNotBlank(user.getUserID()));
+        return user;
+    }
+
+    private Attribute createUserAttribute(String attributeName, String attributeValue) {
+
+        Attribute attribute = new Attribute();
+        attribute.setAttributeName(attributeName);
+        attribute.setAttributeValue(attributeValue);
+        return attribute;
+    }
+
+    // -- Flow helpers (exposed to subclasses) ----------------------------------------------------
+
+    protected String drivePinAuthenticationFlow() throws Exception {
+
+        String customAuthenticatorPageUrl = authorizeApplication();
+        Document customAuthenticatorPage = fetchCustomAuthenticatorPage(customAuthenticatorPageUrl);
+        String commonAuthUrl = submitCredentialsToCustomAuthenticator(customAuthenticatorPage);
+        return handleCommonAuthRequest(commonAuthUrl);
+    }
+
+    protected HttpResponse drivePinAuthenticationFlowExpectingFailure() throws Exception {
+
+        String customAuthenticatorPageUrl = authorizeApplication();
+        HttpResponse pageResponse = sendGetRequest(httpClient, customAuthenticatorPageUrl);
+        // When the token endpoint is stubbed to fail, IS may short-circuit before serving the
+        // authenticator form. Return the early response so the caller can verify no authorization
+        // code was issued without requiring the full pin flow to complete.
+        Document customAuthenticatorPage = parsePageOrNull(pageResponse);
+        if (customAuthenticatorPage == null || customAuthenticatorPage.selectFirst("input[name=flowId]") == null) {
+            return pageResponse;
+        }
+        String commonAuthUrl = submitCredentialsToCustomAuthenticator(customAuthenticatorPage);
+        return sendGetRequest(httpClient, commonAuthUrl);
+    }
+
+    private Document parsePageOrNull(HttpResponse response) throws IOException {
+
+        if (response == null || response.getStatusLine().getStatusCode() != 200
+                || response.getEntity() == null) {
+            return null;
+        }
+        Header contentType = response.getFirstHeader("Content-Type");
+        if (contentType == null || !contentType.getValue().contains("text/html")) {
+            EntityUtils.consume(response.getEntity());
+            return null;
+        }
+        Document doc = Jsoup.parse(EntityUtils.toString(response.getEntity()));
+        EntityUtils.consume(response.getEntity());
+        return doc;
+    }
+
+    private String authorizeApplication() throws Exception {
+
+        List<NameValuePair> urlParameters = buildOAuth2Parameters(consumerKey);
+        urlParameters.add(new BasicNameValuePair("testParam", "123_abc"));
+        HttpResponse authorizeRequest = sendPostRequestWithParameters(httpClient, urlParameters,
+                getTenantQualifiedURL(AUTHORIZE_ENDPOINT_URL, tenantInfo.getDomain()));
+        assertNotNull(authorizeRequest, "Authorization request failed. Authorized response is null.");
+        assertEquals(authorizeRequest.getStatusLine().getStatusCode(), 302);
+
+        Header locationHeader = authorizeRequest.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        Assert.assertNotNull(locationHeader, "Authorization request failed. Authorized response header is null");
+        EntityUtils.consume(authorizeRequest.getEntity());
+
+        String customAuthenticatorPageUrl = locationHeader.getValue();
+        assertTrue(StringUtil.isNotBlank(customAuthenticatorPageUrl),
+                "Custom authenticator page URL is blank or null.");
+        return customAuthenticatorPageUrl;
+    }
+
+    private Document fetchCustomAuthenticatorPage(String customAuthenticatorPageUrl) throws Exception {
+
+        HttpResponse customAuthenticatorPageRequest = sendGetRequest(httpClient, customAuthenticatorPageUrl);
+        assertEquals(customAuthenticatorPageRequest.getStatusLine().getStatusCode(), 200);
+        assertTrue(customAuthenticatorPageRequest.containsHeader("Content-Type"));
+        assertTrue(customAuthenticatorPageRequest.getHeaders("Content-Type")[0].getValue().contains("text/html"),
+                "Response is not HTML");
+
+        Document doc = Jsoup.parse(EntityUtils.toString(customAuthenticatorPageRequest.getEntity()));
+        EntityUtils.consume(customAuthenticatorPageRequest.getEntity());
+        assertNotNull(doc, "Custom authenticator page is null.");
+        return doc;
+    }
+
+    private String submitCredentialsToCustomAuthenticator(Document customAuthenticatorPage) throws Exception {
+
+        Element form = customAuthenticatorPage.selectFirst("form");
+        String customAuthenticatorAuthUrl = mockCustomAuthenticatorService.getCustomAuthenticatorURL();
+        if (form != null) {
+            String actionUrl = form.attr("action");
+            assertTrue(StringUtil.isNotBlank(actionUrl));
+            customAuthenticatorAuthUrl = customAuthenticatorAuthUrl + actionUrl;
+        }
+
+        Element flowIdElement = customAuthenticatorPage.selectFirst("input[name=flowId]");
+        String flowId = (flowIdElement != null) ? flowIdElement.attr("value") : null;
+        assertTrue(StringUtil.isNotBlank(flowId));
+
+        HttpPost customAuthenticatorLoginRequest = buildCustomAuthenticatorLoginRequest(customAuthenticatorAuthUrl,
+                flowId);
+        HttpResponse customAuthenticatorLoginResponse = httpClient.execute(customAuthenticatorLoginRequest);
+        assertNotNull(customAuthenticatorLoginResponse);
+        assertEquals(customAuthenticatorLoginResponse.getStatusLine().getStatusCode(), 200);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(EntityUtils.toString(customAuthenticatorLoginResponse.getEntity()));
+        EntityUtils.consume(customAuthenticatorLoginResponse.getEntity());
+
+        String commonAuthUrl = jsonNode.get("redirectingTo").asText();
+        assertTrue(StringUtil.isNotBlank(commonAuthUrl));
+        return commonAuthUrl;
+    }
+
+    private String handleCommonAuthRequest(String commonAuthUrl) throws Exception {
+
+        HttpResponse commonAuthResponse = sendGetRequest(httpClient, commonAuthUrl);
+        assertNotNull(commonAuthResponse);
+
+        Header locationHeader = commonAuthResponse.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Location header expected post login, is not available.");
+        EntityUtils.consume(commonAuthResponse.getEntity());
+
+        HttpResponse authorizedResponse = sendGetRequest(httpClient, locationHeader.getValue());
+        locationHeader = authorizedResponse.getFirstHeader(OAuth2Constant.HTTP_RESPONSE_HEADER_LOCATION);
+        assertNotNull(locationHeader, "Redirection URL to the application with authorization code is null.");
+        EntityUtils.consume(authorizedResponse.getEntity());
+
+        return getAuthorizationCodeFromURL(locationHeader.getValue());
+    }
+
+    private HttpPost buildCustomAuthenticatorLoginRequest(String customAuthenticatorAuthUrl, String flowId)
+            throws UnsupportedEncodingException {
+
+        HttpPost customAuthenticatorLoginRequest = new HttpPost(customAuthenticatorAuthUrl);
+        customAuthenticatorLoginRequest.setHeader("Content-Type", "application/json");
+        customAuthenticatorLoginRequest.setHeader("User-Agent", OAuth2Constant.USER_AGENT);
+        String jsonBody = "{"
+                + "\"flowId\": \"" + flowId + "\","
+                + "\"username\": \"" + TEST_USER_EMAIL + "\","
+                + "\"pin\": \"1234\""
+                + "}";
+
+        customAuthenticatorLoginRequest.setEntity(new StringEntity(jsonBody));
+        return customAuthenticatorLoginRequest;
+    }
+
+    protected String getAuthorizationCodeFromURL(String location) {
+
+        URI uri = URI.create(location);
+        return URLEncodedUtils.parse(uri, StandardCharsets.UTF_8).stream()
+                .filter(param -> "code".equals(param.getName()))
+                .map(NameValuePair::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    protected List<NameValuePair> buildOAuth2Parameters(String consumerKey) {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("response_type", OAuth2Constant.OAUTH2_GRANT_TYPE_CODE));
+        urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", OAuth2Constant.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("scope", requestedScopes));
+        return urlParameters;
+    }
+
+    // -- Token exchange + claim assertions -------------------------------------------------------
+
+    protected HttpResponse exchangeAuthorizationCodeForTokens() throws Exception {
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("code", authorizationCode));
+        urlParameters.add(new BasicNameValuePair("grant_type", OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE));
+        urlParameters.add(new BasicNameValuePair("redirect_uri", OAuth2Constant.CALLBACK_URL));
+        urlParameters.add(new BasicNameValuePair("client_id", consumerKey));
+        urlParameters.add(new BasicNameValuePair("scope", requestedScopes));
+
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(AUTHORIZATION_HEADER,
+                OAuth2Constant.BASIC_HEADER + " " + getBase64EncodedString(consumerKey, consumerSecret)));
+        headers.add(new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        headers.add(new BasicHeader("User-Agent", OAuth2Constant.USER_AGENT));
+
+        HttpResponse response = sendPostRequest(httpClient, headers, urlParameters,
+                getTenantQualifiedURL(ACCESS_TOKEN_ENDPOINT, tenantInfo.getDomain()));
+        assertNotNull(response, "Failed to receive a response for access token request.");
+        return response;
+    }
+
+    protected void assertExpectedTokenClaims(HttpResponse response) throws Exception {
+
+        String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
+        JSONObject jsonResponse = new JSONObject(responseString);
+
+        assertTrue(jsonResponse.has(OAuth2Constant.ACCESS_TOKEN), "Access token not found in the token response.");
+        String accessToken = jsonResponse.getString(OAuth2Constant.ACCESS_TOKEN);
+        assertNotNull(accessToken, "Access token is null.");
+        assertNotNull(extractJwtClaims(accessToken));
+
+        assertTrue(jsonResponse.has(OAuth2Constant.ID_TOKEN), "ID token not found in the token response.");
+        String idToken = jsonResponse.getString(OAuth2Constant.ID_TOKEN);
+        assertNotNull(idToken, "Id token is null.");
+
+        JWTClaimsSet jwtClaimsOfIdToken = extractJwtClaims(idToken);
+        assertNotNull(jwtClaimsOfIdToken);
+
+        assertNotNull(jwtClaimsOfIdToken.getClaim(GIVEN_NAME_ATTRIBUTE_NAME));
+        assertEquals(jwtClaimsOfIdToken.getClaim(GIVEN_NAME_ATTRIBUTE_NAME).toString(), TEST_USER_FIRST_NAME);
+
+        assertNotNull(jwtClaimsOfIdToken.getClaim(FAMILY_NAME_ATTRIBUTE_NAME));
+        assertEquals(jwtClaimsOfIdToken.getClaim(FAMILY_NAME_ATTRIBUTE_NAME).toString(), TEST_USER_LAST_NAME);
+
+        assertNotNull(jwtClaimsOfIdToken.getClaim(EMAIL_ATTRIBUTE_NAME));
+        assertEquals(jwtClaimsOfIdToken.getClaim(EMAIL_ATTRIBUTE_NAME).toString(), TEST_USER_EMAIL);
+    }
+
+    protected JWTClaimsSet extractJwtClaims(String jwtToken) throws ParseException {
+
+        SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+        return signedJWT.getJWTClaimsSet();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthLocalFailureTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthLocalFailureTestCase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * End-to-end failure tests for local user-defined custom authenticators configured with an OAuth2
+ * endpoint authentication mode (CLIENT_CREDENTIAL, PASSWORD_CREDENTIAL). The token endpoint is
+ * stubbed to return HTTP 500; the authorize flow must not yield an authorization code, and the
+ * authenticator endpoint must not be invoked after the failed token acquisition.
+ *
+ * One TestNG instance is created per (tenant, OAuth2-scenario) pair.
+ */
+public class CustomAuthEndpointAuthLocalFailureTestCase extends CustomAuthEndpointAuthLocalBaseTestCase {
+
+    @Factory(dataProvider = "scenarioProvider")
+    public CustomAuthEndpointAuthLocalFailureTestCase(TestUserMode testUserMode, EndpointAuthScenario scenario) {
+
+        super(testUserMode, scenario);
+    }
+
+    @DataProvider(name = "scenarioProvider")
+    public static Object[][] scenarioProvider() {
+
+        TestUserMode[] userModes = {TestUserMode.SUPER_TENANT_USER, TestUserMode.TENANT_USER};
+        List<Object[]> combinations = new ArrayList<>();
+        for (TestUserMode mode : userModes) {
+            for (EndpointAuthScenario scenario : EndpointAuthScenario.values()) {
+                if (scenario.requiresTokenEndpoint()) {
+                    combinations.add(new Object[]{mode, scenario});
+                }
+            }
+        }
+        return combinations.toArray(new Object[0][]);
+    }
+
+    @Override
+    protected String variantSuffix() {
+
+        return "failure";
+    }
+
+    @Override
+    protected void installTokenEndpointStubs(ServiceExtensionMockServer server) throws IOException {
+
+        scenario.installFailureTokenEndpointStub(server);
+    }
+
+    @Test(groups = "wso2.is", description = "When the OAuth2 token endpoint fails, the authorize flow must " +
+            "not yield an authorization code.")
+    public void testAuthorizeFlowFailsWhenTokenEndpointFails() throws Exception {
+
+        Thread.sleep(5000);
+
+        HttpResponse response = drivePinAuthenticationFlowExpectingFailure();
+        assertNotNull(response, "Expected a response from the commonauth endpoint when token acquisition fails.");
+
+        String authorizationCodeIfAny = null;
+        if (response.getFirstHeader("Location") != null) {
+            String location = response.getFirstHeader("Location").getValue();
+            HttpResponse next = sendGetRequest(httpClient, location);
+            String maybeCodeUrl = next.getFirstHeader("Location") != null
+                    ? next.getFirstHeader("Location").getValue()
+                    : location;
+            EntityUtils.consume(next.getEntity());
+            authorizationCodeIfAny = getAuthorizationCodeFromURL(maybeCodeUrl);
+        }
+        EntityUtils.consume(response.getEntity());
+
+        Assert.assertNull(authorizationCodeIfAny,
+                "Authorization code must not be issued when the token endpoint fails.");
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testAuthorizeFlowFailsWhenTokenEndpointFails",
+            description = "When the OAuth2 token endpoint fails, IS must not invoke the second " +
+                    "/api/authenticate call against the custom authenticator endpoint.")
+    public void testCustomAuthenticatorEndpointNotInvokedPostFailure() {
+
+        int callCount = WireMock.findAll(WireMock.postRequestedFor(
+                WireMock.urlEqualTo(MockCustomAuthenticatorService.API_AUTHENTICATE_ENDPOINT))).size();
+        Assert.assertTrue(callCount <= 1,
+                "Expected at most one /api/authenticate call when token endpoint fails, got " + callCount);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthLocalSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomAuthEndpointAuthLocalSuccessTestCase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import org.apache.http.HttpResponse;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService.API_AUTHENTICATE_ENDPOINT;
+
+/**
+ * End-to-end success tests for local user-defined custom authenticators across every supported
+ * endpoint authentication mode (BASIC, BEARER, API_KEY, CLIENT_CREDENTIAL, PASSWORD_CREDENTIAL).
+ *
+ * One TestNG instance is created per (tenant, auth-type) pair via {@link Factory}, so the same
+ * three test methods run once per combination — keeping the class count low without losing
+ * coverage breadth.
+ */
+public class CustomAuthEndpointAuthLocalSuccessTestCase extends CustomAuthEndpointAuthLocalBaseTestCase {
+
+    @Factory(dataProvider = "scenarioProvider")
+    public CustomAuthEndpointAuthLocalSuccessTestCase(TestUserMode testUserMode, EndpointAuthScenario scenario) {
+
+        super(testUserMode, scenario);
+    }
+
+    @DataProvider(name = "scenarioProvider")
+    public static Object[][] scenarioProvider() {
+
+        TestUserMode[] userModes = {TestUserMode.SUPER_TENANT_USER, TestUserMode.TENANT_USER};
+        EndpointAuthScenario[] scenarios = EndpointAuthScenario.values();
+        List<Object[]> combinations = new ArrayList<>();
+        for (TestUserMode mode : userModes) {
+            for (EndpointAuthScenario scenario : scenarios) {
+                combinations.add(new Object[]{mode, scenario});
+            }
+        }
+        return combinations.toArray(new Object[0][]);
+    }
+
+    @Override
+    protected String variantSuffix() {
+
+        return "success";
+    }
+
+    @Override
+    protected void installTokenEndpointStubs(ServiceExtensionMockServer server) throws IOException {
+
+        scenario.installSuccessTokenEndpointStub(server);
+    }
+
+    @Test(groups = "wso2.is", description = "Drive the OAuth authorize-code flow against a local user-defined " +
+            "custom authenticator and confirm the mock authenticator endpoint receives the configured inbound " +
+            "credentials for the scenario.")
+    public void testInitAuthorizeRequestWithCustomAuthentication() throws Exception {
+
+        Thread.sleep(5000);
+        authorizationCode = drivePinAuthenticationFlow();
+        assertNotNull(authorizationCode);
+
+        verify(postRequestedFor(urlEqualTo(API_AUTHENTICATE_ENDPOINT))
+                .withHeader(scenario.expectedInboundHeaderName(), equalTo(scenario.expectedInboundHeaderValue())));
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testInitAuthorizeRequestWithCustomAuthentication",
+            description = "For OAuth2-based endpoint authentication modes, verify the configured token endpoint " +
+                    "received the expected grant request. Skipped for scenarios that don't use a token endpoint.")
+    public void testTokenEndpointReceivedExpectedGrantRequest() {
+
+        if (!scenario.requiresTokenEndpoint()) {
+            throw new SkipException("Not applicable for endpoint auth scenario: " + scenario.name());
+        }
+        scenario.verifyTokenEndpointReceivedGrantRequest(serviceExtensionMockServer);
+    }
+
+    @Test(groups = "wso2.is", dependsOnMethods = "testInitAuthorizeRequestWithCustomAuthentication",
+            description = "Exchange the authorization code for tokens and verify id_token claims.")
+    public void testGetAccessTokenWithAuthCodeGrant() throws Exception {
+
+        HttpResponse response = exchangeAuthorizationCodeForTokens();
+        assertExpectedTokenClaims(response);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomFederatedAuthenticatorPayloadBuilder.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/CustomFederatedAuthenticatorPayloadBuilder.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.AuthenticationType;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.Endpoint;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.util.UserDefinedAuthenticatorPayload;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Factory for {@link UserDefinedAuthenticatorPayload} instances used by the federated custom
+ * authenticator integration tests. Mirrors the factory methods on
+ * {@link org.wso2.identity.integration.test.restclients.CustomAuthenticatorManagementClient},
+ * but targets the IdP API's {@link UserDefinedAuthenticatorPayload} model.
+ */
+public final class CustomFederatedAuthenticatorPayloadBuilder {
+
+    public static final String DEFAULT_FEDERATED_AUTHENTICATOR_ID = "Y3VzdG9tLUF1dGhlbnRpY2F0b3Ix";
+
+    public static final String USERNAME_PROPERTY = "username";
+    public static final String PASSWORD_PROPERTY = "password";
+    public static final String ACCESS_TOKEN_PROPERTY = "accessToken";
+    public static final String API_KEY_HEADER_PROPERTY = "apiKeyHeader";
+    public static final String API_KEY_VALUE_PROPERTY = "apiKeyValue";
+    public static final String CLIENT_ID_PROPERTY = "clientId";
+    public static final String CLIENT_SECRET_PROPERTY = "clientSecret";
+    public static final String TOKEN_ENDPOINT_PROPERTY = "tokenEndpoint";
+    public static final String SCOPES_PROPERTY = "scopes";
+
+    private CustomFederatedAuthenticatorPayloadBuilder() {
+
+    }
+
+    public static UserDefinedAuthenticatorPayload buildBasic(String endpointUri, String username, String password) {
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(USERNAME_PROPERTY, username);
+        properties.put(PASSWORD_PROPERTY, password);
+        return build(endpointUri, AuthenticationType.TypeEnum.BASIC, properties);
+    }
+
+    public static UserDefinedAuthenticatorPayload buildBearer(String endpointUri, String accessToken) {
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(ACCESS_TOKEN_PROPERTY, accessToken);
+        return build(endpointUri, AuthenticationType.TypeEnum.BEARER, properties);
+    }
+
+    public static UserDefinedAuthenticatorPayload buildApiKey(String endpointUri, String apiKeyHeader,
+                                                              String apiKeyValue) {
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(API_KEY_HEADER_PROPERTY, apiKeyHeader);
+        properties.put(API_KEY_VALUE_PROPERTY, apiKeyValue);
+        return build(endpointUri, AuthenticationType.TypeEnum.API_KEY, properties);
+    }
+
+    public static UserDefinedAuthenticatorPayload buildClientCredential(String endpointUri, String clientId,
+                                                                        String clientSecret, String tokenEndpoint,
+                                                                        String scopes) {
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(CLIENT_ID_PROPERTY, clientId);
+        properties.put(CLIENT_SECRET_PROPERTY, clientSecret);
+        properties.put(TOKEN_ENDPOINT_PROPERTY, tokenEndpoint);
+        properties.put(SCOPES_PROPERTY, scopes);
+        return build(endpointUri, AuthenticationType.TypeEnum.CLIENT_CREDENTIAL, properties);
+    }
+
+    public static UserDefinedAuthenticatorPayload buildPasswordCredential(String endpointUri, String clientId,
+                                                                          String clientSecret, String tokenEndpoint,
+                                                                          String username, String password,
+                                                                          String scopes) {
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(CLIENT_ID_PROPERTY, clientId);
+        properties.put(CLIENT_SECRET_PROPERTY, clientSecret);
+        properties.put(TOKEN_ENDPOINT_PROPERTY, tokenEndpoint);
+        properties.put(USERNAME_PROPERTY, username);
+        properties.put(PASSWORD_PROPERTY, password);
+        properties.put(SCOPES_PROPERTY, scopes);
+        return build(endpointUri, AuthenticationType.TypeEnum.PASSWORD_CREDENTIAL, properties);
+    }
+
+    private static UserDefinedAuthenticatorPayload build(String endpointUri, AuthenticationType.TypeEnum type,
+                                                         Map<String, Object> properties) {
+
+        UserDefinedAuthenticatorPayload payload = new UserDefinedAuthenticatorPayload();
+        payload.setIsEnabled(true);
+        payload.setAuthenticatorId(DEFAULT_FEDERATED_AUTHENTICATOR_ID);
+        payload.setDefinedBy(FederatedAuthenticatorRequest.DefinedByEnum.USER.toString());
+
+        AuthenticationType authenticationType = new AuthenticationType();
+        authenticationType.setType(type);
+        authenticationType.setProperties(properties);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setUri(endpointUri);
+        endpoint.authentication(authenticationType);
+
+        payload.setEndpoint(endpoint);
+        return payload;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/EndpointAuthScenario.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/customauthentication/EndpointAuthScenario.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.serviceextensions.customauthentication;
+
+import org.testng.Assert;
+import org.wso2.identity.integration.test.rest.api.server.idp.v1.util.UserDefinedAuthenticatorPayload;
+import org.wso2.identity.integration.test.restclients.CustomAuthenticatorManagementClient;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.MockCustomAuthenticatorService;
+import org.wso2.identity.integration.test.serviceextensions.mockservices.ServiceExtensionMockServer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Encapsulates the configuration of a single custom authenticator endpoint authentication mode:
+ * how to create the authenticator (local or federated), which inbound header the mock authenticator
+ * endpoint should assert, and (for OAuth2-based modes) how to stub and verify the upstream token
+ * endpoint.
+ *
+ * One enum constant per supported endpoint auth type so the success / failure test classes can
+ * loop over them via {@link org.testng.annotations.Factory}.
+ */
+public enum EndpointAuthScenario {
+
+    BASIC {
+        @Override
+        public String createLocalAuthenticator(CustomAuthenticatorManagementClient client, String authenticatorName,
+                                               String displayName, String endpointUri) throws Exception {
+
+            return client.createCustomAuthWithBasicEndpointAuth(authenticatorName, displayName, endpointUri,
+                    BASIC_USERNAME, BASIC_PASSWORD);
+        }
+
+        @Override
+        public UserDefinedAuthenticatorPayload buildFederatedPayload(String endpointUri) {
+
+            return CustomFederatedAuthenticatorPayloadBuilder.buildBasic(endpointUri, BASIC_USERNAME, BASIC_PASSWORD);
+        }
+
+        @Override
+        public String expectedInboundHeaderName() {
+
+            return MockCustomAuthenticatorService.AUTHORIZATION_HEADER;
+        }
+
+        @Override
+        public String expectedInboundHeaderValue() {
+
+            return "Basic " + Base64.getEncoder().encodeToString(
+                    (BASIC_USERNAME + ":" + BASIC_PASSWORD).getBytes(StandardCharsets.UTF_8));
+        }
+    },
+
+    BEARER {
+        @Override
+        public String createLocalAuthenticator(CustomAuthenticatorManagementClient client, String authenticatorName,
+                                               String displayName, String endpointUri) throws Exception {
+
+            return client.createCustomAuthWithBearerEndpointAuth(authenticatorName, displayName, endpointUri,
+                    BEARER_ACCESS_TOKEN);
+        }
+
+        @Override
+        public UserDefinedAuthenticatorPayload buildFederatedPayload(String endpointUri) {
+
+            return CustomFederatedAuthenticatorPayloadBuilder.buildBearer(endpointUri, BEARER_ACCESS_TOKEN);
+        }
+
+        @Override
+        public String expectedInboundHeaderName() {
+
+            return MockCustomAuthenticatorService.AUTHORIZATION_HEADER;
+        }
+
+        @Override
+        public String expectedInboundHeaderValue() {
+
+            return "Bearer " + BEARER_ACCESS_TOKEN;
+        }
+    },
+
+    API_KEY {
+        @Override
+        public String createLocalAuthenticator(CustomAuthenticatorManagementClient client, String authenticatorName,
+                                               String displayName, String endpointUri) throws Exception {
+
+            return client.createCustomAuthWithApiKeyEndpointAuth(authenticatorName, displayName, endpointUri,
+                    API_KEY_HEADER_NAME, API_KEY_VALUE);
+        }
+
+        @Override
+        public UserDefinedAuthenticatorPayload buildFederatedPayload(String endpointUri) {
+
+            return CustomFederatedAuthenticatorPayloadBuilder.buildApiKey(endpointUri, API_KEY_HEADER_NAME,
+                    API_KEY_VALUE);
+        }
+
+        @Override
+        public String expectedInboundHeaderName() {
+
+            return API_KEY_HEADER_NAME;
+        }
+
+        @Override
+        public String expectedInboundHeaderValue() {
+
+            return API_KEY_VALUE;
+        }
+    },
+
+    CLIENT_CREDENTIAL {
+        @Override
+        public String createLocalAuthenticator(CustomAuthenticatorManagementClient client, String authenticatorName,
+                                               String displayName, String endpointUri) throws Exception {
+
+            return client.createCustomAuthWithClientCredentialEndpointAuth(authenticatorName, displayName, endpointUri,
+                    MOCK_IDP_CLIENT_ID, MOCK_IDP_CLIENT_SECRET, MOCK_IDP_TOKEN_ENDPOINT_URI, MOCK_IDP_SCOPES);
+        }
+
+        @Override
+        public UserDefinedAuthenticatorPayload buildFederatedPayload(String endpointUri) {
+
+            return CustomFederatedAuthenticatorPayloadBuilder.buildClientCredential(endpointUri, MOCK_IDP_CLIENT_ID,
+                    MOCK_IDP_CLIENT_SECRET, MOCK_IDP_TOKEN_ENDPOINT_URI, MOCK_IDP_SCOPES);
+        }
+
+        @Override
+        public String expectedInboundHeaderName() {
+
+            return MockCustomAuthenticatorService.AUTHORIZATION_HEADER;
+        }
+
+        @Override
+        public String expectedInboundHeaderValue() {
+
+            return "Bearer " + MOCK_IDP_ACCESS_TOKEN;
+        }
+
+        @Override
+        public boolean requiresTokenEndpoint() {
+
+            return true;
+        }
+
+        @Override
+        public void installSuccessTokenEndpointStub(ServiceExtensionMockServer server) {
+
+            server.setupTokenEndpointStubForClientCredentialsGrant(MOCK_IDP_TOKEN_ENDPOINT_PATH,
+                    "Basic " + base64(MOCK_IDP_CLIENT_ID, MOCK_IDP_CLIENT_SECRET), MOCK_IDP_ACCESS_TOKEN);
+        }
+
+        @Override
+        public void verifyTokenEndpointReceivedGrantRequest(ServiceExtensionMockServer server) {
+
+            int callCount = server.getReceivedRequestCount(MOCK_IDP_TOKEN_ENDPOINT_PATH);
+            Assert.assertTrue(callCount >= 1, "Expected at least one call to the configured token endpoint.");
+
+            String payload = server.getReceivedRequestPayload(MOCK_IDP_TOKEN_ENDPOINT_PATH);
+            Assert.assertTrue(payload.contains("grant_type=client_credentials"),
+                    "Expected grant_type=client_credentials in token endpoint request body. Body: " + payload);
+            Assert.assertFalse(payload.contains("username="),
+                    "Token endpoint request body must not contain a username field. Body: " + payload);
+            Assert.assertFalse(payload.contains("password="),
+                    "Token endpoint request body must not contain a password field. Body: " + payload);
+        }
+    },
+
+    PASSWORD_CREDENTIAL {
+        @Override
+        public String createLocalAuthenticator(CustomAuthenticatorManagementClient client, String authenticatorName,
+                                               String displayName, String endpointUri) throws Exception {
+
+            return client.createCustomAuthWithPasswordCredentialEndpointAuth(authenticatorName, displayName,
+                    endpointUri, MOCK_IDP_CLIENT_ID, MOCK_IDP_CLIENT_SECRET, MOCK_IDP_TOKEN_ENDPOINT_URI,
+                    MOCK_IDP_USERNAME, MOCK_IDP_PASSWORD, MOCK_IDP_SCOPES);
+        }
+
+        @Override
+        public UserDefinedAuthenticatorPayload buildFederatedPayload(String endpointUri) {
+
+            return CustomFederatedAuthenticatorPayloadBuilder.buildPasswordCredential(endpointUri, MOCK_IDP_CLIENT_ID,
+                    MOCK_IDP_CLIENT_SECRET, MOCK_IDP_TOKEN_ENDPOINT_URI, MOCK_IDP_USERNAME, MOCK_IDP_PASSWORD,
+                    MOCK_IDP_SCOPES);
+        }
+
+        @Override
+        public String expectedInboundHeaderName() {
+
+            return MockCustomAuthenticatorService.AUTHORIZATION_HEADER;
+        }
+
+        @Override
+        public String expectedInboundHeaderValue() {
+
+            return "Bearer " + MOCK_IDP_ACCESS_TOKEN;
+        }
+
+        @Override
+        public boolean requiresTokenEndpoint() {
+
+            return true;
+        }
+
+        @Override
+        public void installSuccessTokenEndpointStub(ServiceExtensionMockServer server) {
+
+            server.setupTokenEndpointStubForPasswordGrant(MOCK_IDP_TOKEN_ENDPOINT_PATH,
+                    "Basic " + base64(MOCK_IDP_CLIENT_ID, MOCK_IDP_CLIENT_SECRET), MOCK_IDP_ACCESS_TOKEN,
+                    MOCK_IDP_USERNAME, MOCK_IDP_PASSWORD);
+        }
+
+        @Override
+        public void verifyTokenEndpointReceivedGrantRequest(ServiceExtensionMockServer server) {
+
+            int callCount = server.getReceivedRequestCount(MOCK_IDP_TOKEN_ENDPOINT_PATH);
+            Assert.assertTrue(callCount >= 1, "Expected at least one call to the configured token endpoint.");
+
+            String payload = server.getReceivedRequestPayload(MOCK_IDP_TOKEN_ENDPOINT_PATH);
+            Assert.assertTrue(payload.contains("grant_type=password"),
+                    "Expected grant_type=password in token endpoint request body. Body: " + payload);
+            Assert.assertTrue(payload.contains("username=" + MOCK_IDP_USERNAME),
+                    "Expected configured username in token endpoint request body. Body: " + payload);
+            Assert.assertTrue(payload.contains("password=" + MOCK_IDP_PASSWORD),
+                    "Expected configured password in token endpoint request body. Body: " + payload);
+        }
+    };
+
+    // -- Per-scenario fixed configuration values used across the test family. --------------------
+
+    public static final String BASIC_USERNAME = "endpointUsername";
+    public static final String BASIC_PASSWORD = "endpointPassword";
+    public static final String BEARER_ACCESS_TOKEN = "static-bearer-token-value";
+    public static final String API_KEY_HEADER_NAME = "X-API-Key";
+    public static final String API_KEY_VALUE = "static-api-key-value";
+
+    // Token endpoint stub configuration — mirrors the Actions framework tests
+    // (ActionsBaseTestCase.java:37-55).
+    public static final String MOCK_IDP_TOKEN_ENDPOINT_PATH = "/test/idp/token";
+    public static final String MOCK_IDP_TOKEN_ENDPOINT_URI = "http://localhost:8587" + MOCK_IDP_TOKEN_ENDPOINT_PATH;
+    public static final String MOCK_IDP_CLIENT_ID = "test-idp-client-id";
+    public static final String MOCK_IDP_CLIENT_SECRET = "test-idp-client-secret";
+    public static final String MOCK_IDP_USERNAME = "test-idp-user";
+    public static final String MOCK_IDP_PASSWORD = "test-idp-password";
+    public static final String MOCK_IDP_SCOPES = "send_scope";
+    public static final String MOCK_IDP_ACCESS_TOKEN = "mock-idp-access-token-value";
+
+    // -- Subclass-supplied behavior --------------------------------------------------------------
+
+    public abstract String createLocalAuthenticator(CustomAuthenticatorManagementClient client,
+                                                    String authenticatorName, String displayName,
+                                                    String endpointUri) throws Exception;
+
+    public abstract UserDefinedAuthenticatorPayload buildFederatedPayload(String endpointUri);
+
+    public abstract String expectedInboundHeaderName();
+
+    public abstract String expectedInboundHeaderValue();
+
+    public boolean requiresTokenEndpoint() {
+
+        return false;
+    }
+
+    public void installSuccessTokenEndpointStub(ServiceExtensionMockServer server) {
+
+        // Default no-op for scenarios that don't use an upstream token endpoint.
+    }
+
+    /**
+     * Failure variant: install a token endpoint stub that always returns HTTP 500. Only meaningful
+     * for the OAuth2 scenarios.
+     */
+    public void installFailureTokenEndpointStub(ServiceExtensionMockServer server) {
+
+        server.setupTokenEndpointStubWithError(MOCK_IDP_TOKEN_ENDPOINT_PATH, 500,
+                "{\"error\":\"server_error\",\"error_description\":\"mock failure\"}");
+    }
+
+    public void verifyTokenEndpointReceivedGrantRequest(ServiceExtensionMockServer server) {
+
+        // Default no-op for scenarios that don't use an upstream token endpoint.
+    }
+
+    private static String base64(String left, String right) {
+
+        return Base64.getEncoder().encodeToString((left + ":" + right).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/mockservices/MockCustomAuthenticatorService.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/mockservices/MockCustomAuthenticatorService.java
@@ -21,6 +21,7 @@ package org.wso2.identity.integration.test.serviceextensions.mockservices;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.client.ScenarioMappingBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.identity.test.integration.service.dao.UserDTO;
@@ -39,10 +40,14 @@ public class MockCustomAuthenticatorService {
 
     public static final String API_PIN_ENTRY = "/api/pin-entry";
     public static final String SCENARIO_INTERNAL_USER = "internal-user";
+    public static final String SCENARIO_FEDERATED_USER = "federated-user";
     public static final String SCENARIO_SESSION_INITIALIZED = "SESSION_INITIALIZED";
     public static final String SCENARIO_SESSION_CHALLENGED = "SESSION_CHALLENGED";
     public static final String SCENARIO_SESSION_VALIDATED = "SESSION_VALIDATED";
     public static final String SCENARIO_SESSION_COMPLETED = "SESSION_COMPLETED";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String FEDERATED_USER_EXTERNAL_ID = "fed-user-external-id-001";
+
     private WireMockServer wireMockServer;
     private static final int port = 3999;
     private static final String host = "localhost";
@@ -50,24 +55,82 @@ public class MockCustomAuthenticatorService {
     public static final String API_VALIDATE_PIN_ENDPOINT = "/api/validate-pin";
 
     private String identityProviderAuthURL;
-    private UserDTO internalUser;
+    private UserDTO user;
+    private String scenarioName;
+    private String expectedInboundHeaderName;
+    private String expectedInboundHeaderValue;
 
     private static final Logger LOG = LoggerFactory.getLogger(MockCustomAuthenticatorService.class);
 
+    /**
+     * Start the mock service in the internal-user scenario with no inbound header assertions.
+     */
     public void start(String identityProviderAuthURL, UserDTO internalUser) {
 
-        this.identityProviderAuthURL = identityProviderAuthURL;
-        this.internalUser = internalUser;
-        this.start();
+        startInternal(identityProviderAuthURL, internalUser, SCENARIO_INTERNAL_USER, null, null);
     }
 
-    private void start() {
+    /**
+     * Start the mock service in the internal-user scenario; assert each inbound call carries the
+     * given {@code Authorization} header value.
+     */
+    public void start(String identityProviderAuthURL, UserDTO internalUser, String expectedAuthorizationHeader) {
+
+        startInternal(identityProviderAuthURL, internalUser, SCENARIO_INTERNAL_USER,
+                AUTHORIZATION_HEADER, expectedAuthorizationHeader);
+    }
+
+    /**
+     * Start the mock service in the internal-user scenario; assert each inbound call carries the
+     * given custom header (used for the API_KEY endpoint auth mode).
+     */
+    public void start(String identityProviderAuthURL, UserDTO internalUser, String expectedHeaderName,
+                      String expectedHeaderValue) {
+
+        startInternal(identityProviderAuthURL, internalUser, SCENARIO_INTERNAL_USER,
+                expectedHeaderName, expectedHeaderValue);
+    }
+
+    /**
+     * Start the mock service in the federated-user scenario. The {@code SUCCESS} response carries a
+     * federated user shape so the framework's JIT provisioner can persist the user.
+     */
+    public void startForFederated(String identityProviderAuthURL, UserDTO federatedUser) {
+
+        startInternal(identityProviderAuthURL, federatedUser, SCENARIO_FEDERATED_USER, null, null);
+    }
+
+    public void startForFederated(String identityProviderAuthURL, UserDTO federatedUser,
+                                  String expectedAuthorizationHeader) {
+
+        startInternal(identityProviderAuthURL, federatedUser, SCENARIO_FEDERATED_USER,
+                AUTHORIZATION_HEADER, expectedAuthorizationHeader);
+    }
+
+    public void startForFederated(String identityProviderAuthURL, UserDTO federatedUser,
+                                  String expectedHeaderName, String expectedHeaderValue) {
+
+        startInternal(identityProviderAuthURL, federatedUser, SCENARIO_FEDERATED_USER,
+                expectedHeaderName, expectedHeaderValue);
+    }
+
+    private void startInternal(String identityProviderAuthURL, UserDTO user, String scenarioName,
+                               String expectedInboundHeaderName, String expectedInboundHeaderValue) {
+
+        this.identityProviderAuthURL = identityProviderAuthURL;
+        this.user = user;
+        this.scenarioName = scenarioName;
+        this.expectedInboundHeaderName = expectedInboundHeaderName;
+        this.expectedInboundHeaderValue = expectedInboundHeaderValue;
+        this.startWireMock();
+    }
+
+    private void startWireMock() {
 
         wireMockServer = new WireMockServer(WireMockConfiguration.options().port(port));
         wireMockServer.start();
         WireMock.configureFor(host, port);
 
-        // Log all received requests
         wireMockServer.addMockServiceRequestListener((request, response) -> {
             LOG.info("Received Request: {}", request);
             LOG.info("Response Sent: {}", response.getBodyAsString());
@@ -75,11 +138,12 @@ public class MockCustomAuthenticatorService {
 
         Runtime.getRuntime().addShutdownHook(new Thread(wireMockServer::stop));
 
-        // Mock /api/authenticate (Initial Request)
-        wireMockServer.stubFor(post(urlEqualTo(API_AUTHENTICATE_ENDPOINT)).inScenario(SCENARIO_INTERNAL_USER)
-                .whenScenarioStateIs(STARTED)
-                .withRequestBody(matchingJsonPath("$.actionType", equalTo("AUTHENTICATION")))
-                .withRequestBody(matchingJsonPath("$.flowId"))
+        // /api/authenticate — initial call (returns a redirect to /api/pin-entry).
+        wireMockServer.stubFor(applyExpectedInboundHeader(
+                post(urlEqualTo(API_AUTHENTICATE_ENDPOINT)).inScenario(scenarioName)
+                        .whenScenarioStateIs(STARTED)
+                        .withRequestBody(matchingJsonPath("$.actionType", equalTo("AUTHENTICATION")))
+                        .withRequestBody(matchingJsonPath("$.flowId")))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -96,49 +160,25 @@ public class MockCustomAuthenticatorService {
                         .withTransformers("response-template"))
                 .willSetStateTo(SCENARIO_SESSION_INITIALIZED));
 
-        // Mock /api/authenticate (Initial Request)
-        wireMockServer.stubFor(post(urlEqualTo(API_AUTHENTICATE_ENDPOINT)).inScenario(SCENARIO_INTERNAL_USER)
-                .whenScenarioStateIs(SCENARIO_SESSION_VALIDATED)
-                .withRequestBody(matchingJsonPath("$.actionType", equalTo("AUTHENTICATION")))
-                .withRequestBody(matchingJsonPath("$.flowId"))
+        // /api/authenticate — second call after pin validation (returns SUCCESS with user claims).
+        wireMockServer.stubFor(applyExpectedInboundHeader(
+                post(urlEqualTo(API_AUTHENTICATE_ENDPOINT)).inScenario(scenarioName)
+                        .whenScenarioStateIs(SCENARIO_SESSION_VALIDATED)
+                        .withRequestBody(matchingJsonPath("$.actionType", equalTo("AUTHENTICATION")))
+                        .withRequestBody(matchingJsonPath("$.flowId")))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{" +
-                                "  \"actionStatus\": \"SUCCESS\"," +
-                                "  \"data\": {" +
-                                "    \"user\": {" +
-                                "      \"id\": \"" + this.internalUser.getUserID() + "\"," +
-                                "      \"claims\": [" +
-                                "        {" +
-                                "          \"uri\": \"" + this.internalUser.getAttributes()[0].getAttributeName() +
-                                "\"," +
-                                "          \"value\": \"" + this.internalUser.getAttributes()[0].getAttributeValue() +
-                                "\"" +
-                                "        }," +
-                                "        {" +
-                                "          \"uri\": \"" + this.internalUser.getAttributes()[1].getAttributeName() +
-                                "\"," +
-                                "          \"value\": \"" + this.internalUser.getAttributes()[1].getAttributeValue() +
-                                "\"" +
-                                "        }," +
-                                "        { \"uri\": \"" + this.internalUser.getAttributes()[2].getAttributeName() +
-                                "\", \"value\": \"" + this.internalUser.getAttributes()[2].getAttributeValue() +
-                                "\" }," +
-                                "        { \"uri\": \"" + this.internalUser.getAttributes()[3].getAttributeName() +
-                                "\", \"value\": \"" + this.internalUser.getAttributes()[3].getAttributeValue() +
-                                "\" }" +
-                                "      ]" +
-                                "    }" +
-                                "  } }")
+                        .withBody(buildSuccessResponseBody())
                         .withTransformers("response-template"))
                 .willSetStateTo(SCENARIO_SESSION_COMPLETED));
 
-        // Stub for serving an HTML page when a GET request is made to /api/pin-entry
-        wireMockServer.stubFor(get(urlPathEqualTo(API_PIN_ENTRY)).inScenario(SCENARIO_INTERNAL_USER)
+        // GET /api/pin-entry — serves the pin entry HTML page.
+        // Note: spId is not asserted because IS only adds it for local custom authenticators; the
+        // federated flow forwards the redirect URL verbatim (flowId only).
+        wireMockServer.stubFor(get(urlPathEqualTo(API_PIN_ENTRY)).inScenario(scenarioName)
                 .whenScenarioStateIs(SCENARIO_SESSION_INITIALIZED)
                 .withQueryParam("flowId", matching(".+"))
-                .withQueryParam("spId", matching(".+"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html")
@@ -154,13 +194,16 @@ public class MockCustomAuthenticatorService {
                                         "</form>" +
                                         "</body>" +
                                         "</html>"
-                                 )
+                        )
                         .withTransformers("response-template"))
                 .willSetStateTo(SCENARIO_SESSION_CHALLENGED));
 
-        wireMockServer.stubFor(post(urlEqualTo(API_VALIDATE_PIN_ENDPOINT)).inScenario(SCENARIO_INTERNAL_USER)
+        // POST /api/validate-pin — validates the user-supplied PIN and signals success back to IS.
+        // This endpoint is the authenticator's own internal endpoint, not protected by the configured
+        // endpoint authentication, so we don't apply the inbound-header matcher here.
+        wireMockServer.stubFor(post(urlEqualTo(API_VALIDATE_PIN_ENDPOINT)).inScenario(scenarioName)
                 .whenScenarioStateIs(SCENARIO_SESSION_CHALLENGED)
-                .withRequestBody(matchingJsonPath("$.username", equalTo("emily@aol.com")))
+                .withRequestBody(matchingJsonPath("$.username"))
                 .withRequestBody(matchingJsonPath("$.pin", equalTo("1234")))
                 .withRequestBody(matchingJsonPath("$.flowId"))
                 .willReturn(aResponse()
@@ -170,6 +213,52 @@ public class MockCustomAuthenticatorService {
                                 "?flowId={{jsonPath request.body '$.flowId'}}\"}")
                         .withTransformers("response-template"))
                 .willSetStateTo(SCENARIO_SESSION_VALIDATED));
+    }
+
+    /**
+     * Apply the configured inbound-header matcher to a stub builder if one was set, otherwise pass
+     * through unchanged. Mirrors how the Actions framework tests guard their action endpoint stubs.
+     */
+    private ScenarioMappingBuilder applyExpectedInboundHeader(ScenarioMappingBuilder mappingBuilder) {
+
+        if (expectedInboundHeaderName != null && expectedInboundHeaderValue != null) {
+            return (ScenarioMappingBuilder) mappingBuilder.withHeader(expectedInboundHeaderName,
+                    equalTo(expectedInboundHeaderValue));
+        }
+        return mappingBuilder;
+    }
+
+    /**
+     * Build a SUCCESS response body. The shape is the same for the internal-user and federated-user
+     * scenarios; the framework treats the response identically at the action layer — the
+     * authenticator's own implementation decides whether to look up an internal user or JIT-provision
+     * a federated user based on the returned claims.
+     */
+    private String buildSuccessResponseBody() {
+
+        String userId = SCENARIO_FEDERATED_USER.equals(scenarioName)
+                ? FEDERATED_USER_EXTERNAL_ID
+                : this.user.getUserID();
+        StringBuilder claims = new StringBuilder();
+        for (int i = 0; i < user.getAttributes().length; i++) {
+            if (i > 0) {
+                claims.append(",");
+            }
+            claims.append("{ \"uri\": \"")
+                    .append(user.getAttributes()[i].getAttributeName())
+                    .append("\", \"value\": \"")
+                    .append(user.getAttributes()[i].getAttributeValue())
+                    .append("\" }");
+        }
+        return "{" +
+                "  \"actionStatus\": \"SUCCESS\"," +
+                "  \"data\": {" +
+                "    \"user\": {" +
+                "      \"id\": \"" + userId + "\"," +
+                "      \"claims\": [" + claims + "]" +
+                "    }" +
+                "  }" +
+                "}";
     }
 
     public void stop() {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -172,6 +172,10 @@
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdateprofile.PreUpdateProfileActionSuccessTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.preupdateprofile.PreUpdateProfileActionFailureTestCase"/>
             <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomInternalUserAuthenticatorTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomAuthEndpointAuthLocalSuccessTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomAuthEndpointAuthFederatedSuccessTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomAuthEndpointAuthLocalFailureTestCase"/>
+            <class name="org.wso2.identity.integration.test.serviceextensions.customauthentication.CustomAuthEndpointAuthFederatedFailureTestCase"/>
             <class name="org.wso2.identity.integration.test.oidc.OIDCHybridFlowIntegrationTest"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsTestCase"/>
             <class name="org.wso2.identity.integration.test.oauth2.OAuth2RichAuthorizationRequestsGrantTypesTestCase"/>


### PR DESCRIPTION
### Purpose
- Add Integration Tests for Service Based Custom Authenticators

### Related Issue
-   https://github.com/wso2/product-is/issues/27832

### Description

This pull request introduces significant enhancements to the integration test suite for custom authenticators, particularly around supporting and testing new OAuth2 endpoint authentication types. The changes add support for CLIENT_CREDENTIAL and PASSWORD_CREDENTIAL authentication types, refactor the client code to be more flexible and forward-compatible, and introduce comprehensive failure-mode tests for federated authenticators using OAuth2 endpoint authentication.

**Support for new authentication types:**

* Added `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL` as new values to the `TypeEnum` in `AuthenticationType.java`, enabling these OAuth2 authentication modes in the test models.
* Updated the copyright year.

**Custom Authenticator Management Client enhancements:**

* Refactored `CustomAuthenticatorManagementClient.java` to add constants for all supported authentication types and their property keys, and implemented new helper methods to create custom authenticators for each endpoint authentication type, including the new OAuth2 types. The client now uses string identifiers for authentication types to ensure compatibility with different versions of the API. [[1]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0R50-R71) [[2]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0R87-R184)
* Centralized the logic for creating custom authenticators into a single method, improving maintainability and reducing code duplication. [[1]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0L106-R207) [[2]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0L121-R237)
* Added a method to fetch the JSON representation of a custom authenticator by ID.

**Testing improvements:**

* Added a new test case, `CustomAuthEndpointAuthFederatedFailureTestCase.java`, which provides end-to-end failure tests for federated custom authenticators configured with OAuth2 endpoint authentication. The tests verify correct system behavior when the token endpoint returns an error.

**API client flexibility:**

* Enhanced `IdpMgtRestClient.java` to allow creating Identity Providers from raw JSON, supporting complex payloads that may not fit the standard request model.

These changes collectively improve the flexibility, coverage, and future-proofing of the integration test suite for custom authenticators.

**Summary of most important changes:**

**Support for new OAuth2 authentication types:**
- Added `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL` to the `AuthenticationType.TypeEnum` in `AuthenticationType.java`.

**Custom Authenticator Management Client enhancements:**
- Introduced constants and helper methods for all supported authentication types, including new OAuth2 types, and refactored creation logic for maintainability in `CustomAuthenticatorManagementClient.java`. [[1]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0R50-R71) [[2]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0R87-R184) [[3]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0L106-R207) [[4]](diffhunk://#diff-d3febbec8d54575abe57cef38fbcdde9a1abe5af6ddb4fd10477b8969f2cc9c0L121-R237)
- Added a method to retrieve a custom authenticator's JSON representation by ID.

**Testing improvements:**
- Added `CustomAuthEndpointAuthFederatedFailureTestCase.java` to test failure scenarios for federated authenticators using OAuth2 endpoint authentication.

**API client flexibility:**
- Enabled creation of Identity Providers from raw JSON payloads in `IdpMgtRestClient.java` for advanced test scenarios.