### PR TITLE
Template requestAttributesEnabled on the Log4j ConfigurableLoggerAccessLogValve

### DIFF
--- a/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -131,7 +131,8 @@
                 <Valve className="org.wso2.carbon.identity.core.context.valve.IdentityContextCreatorValve"/>
                 {% if http_access_log.useLogger is sameas true %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.ConfigurableLoggerAccessLogValve"
-                                    pattern="{{http_access_log.pattern}}"/>
+                                    pattern="{{http_access_log.pattern}}"
+                                    requestAttributesEnabled="{{http_access_log.request_attributes_enabled}}"/>
                 {% else %}
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{http_access_log.directory}}"
                     prefix="{{http_access_log.prefix}}" suffix="{{http_access_log.suffix}}" pattern="{{http_access_log.pattern}}"


### PR DESCRIPTION
## Purpose

Follow-up to #27655. That PR templated `requestAttributesEnabled` on the default `AccessLogValve` (the `{% else %}` branch) but left the Log4j `ConfigurableLoggerAccessLogValve` branch (`{% if http_access_log.useLogger is sameas true %}`) emitting only `pattern` — so `http_access_log.request_attributes_enabled` is silently dropped when the Log4j access logger is used.

When IS is behind a reverse proxy with `RemoteIpValve`, the `%h` pattern cannot log the real client IP because `requestAttributesEnabled` is never propagated to the Log4j valve.

Fixes #27172.

## Change

`modules/distribution/src/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2` — added `requestAttributesEnabled="{{http_access_log.request_attributes_enabled}}"` to the `ConfigurableLoggerAccessLogValve` element, mirroring the default-valve branch from #27655.

- No JAR change — `ConfigurableLoggerAccessLogValve` extends `AbstractAccessLogValve` and already honors the attribute.
- No `default.json` change — `http_access_log.request_attributes_enabled` (default `false`) was added in #27655.
- Reuses the existing knob. No new configuration property.

## Opt-in (requires restart)

```toml
[http_access_log]
useLogger = true
request_attributes_enabled = true
```