### PR TITLE
Register credential management v2 REST API in product-IS

### DIFF
--- a/modules/api-resources/api-resources-full/pom.xml
+++ b/modules/api-resources/api-resources-full/pom.xml
@@ -244,6 +244,14 @@
             <groupId>org.wso2.carbon.identity.user.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.user.password.common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.rest.api.user.credential.v2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.user.credential.common</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wso2.carbon.identity.server.api</groupId>

--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
@@ -445,7 +445,8 @@
                 org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.UserIdApi,
                 org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.AuthorizedAppsApi,
                 org.wso2.carbon.identity.rest.api.user.recovery.v2.RecoveryApi,
-                org.wso2.carbon.identity.rest.api.user.approval.v2.MeApi
+                org.wso2.carbon.identity.rest.api.user.approval.v2.MeApi,
+                org.wso2.carbon.identity.rest.api.user.credential.v2.UsersApi
             </param-value>
         </init-param>
         <init-param>

--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -128,6 +128,16 @@
                 <artifactId>org.wso2.carbon.identity.api.user.password.common</artifactId>
                 <version>${identity.user.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.rest.api.user.credential.v2</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.user.credential.common</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
 
 
             <!-- Server REST API Dependencies. -->


### PR DESCRIPTION
## Purpose

Bundle the **credential management v2** user REST API in product-IS by registering the webapp and adding the required Maven dependencies.

## Changes
- Register `org.wso2.carbon.identity.rest.api.user.credential.v2.UsersApi` in the user API webapp (`web.xml`).
- Add the `org.wso2.carbon.identity.rest.api.user.credential.v2` and `org.wso2.carbon.identity.api.user.credential.common` dependencies (versioned via `identity.user.api.version`).

## Notes
- This PR contains **only the endpoint-bundling changes**. Integration tests are intentionally excluded and will be added in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)