### PR TITLE
Add integration tests

### DIFF
--- a/modules/api-resources/api-resources-full/pom.xml
+++ b/modules/api-resources/api-resources-full/pom.xml
@@ -246,6 +246,14 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.rest.api.user.consent.v1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.user.consent.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
             <artifactId>org.wso2.carbon.identity.rest.api.user.credential.v2</artifactId>
         </dependency>
         <dependency>

--- a/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
+++ b/modules/api-resources/api-resources-full/src/main/webapp/WEB-INF/web.xml
@@ -377,7 +377,8 @@
                 org.wso2.carbon.identity.rest.api.user.idv.v1.MeApi,
                 org.wso2.carbon.identity.rest.api.user.idv.v1.DefaultApi,
                 org.wso2.carbon.identity.api.user.onboard.v1.OfflineInviteLinkApi,
-                org.wso2.carbon.identity.api.user.password.v1.MeApi
+                org.wso2.carbon.identity.api.user.password.v1.MeApi,
+                org.wso2.carbon.identity.api.user.consent.v1.MeApi
             </param-value>
         </init-param>
         <init-param>
@@ -536,7 +537,8 @@
                 org.wso2.carbon.identity.rest.api.user.idv.v1.MeApi,
                 org.wso2.carbon.identity.rest.api.user.idv.v1.DefaultApi,
                 org.wso2.carbon.identity.api.user.onboard.v1.OfflineInviteLinkApi,
-                org.wso2.carbon.identity.api.user.password.v1.MeApi
+                org.wso2.carbon.identity.api.user.password.v1.MeApi,
+                org.wso2.carbon.identity.api.user.consent.v1.MeApi
             </param-value>
         </init-param>
         <init-param>

--- a/modules/api-resources/pom.xml
+++ b/modules/api-resources/pom.xml
@@ -138,6 +138,16 @@
                 <artifactId>org.wso2.carbon.identity.api.user.credential.common</artifactId>
                 <version>${identity.user.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.rest.api.user.consent.v1</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.user.consent.common</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
 
 
             <!-- Server REST API Dependencies. -->

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2AdminModeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2AdminModeTest.java
@@ -1,0 +1,619 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.consent.management.v2;
+
+import io.restassured.RestAssured;
+
+import static io.restassured.RestAssured.given;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthorizedAPICreationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.InboundProtocols;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.OpenIDConnectConfiguration;
+import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.APIResourceListItem;
+import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.ScopeGetModel;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.OAuth2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+import org.wso2.identity.integration.test.utils.CarbonUtils;
+import org.wso2.identity.integration.test.utils.OAuth2Constant;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Integration tests for Consent Management API v2 admin-mode paths.
+ *
+ * <p>Admin mode is active when an OAuth2 M2M token carrying an operation-level scope
+ * (e.g. {@code internal_consent_mgt_consent_view}) is used. In admin mode the server
+ * allows cross-subject access that is forbidden to regular (basic-auth) users.
+ *
+ * <p>Prerequisites: the consent management v2 API resource must be registered with
+ * {@code isOperationScopeMandatory=true} so that {@code AuthorizationValve} sets
+ * {@code OperationScopeValidationContext.validationRequired=true} and
+ * {@code ConsentManagementService.isAdminMode()} returns {@code true}.
+ */
+public class ConsentManagementV2AdminModeTest extends ConsentManagementV2TestBase {
+
+    private static final String CONSENT_MANAGEMENT_API_IDENTIFIER = "/api/identity/consent-mgt/v2.0/consents";
+    private static final String SCOPE_CONSENT_VIEW = "internal_consent_mgt_consent_view";
+    private static final String SCOPE_CONSENT_CREATE = "internal_consent_mgt_consent_create";
+    private static final String SCOPE_CONSENT_UPDATE = "internal_consent_mgt_consent_update";
+
+    private static final String ADMIN_MODE_USER = "consent_admin_mode_user";
+    private static final String ADMIN_MODE_USER_PASSWORD = "Admin@123";
+
+    private CloseableHttpClient httpClient;
+    private OAuth2RestClient oauth2RestClient;
+    private SCIM2RestClient scim2RestClient;
+
+    private String m2mAppId;
+    private String m2mClientId;
+    private String m2mClientSecret;
+
+    private String adminTestUserId;
+    private String adminTestPurposeId;
+    private String adminTestElementId;
+    private String adminTestConsentId;
+    private String updateTestConsentId;
+
+    @Factory(dataProvider = "restAPIUserConfigProvider")
+    public ConsentManagementV2AdminModeTest(TestUserMode userMode) throws Exception {
+
+        super.init(userMode);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.testInit(tenant);
+        httpClient = HttpClients.createDefault();
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        oauth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
+
+        ApplicationModel appModel = new ApplicationModel();
+        appModel.setName("ConsentAdminModeTestApp");
+        appModel.setIsManagementApp(true);
+        OpenIDConnectConfiguration oidcConfig = new OpenIDConnectConfiguration();
+        oidcConfig.setGrantTypes(Arrays.asList("client_credentials"));
+        InboundProtocols inboundProtocols = new InboundProtocols();
+        inboundProtocols.setOidc(oidcConfig);
+        appModel.setInboundProtocolConfiguration(inboundProtocols);
+        m2mAppId = oauth2RestClient.createApplication(appModel);
+
+        OpenIDConnectConfiguration oidcDetails = oauth2RestClient.getOIDCInboundDetails(m2mAppId);
+        m2mClientId = oidcDetails.getClientId();
+        m2mClientSecret = oidcDetails.getClientSecret();
+
+        if (!CarbonUtils.isLegacyAuthzRuntimeEnabled()) {
+            authorizeAPIForApp(CONSENT_MANAGEMENT_API_IDENTIFIER);
+        }
+
+        RestAssured.basePath = basePath;
+        try {
+            Response elementResponse = getResponseOfPost(ELEMENTS_ENDPOINT,
+                    "{\"name\": \"consent_admin_mode_elem\", \"displayName\": \"Admin Mode Elem\","
+                            + " \"description\": \"Admin mode test element\"}");
+            elementResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+            adminTestElementId = elementResponse.jsonPath().getString("id");
+
+            Response purposeResponse = getResponseOfPost(PURPOSES_ENDPOINT,
+                    "{\"name\": \"consent_admin_mode_purpose\", \"description\": \"Admin mode purpose\","
+                            + " \"type\": \"Core\", \"version\": \"1\","
+                            + " \"elements\": [{\"id\": \"" + adminTestElementId + "\", \"mandatory\": true}]}");
+            purposeResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+            adminTestPurposeId = purposeResponse.jsonPath().getString("id");
+
+            adminTestUserId = createTestUser(ADMIN_MODE_USER);
+            String userAuthName = buildUserAuthName(ADMIN_MODE_USER);
+
+            // The user creates their own consent via the user API; the admin tests then read it via the admin API.
+            String consentBody = "{\"serviceId\": \"admin-mode-test\", \"language\": \"en\","
+                    + " \"purposes\": [{\"id\": \"" + adminTestPurposeId + "\","
+                    + " \"elements\": [{\"id\": \"" + adminTestElementId + "\"}]}]}";
+            Response consentResponse = given()
+                    .auth().preemptive().basic(userAuthName, ADMIN_MODE_USER_PASSWORD)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                    .body(consentBody)
+                    .post(getUserConsentApiBaseUrl());
+            consentResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+            adminTestConsentId = consentResponse.jsonPath().getString("id");
+        } finally {
+            RestAssured.basePath = "";
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void testConclude() throws Exception {
+
+        RestAssured.basePath = basePath;
+        try {
+            if (adminTestUserId != null) {
+                scim2RestClient.deleteUser(adminTestUserId);
+            }
+            if (adminTestPurposeId != null) {
+                getResponseOfDelete(PURPOSES_ENDPOINT + "/" + adminTestPurposeId);
+            }
+            if (adminTestElementId != null) {
+                getResponseOfDelete(ELEMENTS_ENDPOINT + "/" + adminTestElementId);
+            }
+            if (m2mAppId != null) {
+                oauth2RestClient.deleteApplication(m2mAppId);
+            }
+        } finally {
+            if (scim2RestClient != null) {
+                scim2RestClient.closeHttpClient();
+            }
+            if (oauth2RestClient != null) {
+                oauth2RestClient.closeHttpClient();
+            }
+            if (httpClient != null) {
+                httpClient.close();
+            }
+            RestAssured.basePath = "";
+            super.testConclude();
+        }
+    }
+
+    // =========================================================================
+    // Admin mode tests — OAuth2 M2M token with operation scopes
+    // =========================================================================
+
+    @Test
+    public void testAdminGetConsentOfAnotherUser() throws Exception {
+
+        String token = getAdminToken(SCOPE_CONSENT_VIEW);
+        getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT + "/" + adminTestConsentId, token)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("subjectId", equalTo(ADMIN_MODE_USER));
+    }
+
+    @Test
+    public void testAdminListConsentsWithSubjectIdFilter() throws Exception {
+
+        String token = getAdminToken(SCOPE_CONSENT_VIEW);
+        getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT + "?subjectId=" + ADMIN_MODE_USER, token)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("totalResults", greaterThanOrEqualTo(1));
+    }
+
+    @Test
+    public void testAdminListConsentsAcrossAllUsers() throws Exception {
+
+        String token = getAdminToken(SCOPE_CONSENT_VIEW);
+        getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT, token)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("totalResults", greaterThanOrEqualTo(1));
+    }
+
+    @Test
+    public void testAdminCreateConsentOnBehalfOfUser() throws Exception {
+
+        String token = getAdminToken(SCOPE_CONSENT_CREATE);
+        String consentBody = "{\"subjectId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"serviceId\": \"admin-mode-created-service\", \"language\": \"en\","
+                + " \"purposes\": [{\"id\": \"" + adminTestPurposeId + "\","
+                + " \"elements\": [{\"id\": \"" + adminTestElementId + "\"}]}]}";
+        // The created consent is cascade-deleted when adminTestUserId is deleted in @AfterClass.
+        getResponseOfPostWithOAuth2(CONSENTS_ENDPOINT, consentBody, token)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("subjectId", equalTo(ADMIN_MODE_USER));
+    }
+
+    /**
+     * Creates a dedicated consent (so the shared {@code adminTestConsentId} read by other tests is
+     * left untouched) and upserts an authorizer through PUT /consents/{consentId}. The added
+     * authorizer (APPROVED) must surface in the consent's authorization list, and the recomputed
+     * consent state must remain ACTIVE. Verifies both the PUT response and a follow-up GET.
+     */
+    @Test
+    public void testAdminUpdateConsentAuthorizations() throws Exception {
+
+        String createToken = getAdminToken(SCOPE_CONSENT_CREATE);
+        String consentBody = "{\"subjectId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"serviceId\": \"admin-mode-update-service\", \"language\": \"en\","
+                + " \"purposes\": [{\"id\": \"" + adminTestPurposeId + "\","
+                + " \"elements\": [{\"id\": \"" + adminTestElementId + "\"}]}]}";
+        // The created consent is cascade-deleted when adminTestUserId is deleted in @AfterClass.
+        Response createResponse = getResponseOfPostWithOAuth2(CONSENTS_ENDPOINT, consentBody, createToken);
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        updateTestConsentId = createResponse.jsonPath().getString("id");
+
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        String updateBody = "{\"authorizations\": [{\"userId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"type\": \"USER\", \"state\": \"APPROVED\"}]}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + updateTestConsentId, updateBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(updateTestConsentId))
+                .body("state", equalTo("ACTIVE"))
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }.state",
+                        equalTo("APPROVED"));
+
+        // Verify the change is persisted.
+        String viewToken = getAdminToken(SCOPE_CONSENT_VIEW);
+        getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT + "/" + updateTestConsentId, viewToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }.state",
+                        equalTo("APPROVED"));
+    }
+
+    /**
+     * Overriding an existing authorizer's state to REVOKED through PUT must transition the consent
+     * to the REVOKED state.
+     */
+    @Test(dependsOnMethods = {"testAdminUpdateConsentAuthorizations"})
+    public void testAdminUpdateConsentAuthorizationRevoke() throws Exception {
+
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        String updateBody = "{\"authorizations\": [{\"userId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"state\": \"REVOKED\"}]}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + updateTestConsentId, updateBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(updateTestConsentId))
+                .body("state", equalTo("REVOKED"))
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }.state",
+                        equalTo("REVOKED"));
+    }
+
+    /**
+     * Updating a consent that does not exist must return 404.
+     */
+    @Test
+    public void testUpdateConsentNotFoundForUnknownId() throws Exception {
+
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/non-existent-consent-id",
+                "{\"authorizations\": [{\"userId\": \"" + ADMIN_MODE_USER + "\","
+                        + " \"type\": \"USER\", \"state\": \"APPROVED\"}]}", updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    /**
+     * Setting {@code expiryTime} through PUT must persist a (future) expiry on the consent.
+     * The PUT response and a follow-up GET must both echo the millis-since-epoch value.
+     */
+    @Test
+    public void testAdminUpdateConsentExpiryTime() throws Exception {
+
+        String consentId = createConsentForUpdate("admin-mode-expiry-service");
+        long expiry = System.currentTimeMillis() + (365L * 24 * 60 * 60 * 1000);
+
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        String updateBody = "{\"expiryTime\": " + expiry + "}";
+        Response patchResponse = getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, updateBody, updateToken);
+        patchResponse.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(consentId));
+        assertEquals(patchResponse.jsonPath().getLong("expiryTime"), expiry,
+                "Expiry time was not updated in the PUT response.");
+
+        // Verify the change is persisted.
+        String viewToken = getAdminToken(SCOPE_CONSENT_VIEW);
+        Response getResponse = getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, viewToken);
+        getResponse.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK);
+        assertEquals(getResponse.jsonPath().getLong("expiryTime"), expiry,
+                "Expiry time was not persisted.");
+    }
+
+    /**
+     * The {@code properties} field is a full replace: a first PUT sets two properties, and a second
+     * PUT with a different single property must drop the previously stored keys (not merge them).
+     */
+    @Test
+    public void testAdminUpdateConsentProperties() throws Exception {
+
+        String consentId = createConsentForUpdate("admin-mode-properties-service");
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+
+        String setBody = "{\"properties\": {\"dataCategory\": \"personal\", \"region\": \"EU\"}}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, setBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.dataCategory", equalTo("personal"))
+                .body("properties.region", equalTo("EU"));
+
+        // A second PUT replaces the full property map — the previous "dataCategory" key must disappear.
+        String replaceBody = "{\"properties\": {\"region\": \"US\"}}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, replaceBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.region", equalTo("US"))
+                .body("properties.dataCategory", nullValue());
+
+        // Verify the replace is persisted.
+        String viewToken = getAdminToken(SCOPE_CONSENT_VIEW);
+        getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, viewToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.region", equalTo("US"))
+                .body("properties.dataCategory", nullValue());
+    }
+
+    /**
+     * Clearing properties: a PUT with an empty {@code properties} object removes all stored
+     * properties (an empty map deletes existing rows and inserts nothing). A {@code null}/omitted
+     * {@code properties} would instead leave them untouched, so {@code {}} is required to clear.
+     */
+    @Test
+    public void testAdminUpdateConsentClearProperties() throws Exception {
+
+        String consentId = createConsentForUpdate("admin-mode-clear-properties-service");
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+
+        String setBody = "{\"properties\": {\"dataCategory\": \"personal\", \"region\": \"EU\"}}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, setBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.dataCategory", equalTo("personal"))
+                .body("properties.region", equalTo("EU"));
+
+        // An empty map clears every property.
+        String clearBody = "{\"properties\": {}}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, clearBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.dataCategory", nullValue())
+                .body("properties.region", nullValue());
+
+        // Verify the clear is persisted.
+        String viewToken = getAdminToken(SCOPE_CONSENT_VIEW);
+        getResponseOfGetWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, viewToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("properties.dataCategory", nullValue())
+                .body("properties.region", nullValue());
+    }
+
+    /**
+     * Setting an authorizer's state to REJECTED through PUT must transition the consent to REJECTED.
+     */
+    @Test
+    public void testAdminUpdateConsentAuthorizationReject() throws Exception {
+
+        String consentId = createConsentForUpdate("admin-mode-reject-service");
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        String updateBody = "{\"authorizations\": [{\"userId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"type\": \"USER\", \"state\": \"REJECTED\"}]}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, updateBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(consentId))
+                .body("state", equalTo("REJECTED"))
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }.state",
+                        equalTo("REJECTED"));
+    }
+
+    /**
+     * Adding a new authorizer without a {@code state} must leave it PENDING. PENDING authorizations
+     * are not exposed in the response DTO, so the user must be absent from the authorization list
+     * while the recomputed consent state becomes PENDING.
+     */
+    @Test
+    public void testAdminAddAuthorizerWithoutStateRemainsPending() throws Exception {
+
+        String consentId = createConsentForUpdate("admin-mode-pending-service");
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        String updateBody = "{\"authorizations\": [{\"userId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"type\": \"USER\"}]}";
+        getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, updateBody, updateToken)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(consentId))
+                .body("state", equalTo("PENDING"))
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }", nullValue());
+    }
+
+    /**
+     * A single PUT carrying {@code expiryTime}, {@code properties} and {@code authorizations}
+     * must apply all three in one request. The APPROVED authorizer drives the state to ACTIVE.
+     */
+    @Test
+    public void testAdminUpdateConsentCombinedFields() throws Exception {
+
+        String consentId = createConsentForUpdate("admin-mode-combined-service");
+        long expiry = System.currentTimeMillis() + (365L * 24 * 60 * 60 * 1000);
+
+        String updateToken = getAdminToken(SCOPE_CONSENT_UPDATE);
+        String updateBody = "{\"expiryTime\": " + expiry + ","
+                + " \"properties\": {\"region\": \"EU\"},"
+                + " \"authorizations\": [{\"userId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"type\": \"USER\", \"state\": \"APPROVED\"}]}";
+        Response patchResponse = getResponseOfPatchWithOAuth2(CONSENTS_ENDPOINT + "/" + consentId, updateBody, updateToken);
+        patchResponse.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("id", equalTo(consentId))
+                .body("state", equalTo("ACTIVE"))
+                .body("properties.region", equalTo("EU"))
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }.state",
+                        equalTo("APPROVED"));
+        assertEquals(patchResponse.jsonPath().getLong("expiryTime"), expiry,
+                "Expiry time was not updated in the combined update.");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private String getUserConsentApiBaseUrl() {
+
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenant)) {
+            return serverURL + "api/users/v1/me/consents";
+        }
+        return serverURL + "t/" + tenant + "/api/users/v1/me/consents";
+    }
+
+    /**
+     * Creates a consent for {@code ADMIN_MODE_USER} via the admin create scope and returns its id.
+     * The created consent is cascade-deleted when {@code adminTestUserId} is deleted in @AfterClass.
+     */
+    private String createConsentForUpdate(String serviceId) throws Exception {
+
+        String createToken = getAdminToken(SCOPE_CONSENT_CREATE);
+        String consentBody = "{\"subjectId\": \"" + ADMIN_MODE_USER + "\","
+                + " \"serviceId\": \"" + serviceId + "\", \"language\": \"en\","
+                + " \"purposes\": [{\"id\": \"" + adminTestPurposeId + "\","
+                + " \"elements\": [{\"id\": \"" + adminTestElementId + "\"}]}]}";
+        Response createResponse = getResponseOfPostWithOAuth2(CONSENTS_ENDPOINT, consentBody, createToken);
+        createResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+        return createResponse.jsonPath().getString("id");
+    }
+
+    private void authorizeAPIForApp(String apiIdentifier) throws IOException {
+
+        List<APIResourceListItem> filteredAPIResource =
+                oauth2RestClient.getAPIResourcesWithFiltering("identifier+eq+" + apiIdentifier);
+        if (filteredAPIResource != null && !filteredAPIResource.isEmpty()) {
+            String apiId = filteredAPIResource.get(0).getId();
+            List<ScopeGetModel> apiResourceScopes = oauth2RestClient.getAPIResourceScopes(apiId);
+            AuthorizedAPICreationModel authorizedAPICreationModel = new AuthorizedAPICreationModel();
+            authorizedAPICreationModel.setId(apiId);
+            authorizedAPICreationModel.setPolicyIdentifier("RBAC");
+            apiResourceScopes.forEach(scope -> authorizedAPICreationModel.addScopesItem(scope.getName()));
+            oauth2RestClient.addAPIAuthorizationToApplication(m2mAppId, authorizedAPICreationModel);
+        }
+    }
+
+    private String getAdminToken(String scopes) throws Exception {
+
+        HttpPost post = new HttpPost(getTokenEndpoint());
+        post.addHeader(HttpHeaders.AUTHORIZATION, "Basic " +
+                Base64.encodeBase64String((m2mClientId + ":" + m2mClientSecret).getBytes()).trim());
+        post.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("grant_type", "client_credentials"));
+        params.add(new BasicNameValuePair("scope", scopes));
+        post.setEntity(new UrlEncodedFormEntity(params));
+        HttpResponse response = httpClient.execute(post);
+        String responseStr = EntityUtils.toString(response.getEntity());
+        JSONObject json = (JSONObject) JSONValue.parse(responseStr);
+        assertNotNull(json.get("access_token"), "Failed to get admin token: " + responseStr);
+        return json.get("access_token").toString();
+    }
+
+    private String getTokenEndpoint() {
+
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenant)) {
+            return serverURL + "oauth2/token";
+        }
+        return serverURL + "t/" + tenant + "/oauth2/token";
+    }
+
+    private String createTestUser(String userName) throws Exception {
+
+        UserObject user = new UserObject();
+        user.setUserName(userName);
+        user.setPassword(ADMIN_MODE_USER_PASSWORD);
+        user.setName(new Name().givenName("Admin").familyName("ModeUser"));
+        user.addEmail(new Email().value(userName + "@wso2.com"));
+        return scim2RestClient.createUser(user);
+    }
+
+    private String buildUserAuthName(String userName) {
+
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenant)
+                ? userName
+                : userName + "@" + tenant;
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2FailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2FailureTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.integration.test.rest.api.server.consent.management.v2;
 
+import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
@@ -37,6 +38,7 @@ import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 /**
@@ -56,6 +58,14 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
 
     private SCIM2RestClient scim2RestClient;
 
+    // Cross-user test state — created in @BeforeClass, used across the 4 cross-user tests.
+    private String crossUserConsentId;
+    private String crossUserPurposeId;
+    private String crossUserElementId;
+    private String crossUserUserAId;
+    private String crossUserUserBId;
+    private String crossUserUserBAuthName;
+
     @Factory(dataProvider = "restAPIUserConfigProvider")
     public ConsentManagementV2FailureTest(TestUserMode userMode) throws Exception {
 
@@ -71,16 +81,34 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
 
         super.testInit(tenant);
         scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        setupCrossUserTestData();
     }
 
     @AfterClass(alwaysRun = true)
     @Override
     public void testConclude() throws Exception {
 
-        if (scim2RestClient != null) {
-            scim2RestClient.closeHttpClient();
+        RestAssured.basePath = basePath;
+        try {
+            if (crossUserUserAId != null) {
+                scim2RestClient.deleteUser(crossUserUserAId);
+            }
+            if (crossUserUserBId != null) {
+                scim2RestClient.deleteUser(crossUserUserBId);
+            }
+            if (crossUserPurposeId != null) {
+                getResponseOfDelete(PURPOSES_ENDPOINT + "/" + crossUserPurposeId);
+            }
+            if (crossUserElementId != null) {
+                getResponseOfDelete(ELEMENTS_ENDPOINT + "/" + crossUserElementId);
+            }
+        } finally {
+            if (scim2RestClient != null) {
+                scim2RestClient.closeHttpClient();
+            }
+            RestAssured.basePath = "";
+            super.testConclude();
         }
-        super.testConclude();
     }
 
     // =========================================================================
@@ -398,79 +426,18 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
     @Test
     public void testAuthorizeNonExistentConsentReturns404() {
 
-        getResponseOfPost(CONSENTS_ENDPOINT + "/" + NON_EXISTENT_ID + "/authorize",
-                "{\"state\": \"APPROVED\"}")
+        // The authorize endpoint lives on the user API (/me/consents/{id}/authorize).
+        given()
+                .auth().preemptive().basic(crossUserUserBAuthName, FAILURE_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .body("{\"state\": \"APPROVED\"}")
+                .post(getUserConsentApiBaseUrl() + "/" + NON_EXISTENT_ID + "/authorize")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void testAuthorizeActiveConsentReturns409() throws Exception {
-
-        String elementId = null;
-        String purposeId = null;
-        String userId = null;
-
-        try {
-            String elementBody = readResource("create-element-for-authorize-conflict.json");
-            Response elementResponse = getResponseOfPost(ELEMENTS_ENDPOINT, elementBody);
-            elementResponse.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_CREATED);
-            elementId = elementResponse.jsonPath().getString("id");
-
-            String purposeBody = readResource("create-purpose-for-authorize-conflict.json");
-            Response purposeResponse = getResponseOfPost(PURPOSES_ENDPOINT, purposeBody);
-            purposeResponse.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_CREATED);
-            purposeId = purposeResponse.jsonPath().getString("id");
-
-            String userName = "consent_fail_authorize_user";
-            userId = createTestUser(userName);
-            String userAuthName = buildUserAuthName(userName);
-
-            String consentBody = readResource("create-consent.json")
-                    .replace("\"subjectId\": \"1\"", "\"subjectId\": \"" + userName + "\"")
-                    .replace("\"purposes\": [{\"id\": \"1\"", "\"purposes\": [{\"id\": \"" + purposeId + "\"")
-                    .replace("\"elements\": [{\"id\": \"1\"", "\"elements\": [{\"id\": \"" + elementId + "\"");
-            Response consentResponse = given()
-                    .auth().preemptive().basic(userAuthName, FAILURE_TEST_USER_PASSWORD)
-                    .contentType(ContentType.JSON)
-                    .header(HttpHeaders.ACCEPT, ContentType.JSON)
-                    .log().ifValidationFails()
-                    .body(consentBody)
-                    .post(CONSENTS_ENDPOINT);
-            consentResponse.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_CREATED);
-            String consentId = consentResponse.jsonPath().getString("id");
-
-            // Authorizing an ACTIVE (non-PENDING) consent must return 409.
-            getResponseOfPost(CONSENTS_ENDPOINT + "/" + consentId + "/authorize",
-                    "{\"state\": \"APPROVED\"}")
-                    .then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_CONFLICT)
-                    .body("code", notNullValue());
-        } finally {
-            // Deleting the user cascades their consents, unblocking purpose/element deletion.
-            if (userId != null) {
-                scim2RestClient.deleteUser(userId);
-            }
-            if (purposeId != null) {
-                getResponseOfDelete(PURPOSES_ENDPOINT + "/" + purposeId);
-            }
-            if (elementId != null) {
-                getResponseOfDelete(ELEMENTS_ENDPOINT + "/" + elementId);
-            }
-        }
     }
 
     // =========================================================================
@@ -547,17 +514,16 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
             userId = createTestUser(userName);
             String userAuthName = buildUserAuthName(userName);
 
-            String consentBody = readResource("create-consent.json")
-                    .replace("\"subjectId\": \"1\"", "\"subjectId\": \"" + userName + "\"")
-                    .replace("\"purposes\": [{\"id\": \"1\"", "\"purposes\": [{\"id\": \"" + purposeId + "\"")
-                    .replace("\"elements\": [{\"id\": \"1\"", "\"elements\": [{\"id\": \"" + elementId + "\"");
+            String consentBody = "{\"serviceId\": \"test-integration-service\", \"language\": \"en\","
+                    + " \"purposes\": [{\"id\": \"" + purposeId + "\","
+                    + " \"elements\": [{\"id\": \"" + elementId + "\"}]}]}";
             given()
                     .auth().preemptive().basic(userAuthName, FAILURE_TEST_USER_PASSWORD)
                     .contentType(ContentType.JSON)
                     .header(HttpHeaders.ACCEPT, ContentType.JSON)
                     .log().ifValidationFails()
                     .body(consentBody)
-                    .post(CONSENTS_ENDPOINT)
+                    .post(getUserConsentApiBaseUrlForUser(userName))
                     .then()
                     .log().ifValidationFails()
                     .assertThat()
@@ -639,17 +605,16 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
             userId = createTestUser(userName);
             String userAuthName = buildUserAuthName(userName);
 
-            String consentBody = readResource("create-consent.json")
-                    .replace("\"subjectId\": \"1\"", "\"subjectId\": \"" + userName + "\"")
-                    .replace("\"purposes\": [{\"id\": \"1\"", "\"purposes\": [{\"id\": \"" + purposeId + "\"")
-                    .replace("\"elements\": [{\"id\": \"1\"", "\"elements\": [{\"id\": \"" + elementId + "\"");
+            String consentBody = "{\"serviceId\": \"test-integration-service\", \"language\": \"en\","
+                    + " \"purposes\": [{\"id\": \"" + purposeId + "\","
+                    + " \"elements\": [{\"id\": \"" + elementId + "\"}]}]}";
             given()
                     .auth().preemptive().basic(userAuthName, FAILURE_TEST_USER_PASSWORD)
                     .contentType(ContentType.JSON)
                     .header(HttpHeaders.ACCEPT, ContentType.JSON)
                     .log().ifValidationFails()
                     .body(consentBody)
-                    .post(CONSENTS_ENDPOINT)
+                    .post(getUserConsentApiBaseUrlForUser(userName))
                     .then()
                     .log().ifValidationFails()
                     .assertThat()
@@ -681,8 +646,117 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
     }
 
     // =========================================================================
+    // Cross-user access tests — non-admin subject enforcement
+    // =========================================================================
+
+    @Test
+    public void testGetConsentOfAnotherUserReturns403() {
+
+        // User B attempts to fetch User A's consent via the user API — must be rejected.
+        given()
+                .auth().preemptive().basic(crossUserUserBAuthName, FAILURE_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .get(getUserConsentApiBaseUrl() + "/" + crossUserConsentId)
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_FORBIDDEN)
+                .body("code", notNullValue());
+    }
+
+    @Test
+    public void testValidateConsentOfAnotherUserReturns403() {
+
+        given()
+                .auth().preemptive().basic(crossUserUserBAuthName, FAILURE_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .get(getUserConsentApiBaseUrl() + "/" + crossUserConsentId + "/validate")
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_FORBIDDEN)
+                .body("code", notNullValue());
+    }
+
+    @Test
+    public void testRevokeConsentOfAnotherUserReturns403() {
+
+        given()
+                .auth().preemptive().basic(crossUserUserBAuthName, FAILURE_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .post(getUserConsentApiBaseUrl() + "/" + crossUserConsentId + "/revoke")
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_FORBIDDEN)
+                .body("code", notNullValue());
+    }
+
+    @Test
+    public void testListConsentsAsUserScopedToCaller() {
+
+        // User B's list on the user API must return only their own consents (none in this case).
+        given()
+                .auth().preemptive().basic(crossUserUserBAuthName, FAILURE_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .get(getUserConsentApiBaseUrl())
+                .then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("size()", equalTo(0));
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
+
+    private void setupCrossUserTestData() throws Exception {
+
+        RestAssured.basePath = basePath;
+        try {
+            Response elementResponse = getResponseOfPost(ELEMENTS_ENDPOINT,
+                    "{\"name\": \"consent_fail_crossuser_elem\", \"displayName\": \"Cross User Elem\","
+                            + " \"description\": \"Cross user test element\"}");
+            elementResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+            crossUserElementId = elementResponse.jsonPath().getString("id");
+
+            Response purposeResponse = getResponseOfPost(PURPOSES_ENDPOINT,
+                    "{\"name\": \"consent_fail_crossuser_purpose\", \"description\": \"Cross user purpose\","
+                            + " \"type\": \"Core\", \"version\": \"1\","
+                            + " \"elements\": [{\"id\": \"" + crossUserElementId + "\", \"mandatory\": true}]}");
+            purposeResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+            crossUserPurposeId = purposeResponse.jsonPath().getString("id");
+
+            crossUserUserAId = createTestUser("consent_fail_crossuser_A");
+            crossUserUserBId = createTestUser("consent_fail_crossuser_B");
+            crossUserUserBAuthName = buildUserAuthName("consent_fail_crossuser_B");
+            String userAAuthName = buildUserAuthName("consent_fail_crossuser_A");
+
+            // Create the consent via the user API — user A creates their own consent.
+            String consentBody = "{\"serviceId\": \"cross-user-test\", \"language\": \"en\","
+                    + " \"purposes\": [{\"id\": \"" + crossUserPurposeId + "\","
+                    + " \"elements\": [{\"id\": \"" + crossUserElementId + "\"}]}]}";
+            Response consentResponse = given()
+                    .auth().preemptive().basic(userAAuthName, FAILURE_TEST_USER_PASSWORD)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                    .body(consentBody)
+                    .post(getUserConsentApiBaseUrlForUser("consent_fail_crossuser_A"));
+            consentResponse.then().assertThat().statusCode(HttpStatus.SC_CREATED);
+            crossUserConsentId = consentResponse.jsonPath().getString("id");
+        } finally {
+            RestAssured.basePath = "";
+        }
+    }
 
     private String createTestUser(String userName) throws Exception {
 
@@ -699,5 +773,18 @@ public class ConsentManagementV2FailureTest extends ConsentManagementV2TestBase 
         return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenant)
                 ? userName
                 : userName + "@" + tenant;
+    }
+
+    private String getUserConsentApiBaseUrl() {
+
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenant)) {
+            return serverURL + "api/users/v1/me/consents";
+        }
+        return serverURL + "t/" + tenant + "/api/users/v1/me/consents";
+    }
+
+    private String getUserConsentApiBaseUrlForUser(String userName) {
+
+        return getUserConsentApiBaseUrl();
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2SuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2SuccessTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.integration.test.rest.api.server.consent.management.v2;
 
+import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
@@ -39,11 +40,11 @@ import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
 
 import java.io.IOException;
 import java.rmi.RemoteException;
-import java.sql.Timestamp;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -107,8 +108,10 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     @Override
     public void testConclude() throws Exception {
 
+        // @AfterMethod resets RestAssured.basePath; restore it so cleanup requests hit the right endpoints.
+        RestAssured.basePath = basePath;
         try {
-            if (testUserId != null) {
+            if (scim2RestClient != null && testUserId != null) {
                 scim2RestClient.deleteUser(testUserId);
             }
             if (createdPurposeId != null) {
@@ -128,6 +131,35 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
         }
     }
 
+    private String getUserConsentApiBaseUrl() {
+
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenant)) {
+            return serverURL + "api/users/v1/me/consents";
+        }
+        return serverURL + "t/" + tenant + "/api/users/v1/me/consents";
+    }
+
+    private Response userApiGet(String url) {
+
+        return given()
+                .auth().preemptive().basic(consentTestUserAuthName, CONSENT_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .get(url);
+    }
+
+    private Response userApiPost(String url, String body) {
+
+        return given()
+                .auth().preemptive().basic(consentTestUserAuthName, CONSENT_TEST_USER_PASSWORD)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.ACCEPT, ContentType.JSON)
+                .log().ifValidationFails()
+                .body(body)
+                .post(url);
+    }
+
     // =========================================================================
     // Element tests
     // =========================================================================
@@ -145,7 +177,9 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
                 .body("id", notNullValue())
                 .body("name", equalTo("email_address"))
                 .body("displayName", equalTo("Email Address"))
-                .body("description", equalTo("User's primary email address"));
+                .body("description", equalTo("User's primary email address"))
+                .body("properties.dataCategory", equalTo("personal"))
+                .body("properties.retentionPeriod", equalTo("365"));
 
         createdElementId = response.jsonPath().getString("id");
     }
@@ -161,7 +195,9 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
                 .body("id", equalTo(createdElementId))
                 .body("name", equalTo("email_address"))
                 .body("displayName", equalTo("Email Address"))
-                .body("description", equalTo("User's primary email address"));
+                .body("description", equalTo("User's primary email address"))
+                .body("properties.dataCategory", equalTo("personal"))
+                .body("properties.retentionPeriod", equalTo("365"));
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testGetElement"})
@@ -193,6 +229,8 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
                 .body("totalResults", greaterThanOrEqualTo(2))
                 .body("Elements.id", hasSize(greaterThanOrEqualTo(2)))
                 .body("Elements.find { it.id == '" + createdElementId + "' }.name", equalTo("email_address"))
+                .body("Elements.find { it.id == '" + createdElementId + "' }.properties.dataCategory",
+                        equalTo("personal"))
                 .body("Elements.find { it.id == '" + createdSecondElementId + "' }.name", equalTo("phone_number"))
                 .body("links", notNullValue());
     }
@@ -476,25 +514,18 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     // =========================================================================
 
     @Test(groups = "wso2.is", dependsOnMethods = { "testDeletePurposeVersion" })
-    public void testCreateConsent() throws IOException {
+    public void testCreateConsent() {
 
-        String body = readResource("create-consent.json")
-                .replace("\"subjectId\": \"1\"", "\"subjectId\": \"" + CONSENT_TEST_USER_NAME + "\"")
-                .replace("\"purposes\": [{\"id\": \"1\"", "\"purposes\": [{\"id\": \"" + createdPurposeId + "\"")
-                .replace("\"elements\": [{\"id\": \"1\"", "\"elements\": [{\"id\": \"" + createdElementId + "\"");
-        // Consent creation requires the authenticated user to match the subjectId, so authenticate as the test user.
-        Response response = given()
-                .auth().preemptive().basic(consentTestUserAuthName, CONSENT_TEST_USER_PASSWORD)
-                .contentType(ContentType.JSON)
-                .header(HttpHeaders.ACCEPT, ContentType.JSON)
-                .log().ifValidationFails()
-                .body(body)
-                .post(CONSENTS_ENDPOINT);
+        // User API does not require subjectId — the caller is always the subject.
+        String body = "{\"serviceId\": \"test-integration-service\", \"language\": \"en\","
+                + " \"purposes\": [{\"id\": \"" + createdPurposeId + "\","
+                + " \"elements\": [{\"id\": \"" + createdElementId + "\"}]}],"
+                + " \"properties\": {\"testKey\": \"testValue\"}}";
+        Response response = userApiPost(getUserConsentApiBaseUrl(), body);
         response.then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.LOCATION, notNullValue())
                 .body("id", notNullValue());
 
         createdReceiptId = response.jsonPath().getString("id");
@@ -503,7 +534,7 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     @Test(groups = "wso2.is", dependsOnMethods = {"testCreateConsent"})
     public void testGetConsent() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "/" + createdReceiptId)
+        userApiGet(getUserConsentApiBaseUrl() + "/" + createdReceiptId)
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
@@ -523,91 +554,73 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     @Test(groups = "wso2.is", dependsOnMethods = {"testGetConsent"})
     public void testListConsents() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT)
+        // User API returns a plain JSON array scoped to the authenticated user.
+        userApiGet(getUserConsentApiBaseUrl())
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("Consents", notNullValue())
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }.serviceId",
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("find { it.id == '" + createdReceiptId + "' }", notNullValue())
+                .body("find { it.id == '" + createdReceiptId + "' }.serviceId",
                         equalTo("test-integration-service"))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }.state",
-                        equalTo("ACTIVE"))
-                .body("links", notNullValue());
+                .body("find { it.id == '" + createdReceiptId + "' }.state",
+                        equalTo("ACTIVE"));
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testListConsents"})
     public void testListConsentsWithPurposeIdFilter() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "?purposeId=" + createdPurposeId)
+        userApiGet(getUserConsentApiBaseUrl() + "?purposeId=" + createdPurposeId)
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("links", notNullValue());
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("id", hasItem(createdReceiptId));
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testListConsentsWithPurposeIdFilter"})
     public void testListConsentsWithPurposeVersionIdFilter() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "?purposeVersionId=" + createdVersionId)
+        userApiGet(getUserConsentApiBaseUrl() + "?purposeVersionId=" + createdVersionId)
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("links", notNullValue());
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("id", hasItem(createdReceiptId));
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testListConsents"})
     public void testListConsentsWithStateFilter() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "?state=ACTIVE")
+        userApiGet(getUserConsentApiBaseUrl() + "?state=ACTIVE")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("Consents.findAll { it.state != 'ACTIVE' }.size()", equalTo(0))
-                .body("links", notNullValue());
-    }
-
-    @Test(groups = "wso2.is", dependsOnMethods = {"testListConsents"})
-    public void testListConsentsWithSubjectIdFilter() {
-
-        getResponseOfGet(CONSENTS_ENDPOINT + "?subjectId=" + CONSENT_TEST_USER_NAME)
-                .then()
-                .log().ifValidationFails()
-                .assertThat()
-                .statusCode(HttpStatus.SC_OK)
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("links", notNullValue());
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("id", hasItem(createdReceiptId))
+                .body("findAll { it.state != 'ACTIVE' }.size()", equalTo(0));
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testListConsents"})
     public void testListConsentsWithServiceIdFilter() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "?serviceId=test-integration-service")
+        userApiGet(getUserConsentApiBaseUrl() + "?serviceId=test-integration-service")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("links", notNullValue());
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("id", hasItem(createdReceiptId));
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testGetConsent"})
     public void testValidateActiveConsent() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "/" + createdReceiptId + "/validate")
+        userApiGet(getUserConsentApiBaseUrl() + "/" + createdReceiptId + "/validate")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
@@ -617,40 +630,31 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testValidateActiveConsent"})
-    public void testValidateExpiredConsent() throws IOException {
+    public void testValidateExpiredConsent() {
 
-        Timestamp expiredTimestamp = new Timestamp(System.currentTimeMillis() - 60_000L);
-        String expiredTimeValue = String.valueOf(expiredTimestamp.getTime());
-        String body = readResource("create-consent.json")
-                .replace("\"subjectId\": \"1\"", "\"subjectId\": \"" + CONSENT_TEST_USER_NAME + "\"")
-                .replace("\"purposes\": [{\"id\": \"1\"", "\"purposes\": [{\"id\": \"" + createdPurposeId + "\"")
-                .replace("\"elements\": [{\"id\": \"1\"", "\"elements\": [{\"id\": \"" + createdElementId + "\"")
-                .replace("\"properties\": {", "\"expiryTime\": " + expiredTimeValue + ",\n  \"properties\": {");
+        long expiredTime = System.currentTimeMillis() - 60_000L;
+        String body = "{\"serviceId\": \"test-integration-service\", \"language\": \"en\","
+                + " \"expiryTime\": " + expiredTime + ","
+                + " \"purposes\": [{\"id\": \"" + createdPurposeId + "\","
+                + " \"elements\": [{\"id\": \"" + createdElementId + "\"}]}]}";
 
-        Response response = given()
-                .auth().preemptive().basic(consentTestUserAuthName, CONSENT_TEST_USER_PASSWORD)
-                .contentType(ContentType.JSON)
-                .header(HttpHeaders.ACCEPT, ContentType.JSON)
-                .log().ifValidationFails()
-                .body(body)
-                .post(CONSENTS_ENDPOINT);
+        Response response = userApiPost(getUserConsentApiBaseUrl(), body);
         response.then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.LOCATION, notNullValue())
                 .body("id", notNullValue());
 
         String expiredReceiptId = response.jsonPath().getString("id");
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "/" + expiredReceiptId + "/validate")
+        userApiGet(getUserConsentApiBaseUrl() + "/" + expiredReceiptId + "/validate")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("state", equalTo("EXPIRED"));
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "/" + expiredReceiptId)
+        userApiGet(getUserConsentApiBaseUrl() + "/" + expiredReceiptId)
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
@@ -661,34 +665,34 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     @Test(groups = "wso2.is", dependsOnMethods = {
             "testListConsentsWithPurposeVersionIdFilter",
             "testListConsentsWithStateFilter",
-            "testListConsentsWithSubjectIdFilter",
             "testListConsentsWithServiceIdFilter",
             "testValidateActiveConsent"
     })
     public void testRevokeConsent() {
 
-        getResponseOfPost(CONSENTS_ENDPOINT + "/" + createdReceiptId + "/revoke", "")
+        // User API revoke returns 200.
+        userApiPost(getUserConsentApiBaseUrl() + "/" + createdReceiptId + "/revoke", "")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+                .statusCode(HttpStatus.SC_OK);
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testRevokeConsent"})
     public void testRevokeConsentIdempotent() {
 
-        // Second revoke of an already-revoked consent must also succeed with 204.
-        getResponseOfPost(CONSENTS_ENDPOINT + "/" + createdReceiptId + "/revoke", "")
+        // Second revoke of an already-revoked consent must also succeed with 200.
+        userApiPost(getUserConsentApiBaseUrl() + "/" + createdReceiptId + "/revoke", "")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+                .statusCode(HttpStatus.SC_OK);
     }
 
     @Test(groups = "wso2.is", dependsOnMethods = {"testRevokeConsentIdempotent"})
     public void testGetRevokedConsentStillAccessible() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "/" + createdReceiptId)
+        userApiGet(getUserConsentApiBaseUrl() + "/" + createdReceiptId)
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
@@ -700,7 +704,7 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     @Test(groups = "wso2.is", dependsOnMethods = {"testGetRevokedConsentStillAccessible"})
     public void testValidateRevokedConsent() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "/" + createdReceiptId + "/validate")
+        userApiGet(getUserConsentApiBaseUrl() + "/" + createdReceiptId + "/validate")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
@@ -711,15 +715,14 @@ public class ConsentManagementV2SuccessTest extends ConsentManagementV2TestBase 
     @Test(groups = "wso2.is", dependsOnMethods = {"testGetRevokedConsentStillAccessible"})
     public void testListRevokedConsentsWithStateFilter() {
 
-        getResponseOfGet(CONSENTS_ENDPOINT + "?state=REVOKED")
+        userApiGet(getUserConsentApiBaseUrl() + "?state=REVOKED")
                 .then()
                 .log().ifValidationFails()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("totalResults", greaterThanOrEqualTo(1))
-                .body("Consents.find { it.id == '" + createdReceiptId + "' }", notNullValue())
-                .body("Consents.findAll { it.state != 'REVOKED' }.size()", equalTo(0))
-                .body("links", notNullValue());
+                .body("size()", greaterThanOrEqualTo(1))
+                .body("id", hasItem(createdReceiptId))
+                .body("findAll { it.state != 'REVOKED' }.size()", equalTo(0));
     }
 
     // =========================================================================

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/create-element-for-authorize-conflict.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/create-element-for-authorize-conflict.json
@@ -1,5 +1,0 @@
-{
-  "name": "authorize_conflict_test_element",
-  "displayName": "Authorize Conflict Test Element",
-  "description": "Element used for testing authorize on non-pending consent"
-}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/create-element.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/create-element.json
@@ -1,5 +1,9 @@
 {
   "name": "email_address",
   "displayName": "Email Address",
-  "description": "User's primary email address"
+  "description": "User's primary email address",
+  "properties": {
+    "dataCategory": "personal",
+    "retentionPeriod": "365"
+  }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/create-purpose-for-authorize-conflict.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/create-purpose-for-authorize-conflict.json
@@ -1,6 +1,0 @@
-{
-  "name": "Authorize Conflict Test Purpose",
-  "description": "Purpose used for testing authorize on non-pending consent",
-  "type": "Test",
-  "version": "1"
-}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -343,6 +343,7 @@
             <!--            <class name="org.wso2.identity.integration.test.rest.api.server.flow.execution.v1.FlowExecutionNegativeTest"/>-->
             <class name="org.wso2.identity.integration.test.rest.api.server.consent.management.v2.ConsentManagementV2SuccessTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.consent.management.v2.ConsentManagementV2FailureTest"/>
+            <class name="org.wso2.identity.integration.test.rest.api.server.consent.management.v2.ConsentManagementV2AdminModeTest"/>
             <class name="org.wso2.identity.integration.test.rest.api.server.configs.v1.ConsentPurposesSuccessTest"/>
         </classes>
     </test>

--- a/pom.xml
+++ b/pom.xml
@@ -2701,7 +2701,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.142</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.144</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2754,7 +2754,7 @@
         <identity.event.handler.account.lock.version>1.12.0</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.13.6</identity.event.handler.notification.version>
 
-        <org.wso2.identity.webhook.event.handlers.version>1.2.6</org.wso2.identity.webhook.event.handlers.version>
+        <org.wso2.identity.webhook.event.handlers.version>1.2.7</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.2.3</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->
@@ -2835,7 +2835,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.6.31</identity.server.api.version>
+        <identity.server.api.version>1.6.32</identity.server.api.version>
         <identity.user.api.version>1.5.12</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>


### PR DESCRIPTION
This pull request introduces enhancements and fixes to the consent management REST API integration tests and updates dependencies to support new user consent APIs. The most significant changes include the addition of cross-user access tests to ensure proper access control, refactoring of consent creation in tests for clarity and correctness, and updates to project dependencies and configuration files to include the new user consent APIs.

Related issue https://github.com/wso2/product-is/issues/26859

**Integration Test Enhancements:**

* Added comprehensive cross-user access tests in `ConsentManagementV2FailureTest.java` to verify that users cannot access or modify consents belonging to other users, ensuring proper enforcement of non-admin subject restrictions. 
* Refactored consent creation in several tests to construct consent bodies directly in Java rather than relying on resource file replacement, improving clarity and reducing test fragility.

**Dependency and Configuration Updates:**

* Added new dependencies for `org.wso2.carbon.identity.rest.api.user.consent.v1` and `org.wso2.carbon.identity.api.user.consent.common` in both `api-resources-full/pom.xml` and `api-resources/pom.xml` to support user consent APIs.

**Minor Improvements:**

* Added missing imports and removed unused ones in test files for better code hygiene. 
* Improved test utility methods for building user API endpoints and user authentication names, increasing maintainability and clarity.

These changes collectively improve the reliability, coverage, and future extensibility of the consent management REST API integration tests, while ensuring the codebase is ready for new user consent API features.