### PR TITLE
Address review comments on compatibility settings tests.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/compatibilitysettings/CompatibilitySettingsDeploymentConfigTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/compatibilitysettings/CompatibilitySettingsDeploymentConfigTest.java
@@ -74,7 +74,7 @@ public class CompatibilitySettingsDeploymentConfigTest extends ConfigTestBase {
                 getISResourceLocation() + File.separator + "compatibility-settings" + File.separator
                         + COMPATIBILITY_SETTINGS_FRAGMENT_TOML);
 
-        // Merge only the compatibility-settings fragment into existing deployment.toml to avoid conflicts
+        // Merge only the compatibility-settings fragment into existing deployment.toml to avoid conflicts.
         String existingContent = new String(Files.readAllBytes(defaultConfigFile.toPath()), StandardCharsets.UTF_8);
         String fragmentContent = new String(Files.readAllBytes(fragmentFile.toPath()), StandardCharsets.UTF_8);
         String mergedContent = existingContent.trim() + "\n\n" + fragmentContent.trim() + "\n";
@@ -114,7 +114,7 @@ public class CompatibilitySettingsDeploymentConfigTest extends ConfigTestBase {
         RestAssured.basePath = basePath;
     }
 
-    @Test(description = "After deployment.toml override and restart, GET all compatibility settings returns 200")
+    @Test(description = "After deployment.toml override and restart, GET all compatibility settings returns 200.")
     public void testCompatibilitySettingsReflectDeploymentConfigGetAll() throws Exception {
 
         Response response = getResponseOfGet(CONFIGS_COMPATIBILITY_SETTINGS_API_BASE_PATH);
@@ -125,7 +125,7 @@ public class CompatibilitySettingsDeploymentConfigTest extends ConfigTestBase {
         response.then().body("$", notNullValue());
     }
 
-    @Test(description = "After deployment.toml override and restart, GET flowExecution reflects target_value=true")
+    @Test(description = "After deployment.toml override and restart, GET flowExecution reflects target_value=true.")
     public void testCompatibilitySettingsReflectDeploymentConfigByGroup() throws Exception {
 
         Response response = getResponseOfGet(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/compatibilitysettings/CompatibilitySettingsFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/compatibilitysettings/CompatibilitySettingsFailureTest.java
@@ -85,7 +85,7 @@ public class CompatibilitySettingsFailureTest extends ConfigTestBase {
         };
     }
 
-    @Test(description = "GET by group with invalid group name returns 400 CNF-60003")
+    @Test(description = "GET by group with invalid group name returns 400 CNF-60003.")
     public void testGetCompatibilitySettingsByGroupInvalidGroupName() {
 
         Response response = getResponseOfGet(
@@ -93,7 +93,7 @@ public class CompatibilitySettingsFailureTest extends ConfigTestBase {
         validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, ERROR_CODE_INVALID_INPUT);
     }
 
-    @Test(description = "GET by group with non-existent group returns 400 ICS-60002")
+    @Test(description = "GET by group with non-existent group returns 400 ICS-60002.")
     public void testGetCompatibilitySettingsByGroupNonexistentGroup() {
 
         Response response = getResponseOfGet(
@@ -101,7 +101,7 @@ public class CompatibilitySettingsFailureTest extends ConfigTestBase {
         validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, ERROR_CODE_UNSUPPORTED_SETTING_GROUP);
     }
 
-    @Test(description = "GET all compatibility settings without auth returns 401")
+    @Test(description = "GET all compatibility settings without auth returns 401.")
     public void testGetCompatibilitySettingsWithoutAuth() {
 
         Response response = getResponseOfGetWithoutAuthentication(
@@ -109,7 +109,7 @@ public class CompatibilitySettingsFailureTest extends ConfigTestBase {
         validateHttpStatusCode(response, HttpStatus.SC_UNAUTHORIZED);
     }
 
-    @Test(description = "GET by group without auth returns 401")
+    @Test(description = "GET by group without auth returns 401.")
     public void testGetCompatibilitySettingsByGroupWithoutAuth() {
 
         Response response = getResponseOfGetWithoutAuthentication(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/compatibilitysettings/CompatibilitySettingsSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/configs/v1/compatibilitysettings/CompatibilitySettingsSuccessTest.java
@@ -88,7 +88,7 @@ public class CompatibilitySettingsSuccessTest extends ConfigTestBase {
         };
     }
 
-    @Test(description = "GET all compatibility settings returns 200 and valid structure")
+    @Test(description = "GET all compatibility settings returns 200 and valid structure.")
     public void testGetCompatibilitySettings() throws Exception {
 
         Response response = getResponseOfGet(CONFIGS_COMPATIBILITY_SETTINGS_API_BASE_PATH);
@@ -99,7 +99,7 @@ public class CompatibilitySettingsSuccessTest extends ConfigTestBase {
         response.then().body("$", notNullValue());
     }
 
-    @Test(description = "GET compatibility settings by group flowExecution returns 200 and enableLegacyFlows")
+    @Test(description = "GET compatibility settings by group flowExecution returns 200 and enableLegacyFlows.")
     public void testGetCompatibilitySettingsByGroupFlowExecution() throws Exception {
 
         Response response = getResponseOfGet(
@@ -111,7 +111,7 @@ public class CompatibilitySettingsSuccessTest extends ConfigTestBase {
                 .body(ENABLE_LEGACY_FLOWS, equalTo("false"));
     }
 
-    @Test(description = "PATCH compatibility settings then GET reflects updated value",
+    @Test(description = "PATCH compatibility settings then GET reflects updated value.",
             dependsOnMethods = {"testGetCompatibilitySettingsByGroupFlowExecution"})
     public void testPatchCompatibilitySettingsFlowExecution() throws Exception {
 
@@ -131,7 +131,7 @@ public class CompatibilitySettingsSuccessTest extends ConfigTestBase {
                 .body(ENABLE_LEGACY_FLOWS, equalTo("true"));
     }
 
-    @Test(description = "PATCH then GET by group returns consistent flowExecution settings",
+    @Test(description = "PATCH then GET by group returns consistent flowExecution settings.",
             dependsOnMethods = {"testPatchCompatibilitySettingsFlowExecution"})
     public void testPatchThenGetByGroup() throws Exception {
 


### PR DESCRIPTION
Add trailing periods to test descriptions and one inline comment in the compatibility settings integration tests, as suggested in review feedback on #26953.