### PR TITLE
Bump Apache Tomcat version to 9.0.118

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2971,7 +2971,7 @@
         <selenium.version>2.40.0</selenium.version>
         <testng.version>6.1.1</testng.version>
         <junit.version>4.13.1</junit.version>
-        <org.apache.tomcat.version>9.0.113</org.apache.tomcat.version>
+        <org.apache.tomcat.version>9.0.118</org.apache.tomcat.version>
         <msf4j.version>2.6.2</msf4j.version>
         <jacoco.agent.version>0.8.12</jacoco.agent.version>
         <xml.apis.version>1.4.01</xml.apis.version>


### PR DESCRIPTION
## Purpose
Bump the `org.apache.tomcat.version` property from `9.0.113` to `9.0.118` in the product reactor pom, picking up the latest Apache Tomcat 9.0.x maintenance release for the `tomcat-embed-*` dependencies.

> Note: the packaged (runtime) Tomcat orbit bundles are driven by `version.tomcat` in carbon-kernel; that bump is raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)