### PR TITLE
[Integration-Test] Enhance pre-update profile action to support modifying user claims

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileActionRequest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreUpdateProfileActionRequest.java
@@ -21,6 +21,7 @@ package org.wso2.identity.integration.test.serviceextensions.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -34,6 +35,7 @@ public class PreUpdateProfileActionRequest {
     private final String flowId;
     private final String requestId;
     private final PreUpdateProfileEvent event;
+    private final List<AllowedOperation> allowedOperations;
 
     public PreUpdateProfileActionRequest(Builder builder) {
 
@@ -41,6 +43,7 @@ public class PreUpdateProfileActionRequest {
         this.flowId = builder.flowId;
         this.requestId = builder.requestId;
         this.event = builder.event;
+        this.allowedOperations = builder.allowedOperations;
     }
 
     public ActionType getActionType() {
@@ -63,6 +66,11 @@ public class PreUpdateProfileActionRequest {
         return event;
     }
 
+    public List<AllowedOperation> getAllowedOperations() {
+
+        return allowedOperations;
+    }
+
     @Override
     public boolean equals(Object o) {
 
@@ -70,13 +78,14 @@ public class PreUpdateProfileActionRequest {
         if (o == null || getClass() != o.getClass()) return false;
         PreUpdateProfileActionRequest that = (PreUpdateProfileActionRequest) o;
         return actionType == that.actionType &&
-                Objects.equals(event, that.event);
+                Objects.equals(event, that.event) &&
+                Objects.equals(allowedOperations, that.allowedOperations);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(actionType, event);
+        return Objects.hash(actionType, event, allowedOperations);
     }
 
     /**
@@ -89,6 +98,7 @@ public class PreUpdateProfileActionRequest {
         private String flowId;
         private String requestId;
         private PreUpdateProfileEvent event;
+        private List<AllowedOperation> allowedOperations;
 
         public Builder actionType(ActionType actionType) {
 
@@ -114,10 +124,15 @@ public class PreUpdateProfileActionRequest {
             return this;
         }
 
+        public Builder allowedOperations(List<AllowedOperation> allowedOperations) {
+
+            this.allowedOperations = allowedOperations;
+            return this;
+        }
+
         public PreUpdateProfileActionRequest build() {
 
             return new PreUpdateProfileActionRequest(this);
         }
     }
 }
-

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionBaseTestCase.java
@@ -72,9 +72,17 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
     protected static final String TEST_USER_GIVEN_NAME = "test_user_given_name";
     protected static final String TEST_USER_LASTNAME = "test_user_last_name";
     protected static final String TEST_USER_EMAIL = "test.user@gmail.com";
+    protected static final String TEST_USER_MOBILE_NUMBER = "0771234567";
+    protected static final String TEST_USER_UPDATED_MOBILE_NUMBER = "0717654329";
+    protected static final String USER_SYSTEM_SCHEMA_ATTRIBUTE = "urn:scim:wso2:schema";
+    protected static final String COUNTRY_SCHEMA_NAME = "country";
+    protected static final String MOBILE_NUMBERS_SCHEMA_NAME = "mobileNumbers";
     protected static final String NICK_NAME_USER_SCHEMA_NAME = "nickName";
     protected static final String NICK_NAME_CLAIM_URI = "http://wso2.org/claims/nickname";
     protected static final String GIVEN_NAME_CLAIM_URI = "http://wso2.org/claims/givenname";
+    protected static final String LAST_NAME_CLAIM_URI = "http://wso2.org/claims/lastname";
+    protected static final String COUNTRY_CLAIM_URI = "http://wso2.org/claims/country";
+    protected static final String MOBILE_NUMBERS_CLAIM_URI = "http://wso2.org/claims/mobileNumbers";
     protected static final String PRIMARY_USER_STORE_ID = "UFJJTUFSWQ==";
     protected static final String PRIMARY_USER_STORE_NAME = "PRIMARY";
     protected static final String PRE_UPDATE_PROFILE_API_PATH = "preUpdateProfile";
@@ -144,6 +152,13 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
 
     protected String createPreUpdateProfileAction(String actionName, String actionDescription) throws IOException {
 
+        return createPreUpdateProfileAction(actionName, actionDescription,
+                Collections.singletonList(NICK_NAME_CLAIM_URI));
+    }
+
+    protected String createPreUpdateProfileAction(String actionName, String actionDescription, List<String> attributes)
+            throws IOException {
+
         AuthenticationType authentication = new AuthenticationType()
                 .type(AuthenticationType.TypeEnum.BASIC)
                 .putPropertiesItem(USERNAME_PROPERTY, MOCK_SERVER_AUTH_BASIC_USERNAME)
@@ -157,9 +172,15 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
         actionModel.setName(actionName);
         actionModel.setDescription(actionDescription);
         actionModel.setEndpoint(endpoint);
-        actionModel.setAttributes(Collections.singletonList(NICK_NAME_CLAIM_URI));
+        actionModel.setAttributes(attributes);
 
         return createAction(PRE_UPDATE_PROFILE_API_PATH, actionModel);
+    }
+
+    protected List<String> getPreUpdateProfileClaimModificationTestAttributes() {
+
+        return Arrays.asList(NICK_NAME_CLAIM_URI, GIVEN_NAME_CLAIM_URI, LAST_NAME_CLAIM_URI, COUNTRY_CLAIM_URI,
+                MOBILE_NUMBERS_CLAIM_URI);
     }
 
     protected String getTokenWithClientCredentialsGrant(String applicationId, String clientId, String clientSecret) throws Exception {
@@ -241,4 +262,3 @@ public class PreUpdateProfileActionBaseTestCase extends ActionsBaseTestCase {
         return jsonResponse.getString("access_token");
     }
 }
-

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/preupdateprofile/PreUpdateProfileActionSuccessTestCase.java
@@ -20,6 +20,7 @@ package org.wso2.identity.integration.test.serviceextensions.preupdateprofile;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.simple.JSONArray;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -44,7 +45,10 @@ import org.wso2.identity.integration.test.rest.api.user.common.model.UserItemAdd
 import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
 import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 import org.wso2.identity.integration.test.serviceextensions.model.UpdatingUserClaim;
+import org.wso2.identity.integration.test.serviceextensions.model.UserClaim;
 import org.wso2.identity.integration.test.utils.FileUtils;
+
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -112,7 +116,8 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
                 .addEmail(new Email().value(TEST_USER_EMAIL));
         userId = scim2RestClient.createUser(userInfo);
         currentClaimValue = TEST_USER_GIVEN_NAME;
-        actionId = createPreUpdateProfileAction(ACTION_NAME, ACTION_DESCRIPTION);
+        actionId = createPreUpdateProfileAction(ACTION_NAME, ACTION_DESCRIPTION,
+                getPreUpdateProfileClaimModificationTestAttributes());
 
         userAccessToken = getUserAccessToken(clientId, clientSecret,
                 TEST_USER1_USERNAME, TEST_USER_PASSWORD);
@@ -122,7 +127,8 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
         serviceExtensionMockServer.setupStub(MOCK_SERVER_ENDPOINT_RESOURCE_PATH,
                 "Basic " + getBase64EncodedString(MOCK_SERVER_AUTH_BASIC_USERNAME,
                         MOCK_SERVER_AUTH_BASIC_PASSWORD),
-                FileUtils.readFileInClassPathAsString("actions/response/pre-update-profile-response.json"));
+                FileUtils.readFileInClassPathAsString(
+                        "actions/response/pre-update-profile-claim-modification-response.json"));
     }
 
     @BeforeMethod
@@ -302,6 +308,13 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
                 PreUpdateProfileEvent.FlowInitiatorType.APPLICATION, PreUpdateProfileEvent.Action.UPDATE);
     }
 
+    @Test(dependsOnMethods = "testApplicationUpdateProfileWithRemoveOperation",
+            description = "Verify the pre update profile action response can modify user claims")
+    public void testActionResponseClaimModificationOperations() throws Exception {
+
+        assertClaimModificationOperations();
+    }
+
     private void assertUpdatingClaimValue(String claimValue) throws Exception {
 
         org.json.simple.JSONObject userObj = scim2RestClient.getUser(userId, null);
@@ -313,6 +326,20 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
 
         org.json.simple.JSONObject userObj = scim2RestClient.getUser(userId, null);
         Assert.assertNull(userObj.get(NICK_NAME_USER_SCHEMA_NAME));
+    }
+
+    private void assertClaimModificationOperations() throws Exception {
+
+        org.json.simple.JSONObject userObj = scim2RestClient.getUser(userId, null);
+        org.json.simple.JSONObject wso2Schema = (org.json.simple.JSONObject) userObj.get(USER_SYSTEM_SCHEMA_ATTRIBUTE);
+        if (wso2Schema != null) {
+            Assert.assertNull(wso2Schema.get(COUNTRY_SCHEMA_NAME));
+        }
+        Assert.assertNotNull(wso2Schema);
+        JSONArray mobileNumbers = (JSONArray) wso2Schema.get(MOBILE_NUMBERS_SCHEMA_NAME);
+        Assert.assertNotNull(mobileNumbers);
+        Assert.assertTrue(mobileNumbers.contains(TEST_USER_MOBILE_NUMBER));
+        Assert.assertTrue(mobileNumbers.contains(TEST_USER_UPDATED_MOBILE_NUMBER));
     }
 
     private void assertActionRequestPayload(UserItemAddGroupobj.OpEnum operation,String userId, String currentClaimValue,
@@ -334,22 +361,34 @@ public class PreUpdateProfileActionSuccessTestCase extends PreUpdateProfileActio
         ProfileUpdatingUser user = actionRequest.getEvent().getProfileUpdatingUser();
 
         assertEquals(user.getId(), userId);
+        UserClaim userClaim = getClaim(user.getClaims(), NICK_NAME_CLAIM_URI);
         if (operation == UserItemAddGroupobj.OpEnum.ADD) {
-            assertNull(user.getClaims());
+            assertNull(userClaim);
         } else if (operation == UserItemAddGroupobj.OpEnum.REPLACE) {
-            assertEquals(user.getClaims().get(0).getUri(), NICK_NAME_CLAIM_URI);
-            assertEquals(((UpdatingUserClaim) user.getClaims().get(0)).getUpdatingValue(), updateClaimValue);
-            assertEquals(user.getClaims().get(0).getValue(), currentClaimValue);
+            assertNotNull(userClaim);
+            assertEquals(((UpdatingUserClaim) userClaim).getUpdatingValue(), updateClaimValue);
+            assertEquals(userClaim.getValue(), currentClaimValue);
         } else if (operation == UserItemAddGroupobj.OpEnum.REMOVE) {
-            assertEquals(user.getClaims().get(0).getUri(), NICK_NAME_CLAIM_URI);
-            assertEquals(user.getClaims().get(0).getValue(), currentClaimValue);
+            assertNotNull(userClaim);
+            assertEquals(userClaim.getValue(), currentClaimValue);
         }
 
         PreUpdateProfileRequest request = actionRequest.getEvent().getRequest();
+        UserClaim requestClaim = getClaim(request.getClaims(), NICK_NAME_CLAIM_URI);
 
-        assertEquals(request.getClaims().get(0).getUri(), NICK_NAME_CLAIM_URI);
-        assertNull(request.getClaims().get(0).getUpdatingValue());
-        assertEquals(request.getClaims().get(0).getValue(), updateClaimValue);
+        assertNotNull(requestClaim);
+        assertNull(((UpdatingUserClaim) requestClaim).getUpdatingValue());
+        assertEquals(requestClaim.getValue(), updateClaimValue);
+    }
+
+    private UserClaim getClaim(List<? extends UserClaim> claims, String uri) {
+
+        if (claims == null) {
+            return null;
+        }
+        return claims.stream()
+                .filter(claim -> claim != null && uri.equals(claim.getUri()))
+                .findFirst()
+                .orElse(null);
     }
 }
-

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-update-profile-claim-modification-response.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/actions/response/pre-update-profile-claim-modification-response.json
@@ -1,0 +1,22 @@
+{
+  "actionStatus": "SUCCESS",
+  "operations": [
+    {
+      "op": "add",
+      "path": "/user/claims[uri=http://wso2.org/claims/country]",
+      "value": "Sri Lanka"
+    },
+    {
+      "op": "remove",
+      "path": "/user/claims[uri=http://wso2.org/claims/country]"
+    },
+    {
+      "op": "replace",
+      "path": "/user/claims[uri=http://wso2.org/claims/mobileNumbers]",
+      "value": [
+        "0771234567",
+        "0717654329"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request enhances the pre-update profile action integration tests by adding support for testing claim modification operations, expanding the test data and utility methods, and improving test coverage for user claim operations. The changes primarily focus on enabling more comprehensive testing of claim add, remove, and replace operations during the pre-update profile flow.

**Enhancements to integration tests:**

* Modified the test initialization in `PreUpdateProfileActionSuccessTestCase` to use the new attribute list and a specialized mock response for claim modification operations.
* Added a new test method, `testActionResponseClaimModificationOperations`, to verify that the pre-update profile action can correctly modify user claims, and implemented supporting assertion logic.
* Improved assertions for user claim updates by introducing a helper method to retrieve claims by URI and refactoring existing test methods for clarity and completeness.

**Test data updates:**

* Added a new mock response file, `pre-update-profile-claim-modification-response.json`, to simulate a variety of claim modification operations (add, remove, replace) in the pre-update profile flow.

**Related PRs**
- https://github.com/wso2/carbon-identity-framework/pull/8124
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/794

> First need to merge these PRs  to the `main` branch before merge this