### PR TITLE
Add flow extension support to the new flow engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1414,6 +1414,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.flow.extension</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.saml.common</groupId>
                 <artifactId>org.wso2.carbon.identity.saml.common.util</artifactId>
                 <version>${saml.common.util.version}</version>
@@ -2696,7 +2701,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.95</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.99</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2830,7 +2835,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.6.19</identity.server.api.version>
+        <identity.server.api.version>1.6.21</identity.server.api.version>
         <identity.user.api.version>1.5.6</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
## Purpose
Add the `org.wso2.carbon.identity.flow.extension` module to product-is and bump the related framework and API versions to enable in-flow extension support in the new flow engine.

## Related Issue
- https://github.com/wso2/product-is/issues/27771

## Implementation
- Added `org.wso2.carbon.identity.flow.extension` as a managed dependency under `carbon.identity.framework`.
- Bumped `carbon.identity.framework.version` from `7.11.95` to `7.11.99`.
- Bumped `identity.server.api.version` from `1.6.19` to `1.6.21`.