### PR TITLE
Update README logo to support light and dark modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <a href="http://wso2.com/products/identity-server/">
-<img src="https://wso2.cachefly.net/wso2/sites/all/image_resources/wso2-branding-logos/wso2-logo-orange.png" alt="WSO2 logo" width=30% height=30% />
-
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/WSO2-Logo-White.png" />
+<source media="(prefers-color-scheme: light)" srcset="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/WSO2-Logo-Black.png" />
+<img src="https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/WSO2-Logo-Black.png" alt="WSO2 logo" width=30% height=30% />
+</picture>
 </a>
 
 # WSO2 Identity Server


### PR DESCRIPTION
## Purpose
The README logo previously used a single fixed image that did not adapt to the reader's color scheme. This updates it to display an appropriate logo variant in both light and dark modes for better legibility.

### Dark mode
<img width="839" height="367" alt="Screenshot 2026-06-17 at 8 16 46 AM" src="https://github.com/user-attachments/assets/8f3c9897-ab6b-45f1-adb2-060fa1fcbc65" />



### Light mode
<img width="844" height="373" alt="Screenshot 2026-06-17 at 8 16 30 AM" src="https://github.com/user-attachments/assets/29447ebc-58e9-4862-bcaa-5afa2765b7d1" />

## Related Issue
- N/A

## Implementation
Replaced the single `<img>` logo with a `<picture>` element that selects the logo based on `prefers-color-scheme`:
- Light mode: WSO2 black logo
- Dark mode: WSO2 white logo
- The black logo remains as the fallback `<img>` for clients that do not support `prefers-color-scheme`.