### PR TITLE
Fix webhook event integration tests for added initiatorIpAddress field

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/password/v1/PasswordUpdateWebhookTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/user/password/v1/PasswordUpdateWebhookTest.java
@@ -143,6 +143,7 @@ public class PasswordUpdateWebhookTest extends PasswordUpdateTestBase {
 
         JSONObject payload = new JSONObject();
         payload.put("initiatorType", "USER");
+        payload.put("initiatorIpAddress", "dummy-initiator-ip-address");
         payload.put("action", "CREDENTIAL_UPDATE");
         payload.put("credentialType", "PASSWORD");
         payload.put("user", buildUserObject(userId, tenantDomain));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/usermanagement/eventpayloadbuilder/AdminInitCredentialEventTestExpectedEventPayloadBuilder.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/usermanagement/eventpayloadbuilder/AdminInitCredentialEventTestExpectedEventPayloadBuilder.java
@@ -70,6 +70,7 @@ public class AdminInitCredentialEventTestExpectedEventPayloadBuilder {
         JSONObject userProfileUpdateEvent = new JSONObject();
 
         userProfileUpdateEvent.put("initiatorType", "ADMIN");
+        userProfileUpdateEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userProfileUpdateEvent.put("user",
                 createUserObjectForUserCredentialUpdateWithoutAnyOtherClaims(userId, tenantDomain));
         userProfileUpdateEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/usermanagement/eventpayloadbuilder/AdminInitUserManagementEventTestExpectedEventPayloadBuilder.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/usermanagement/eventpayloadbuilder/AdminInitUserManagementEventTestExpectedEventPayloadBuilder.java
@@ -44,6 +44,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userCreatedEvent = new JSONObject();
 
         userCreatedEvent.put("initiatorType", "ADMIN");
+        userCreatedEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userCreatedEvent.put("user", createUserObjectForUserCreate(userId, tenantDomain));
         userCreatedEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         userCreatedEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -68,6 +69,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject registrationSuccessEvent = new JSONObject();
 
         registrationSuccessEvent.put("initiatorType", "ADMIN");
+        registrationSuccessEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         registrationSuccessEvent.put("user", createUserObjectForUserCreate(userId, tenantDomain));
         registrationSuccessEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         registrationSuccessEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -92,6 +94,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userProfileUpdateEvent = new JSONObject();
 
         userProfileUpdateEvent.put("initiatorType", "ADMIN");
+        userProfileUpdateEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userProfileUpdateEvent.put("user",
                 createUserObjectForUserProfileUpdateWithoutAnyAccountStateManagementClaims(userId, tenantDomain));
         userProfileUpdateEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
@@ -117,6 +120,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userProfileUpdateEvent = new JSONObject();
 
         userProfileUpdateEvent.put("initiatorType", "ADMIN");
+        userProfileUpdateEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userProfileUpdateEvent.put("user",
                 createUserObjectForUserProfileUpdateWithAccountLockClaim(userId, tenantDomain));
         userProfileUpdateEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
@@ -140,6 +144,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
 
         JSONObject accountLockedEvent = new JSONObject();
 
+        accountLockedEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         accountLockedEvent.put("user", createUserObjectForUserAccountStateChange(userId, tenantDomain));
         accountLockedEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         accountLockedEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -161,6 +166,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
 
         JSONObject accountLockedEvent = new JSONObject();
 
+        accountLockedEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         accountLockedEvent.put("user", createUserObjectForUserAccountStateChange(userId, tenantDomain));
         accountLockedEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         accountLockedEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -184,6 +190,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userProfileUpdateEvent = new JSONObject();
 
         userProfileUpdateEvent.put("initiatorType", "ADMIN");
+        userProfileUpdateEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userProfileUpdateEvent.put("user",
                 createUserObjectForUserProfileUpdateWithAccountDisableClaim(userId, tenantDomain));
         userProfileUpdateEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
@@ -208,6 +215,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userDisableEvent = new JSONObject();
 
         userDisableEvent.put("initiatorType", "ADMIN");
+        userDisableEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userDisableEvent.put("user", createUserObjectForUserAccountStateChange(userId, tenantDomain));
         userDisableEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         userDisableEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -230,6 +238,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userDisableEvent = new JSONObject();
 
         userDisableEvent.put("initiatorType", "ADMIN");
+        userDisableEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userDisableEvent.put("user", createUserObjectForUserAccountStateChange(userId, tenantDomain));
         userDisableEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         userDisableEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -252,6 +261,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject userDeletedEvent = new JSONObject();
 
         userDeletedEvent.put("initiatorType", "ADMIN");
+        userDeletedEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         userDeletedEvent.put("user", createUserObjectForUserDelete(userId, tenantDomain));
         userDeletedEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         userDeletedEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));
@@ -275,6 +285,7 @@ public class AdminInitUserManagementEventTestExpectedEventPayloadBuilder {
         JSONObject registrationFailedEvent = new JSONObject();
 
         registrationFailedEvent.put("initiatorType", "ADMIN");
+        registrationFailedEvent.put("initiatorIpAddress", "dummy-initiator-ip-address");
         registrationFailedEvent.put("user", createUserObjectForUserCreateFailure(tenantDomain));
         registrationFailedEvent.put("tenant", EventPayloadUtils.createTenantObject(tenantDomain));
         registrationFailedEvent.put("organization", EventPayloadUtils.createOrganizationObject(tenantDomain));

--- a/pom.xml
+++ b/pom.xml
@@ -2754,7 +2754,7 @@
         <identity.event.handler.account.lock.version>1.12.0</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.13.4</identity.event.handler.notification.version>
 
-        <org.wso2.identity.webhook.event.handlers.version>1.2.4</org.wso2.identity.webhook.event.handlers.version>
+        <org.wso2.identity.webhook.event.handlers.version>1.2.5</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.2.3</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->


### PR DESCRIPTION
## Purpose

[identity-webhook-event-handlers#132](https://github.com/wso2-extensions/identity-webhook-event-handlers/pull/132) adds an `initiatorIpAddress` field (resolved from the request-scoped client IP) to the WSO2 webhook event payloads. This caused the webhook integration tests to fail with schema mismatches, e.g.:

```
Payload validation failed for event URI: https://schemas.identity.wso2.org/events/credential/event-type/credentialUpdated.
Error: Schema mismatch: expected keys [credentialType, userStore, organization, action, user, tenant, initiatorType],
but found keys [credentialType, userStore, organization, action, initiatorIpAddress, user, tenant, initiatorType]
```

## Changes

- Add `initiatorIpAddress` to the expected event payload builders so the expected schema matches the new payloads:
  - `AdminInitCredentialEventTestExpectedEventPayloadBuilder` (`credentialUpdated`)
  - `AdminInitUserManagementEventTestExpectedEventPayloadBuilder` (all event builders: `registrationSuccess`, `registrationFailed`, `userCreated`, `userProfileUpdated` variants, `userAccountLocked`, `userAccountUnlocked`, `userDisabled`, `userEnabled`, `userDeleted`)
  - A `dummy-*` value is used, following the existing convention — `EventPayloadValidator` skips value validation for `dummy` values (the IP is not deterministic) while still asserting the key's presence.
- Bump `org.wso2.identity.webhook.event.handlers.version` to `1.2.5` in `pom.xml` to pick up the upstream change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)