### PR TITLE
[product-is] Bump Jackson to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2989,9 +2989,9 @@
         <swagger-core-version>1.5.22</swagger-core-version>
         <swagger-request-validator.version>2.6.0</swagger-request-validator.version>
         <!--UI Cypress test -->
-        <com.fasterxml.jackson.version>2.18.3</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.databind.version>2.18.3</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.annotations.version>2.18.3</com.fasterxml.jackson.annotations.version>
+        <com.fasterxml.jackson.version>2.21.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>
         <jackson-core-asl.version>1.9.13</jackson-core-asl.version>
         <!--ws-trust-client-->
         <org.apache.velocity.version>1.7</org.apache.velocity.version>


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the 2.18.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in the root `pom.xml`:
- `com.fasterxml.jackson.version` → `2.21.2`
- `com.fasterxml.jackson.databind.version` → `2.21.2`
- `com.fasterxml.jackson.annotations.version` → `2.21`