### PR TITLE
Fix documentation link pointing to incorrect version in Console

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -75,7 +75,7 @@
   "legacy_authz_runtime.enable": false,
   "management_console_deprecation_banner.enable": true,
 
-  "console.doc_site_path": "https://is.docs.wso2.com/en/7.2.0",
+  "console.doc_site_path": "https://is.docs.wso2.com/en/latest",
 
   "admin_service.deny_list": [
     "CarbonAppUploader",


### PR DESCRIPTION
### Purpose
Fix the documentation link in the IS Console header that was incorrectly 
pointing to the 7.2.0 documentation site instead of the 7.3.0 documentation.

### Related Issues
Fixes #28035

### Approach
Updated the 'console.doc_site_path' configuration value in 'default.json'
to point to the correct WSO2 Identity Server 7.3.0 documentation URL.

### Changes
- 'modules/distribution/src/repository/resources/conf/default.json'
  - Updated 'console.doc_site_path' from 'https://is.docs.wso2.com/en/7.2.0' 
    to 'https://is.docs.wso2.com/en/7.3.0'

### Testing
- Start an IS 7.3.0 pack
- Log in to the Console ('https://localhost:9443/console')
- Click the **Documentation** link in the header
- Verify the browser opens 'https://is.docs.wso2.com/en/7.3.0' 
  instead of the outdated '7.2.0' URL

