### PR TITLE
Bump carbon.kernel.version to 4.12.44

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.43" useFeatures="true" includeLaunchers="true">
+version="4.12.44" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.43" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.43"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.44"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2857,7 +2857,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.43</carbon.kernel.version>
+        <carbon.kernel.version>4.12.44</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.2</identity.verification.version>


### PR DESCRIPTION
## Purpose
Bump `carbon.kernel.version` from `4.12.43` to `4.12.44` to pick up the latest WSO2 Carbon Kernel release.

This pulls the updated orbit Tomcat bundles (Apache Tomcat `9.0.118`) into the product runtime, since the packaged Tomcat is driven by `version.tomcat` in carbon-kernel's `parent/pom.xml`.

## Dependency
Carbon Kernel `4.12.44` has been released with 

- https://github.com/wso2/carbon-kernel/pull/4605

