### PR TITLE
Bump framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2701,7 +2701,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.111</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.112</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 


### PR DESCRIPTION
## Summary
This pull request makes a minor update to the `pom.xml` file by bumping the `carbon.identity.framework.version` from `7.11.111` to `7.11.112`. This ensures the project uses the latest patch version of the Carbon Identity Framework.
## Related PR
 - https://github.com/wso2/carbon-identity-framework/pull/8141
