### PR TITLE
Introduce Session Data Optimizer v2 to optimize session data footprint

### DIFF
--- a/modules/features/org.wso2.identity.utils.feature/pom.xml
+++ b/modules/features/org.wso2.identity.utils.feature/pom.xml
@@ -59,6 +59,11 @@
                 <groupId>org.apache.axis2.wso2</groupId>
                 <artifactId>axis2-jaxbri</artifactId>
 			</dependency>
+			<dependency>
+				<groupId>org.wso2.is</groupId>
+				<artifactId>org.wso2.carbon.identity.session.data.optimizer</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 	</dependencies>
 
 	<build>
@@ -92,6 +97,7 @@
 								<bundleDef>org.apache.axis2.wso2:axis2-jibx</bundleDef>
 								<bundleDef>org.jibx.wso2:jibx</bundleDef>
 								<bundleDef>org.apache.axis2.wso2:axis2-jaxbri</bundleDef>
+								<bundleDef>org.wso2.is:org.wso2.carbon.identity.session.data.optimizer:${project.version}</bundleDef>
 							</bundles>
 							<importFeatures>
 								<importFeatureDef>org.wso2.carbon.core.server:${carbon.kernel.version}</importFeatureDef>

--- a/modules/identity-session-data-optimizer/pom.xml
+++ b/modules/identity-session-data-optimizer/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.is</groupId>
+        <artifactId>identity-server-parent</artifactId>
+        <version>7.4.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.session.data.optimizer</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Identity Server - Session Data Optimizer v2</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>
+                            org.osgi.framework;version="[1.7.0, 2.0.0)",
+                            org.osgi.service.component;version="[1.2.0, 2.0.0)",
+                            org.apache.commons.logging;version="[1.2.0, 2.0.0)",
+                            org.wso2.carbon.identity.application.authentication.framework.store;version="[5.0.0, 8.0.0)",
+                            *
+                        </Import-Package>
+                        <Export-Package>
+                            org.wso2.carbon.identity.session.data.optimizer.*;version="${project.version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/modules/identity-session-data-optimizer/src/main/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializer.java
+++ b/modules/identity-session-data-optimizer/src/main/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.session.data.optimizer;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.identity.application.authentication.framework.exception.SessionSerializerException;
+import org.wso2.carbon.identity.application.authentication.framework.store.SessionSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * GzipSessionSerializer implements data level optimization for WSO2 Identity Server session persistence.
+ * It serializes session context objects using Java Serialization and compresses the output using GZIP.
+ * On deserialization, it checks for GZIP magic headers, ensuring backward compatibility with uncompressed data.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.session.data.optimizer.GzipSessionSerializer",
+        service = SessionSerializer.class,
+        immediate = true,
+        property = {
+                "service.ranking:Integer=100"
+        }
+)
+public class GzipSessionSerializer implements SessionSerializer {
+
+    private static final Log log = LogFactory.getLog(GzipSessionSerializer.class);
+
+    @Override
+    public java.io.InputStream serializeSessionObject(Object obj) throws SessionSerializerException {
+        if (obj == null) {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Serializing and compressing session object using GzipSessionSerializer");
+        }
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             GZIPOutputStream gzos = new GZIPOutputStream(baos);
+             ObjectOutputStream oos = new ObjectOutputStream(gzos)) {
+            oos.writeObject(obj);
+            oos.flush();
+            gzos.finish();
+            byte[] compressedData = baos.toByteArray();
+            if (log.isDebugEnabled()) {
+                log.debug("Session object compressed successfully. Compressed size: " + compressedData.length + " bytes.");
+            }
+            return new ByteArrayInputStream(compressedData);
+        } catch (IOException e) {
+            throw new SessionSerializerException("Error while serializing and compressing session object", e);
+        }
+    }
+
+    @Override
+    public Object deSerializeSessionObject(java.io.InputStream inputStream) throws SessionSerializerException {
+        if (inputStream == null) {
+            return null;
+        }
+        try {
+            byte[] data;
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[1024];
+                int len;
+                while ((len = inputStream.read(buffer)) != -1) {
+                    baos.write(buffer, 0, len);
+                }
+                data = baos.toByteArray();
+            }
+            if (data.length == 0) {
+                return null;
+            }
+            if (isGzipped(data)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Deserializing GZIP compressed session data");
+                }
+                try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                     GZIPInputStream gzis = new GZIPInputStream(bais);
+                     ObjectInputStream ois = new ObjectInputStream(gzis)) {
+                    return ois.readObject();
+                } catch (ClassNotFoundException e) {
+                    throw new SessionSerializerException("Class not found while decompressing and deserializing session data", e);
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Deserializing standard (uncompressed) session data");
+                }
+                try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                     ObjectInputStream ois = new ObjectInputStream(bais)) {
+                    return ois.readObject();
+                } catch (ClassNotFoundException e) {
+                    throw new SessionSerializerException("Class not found while deserializing standard session data", e);
+                }
+            }
+        } catch (IOException e) {
+            throw new SessionSerializerException("Error while decompressing and deserializing session data", e);
+        }
+    }
+
+    /**
+     * Checks if the byte array is GZIP compressed.
+     *
+     * @param compressed Byte array to check.
+     * @return true if GZIP compressed, false otherwise.
+     */
+    private boolean isGzipped(byte[] compressed) {
+        return (compressed.length >= 2 &&
+                compressed[0] == (byte) (GZIPInputStream.GZIP_MAGIC) &&
+                compressed[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8));
+    }
+}

--- a/modules/identity-session-data-optimizer/src/main/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializer.java
+++ b/modules/identity-session-data-optimizer/src/main/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializer.java
@@ -76,40 +76,28 @@ public class GzipSessionSerializer implements SessionSerializer {
         if (inputStream == null) {
             return null;
         }
-        try {
-            byte[] data;
-            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                byte[] buffer = new byte[1024];
-                int len;
-                while ((len = inputStream.read(buffer)) != -1) {
-                    baos.write(buffer, 0, len);
-                }
-                data = baos.toByteArray();
-            }
-            if (data.length == 0) {
+        try (java.io.PushbackInputStream pbis = new java.io.PushbackInputStream(inputStream, 2)) {
+            byte[] header = new byte[2];
+            int len = pbis.read(header);
+            if (len <= 0) {
                 return null;
             }
-            if (isGzipped(data)) {
-                if (log.isDebugEnabled()) {
+            pbis.unread(header, 0, len);
+
+            boolean isCompressed = isGzipped(header, len);
+            if (log.isDebugEnabled()) {
+                if (isCompressed) {
                     log.debug("Deserializing GZIP compressed session data");
-                }
-                try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
-                     GZIPInputStream gzis = new GZIPInputStream(bais);
-                     ObjectInputStream ois = new ObjectInputStream(gzis)) {
-                    return ois.readObject();
-                } catch (ClassNotFoundException e) {
-                    throw new SessionSerializerException("Class not found while decompressing and deserializing session data", e);
-                }
-            } else {
-                if (log.isDebugEnabled()) {
+                } else {
                     log.debug("Deserializing standard (uncompressed) session data");
                 }
-                try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
-                     ObjectInputStream ois = new ObjectInputStream(bais)) {
-                    return ois.readObject();
-                } catch (ClassNotFoundException e) {
-                    throw new SessionSerializerException("Class not found while deserializing standard session data", e);
-                }
+            }
+
+            java.io.InputStream source = isCompressed ? new GZIPInputStream(pbis) : pbis;
+            try (ObjectInputStream ois = new ObjectInputStream(source)) {
+                return ois.readObject();
+            } catch (ClassNotFoundException e) {
+                throw new SessionSerializerException("Class not found while deserializing session data", e);
             }
         } catch (IOException e) {
             throw new SessionSerializerException("Error while decompressing and deserializing session data", e);
@@ -119,12 +107,13 @@ public class GzipSessionSerializer implements SessionSerializer {
     /**
      * Checks if the byte array is GZIP compressed.
      *
-     * @param compressed Byte array to check.
+     * @param header Byte array header to check.
+     * @param len Length of read bytes.
      * @return true if GZIP compressed, false otherwise.
      */
-    private boolean isGzipped(byte[] compressed) {
-        return (compressed.length >= 2 &&
-                compressed[0] == (byte) (GZIPInputStream.GZIP_MAGIC) &&
-                compressed[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8));
+    private boolean isGzipped(byte[] header, int len) {
+        return (len >= 2 &&
+                header[0] == (byte) (GZIPInputStream.GZIP_MAGIC) &&
+                header[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8));
     }
 }

--- a/modules/identity-session-data-optimizer/src/main/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializer.java
+++ b/modules/identity-session-data-optimizer/src/main/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializer.java
@@ -94,13 +94,17 @@ public class GzipSessionSerializer implements SessionSerializer {
             }
 
             java.io.InputStream source = isCompressed ? new GZIPInputStream(pbis) : pbis;
-            try (ObjectInputStream ois = new ObjectInputStream(source)) {
-                return ois.readObject();
-            } catch (ClassNotFoundException e) {
-                throw new SessionSerializerException("Class not found while deserializing session data", e);
-            }
+            return readSessionObject(source);
         } catch (IOException e) {
             throw new SessionSerializerException("Error while decompressing and deserializing session data", e);
+        }
+    }
+
+    private Object readSessionObject(java.io.InputStream source) throws SessionSerializerException {
+        try (ObjectInputStream ois = new ObjectInputStream(source)) {
+            return ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new SessionSerializerException("Error while deserializing session data", e);
         }
     }
 

--- a/modules/identity-session-data-optimizer/src/test/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializerTest.java
+++ b/modules/identity-session-data-optimizer/src/test/java/org/wso2/carbon/identity/session/data/optimizer/GzipSessionSerializerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.session.data.optimizer;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.exception.SessionSerializerException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for GzipSessionSerializer.
+ */
+public class GzipSessionSerializerTest {
+
+    private GzipSessionSerializer serializer;
+
+    @BeforeMethod
+    public void setUp() {
+        serializer = new GzipSessionSerializer();
+    }
+
+    @Test
+    public void testSerializeAndDeserialize() throws SessionSerializerException, IOException {
+        Map<String, String> sessionData = new HashMap<>();
+        sessionData.put("key1", "value1");
+        sessionData.put("key2", "value2");
+
+        InputStream serializedStream = serializer.serializeSessionObject(sessionData);
+        Assert.assertNotNull(serializedStream);
+
+        // Read stream to byte array to check content
+        byte[] serializedData = readAllBytes(serializedStream);
+        Assert.assertTrue(serializedData.length > 0);
+
+        // Verify it is actually gzipped
+        Assert.assertTrue(isGzipped(serializedData), "Serialized data should be GZIP compressed");
+
+        // Deserialize
+        InputStream deStream = new ByteArrayInputStream(serializedData);
+        Object deserializedObj = serializer.deSerializeSessionObject(deStream);
+        Assert.assertNotNull(deserializedObj);
+        Assert.assertTrue(deserializedObj instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> deserializedData = (Map<String, String>) deserializedObj;
+        Assert.assertEquals(deserializedData.get("key1"), "value1");
+        Assert.assertEquals(deserializedData.get("key2"), "value2");
+    }
+
+    @Test
+    public void testDeserializeUncompressedData() throws SessionSerializerException, IOException {
+        // Create standard Java serialized data (not gzipped)
+        Map<String, String> sessionData = new HashMap<>();
+        sessionData.put("key1", "legacyValue");
+
+        byte[] legacyData;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(sessionData);
+            oos.flush();
+            legacyData = baos.toByteArray();
+        }
+
+        // Verify it is NOT gzipped
+        Assert.assertFalse(isGzipped(legacyData), "Legacy serialized data should not be GZIP compressed");
+
+        // Deserialize using GzipSessionSerializer (fallback path)
+        InputStream deStream = new ByteArrayInputStream(legacyData);
+        Object deserializedObj = serializer.deSerializeSessionObject(deStream);
+        Assert.assertNotNull(deserializedObj);
+        Assert.assertTrue(deserializedObj instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> deserializedData = (Map<String, String>) deserializedObj;
+        Assert.assertEquals(deserializedData.get("key1"), "legacyValue");
+    }
+
+    @Test
+    public void testNullOrEmptyData() throws SessionSerializerException, IOException {
+        InputStream nullOut = serializer.serializeSessionObject(null);
+        Assert.assertNotNull(nullOut);
+        Assert.assertEquals(readAllBytes(nullOut).length, 0);
+
+        Assert.assertNull(serializer.deSerializeSessionObject(null));
+        Assert.assertNull(serializer.deSerializeSessionObject(new ByteArrayInputStream(new byte[0])));
+    }
+
+    private byte[] readAllBytes(InputStream inputStream) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = inputStream.read(buffer)) != -1) {
+                baos.write(buffer, 0, len);
+            }
+            return baos.toByteArray();
+        }
+    }
+
+    private boolean isGzipped(byte[] compressed) {
+        return (compressed.length >= 2 &&
+                compressed[0] == (byte) (0x1f) &&
+                compressed[1] == (byte) (0x8b));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <url>http://wso2.org/projects/identity</url>
 
     <modules>
+        <module>modules/identity-session-data-optimizer</module>
         <module>modules/features</module>
         <module>modules/p2-profile-gen</module>
         <module>modules/connectors</module>


### PR DESCRIPTION
Introduces Session Data Optimizer v2 to enable GZIP data-level optimization for persistent session objects.

This PR implements a custom compressed OSGi `SessionSerializer` (`GzipSessionSerializer`) with GZIP compression/decompression logic and uncompressed fallback checks to ensure backward compatibility.

Fixes #28028