### PR TITLE
Apply PR diff before disabling tests in PR builder

### DIFF
--- a/.github/scripts/pr-builder.sh
+++ b/.github/scripts/pr-builder.sh
@@ -96,8 +96,6 @@ echo "=========================================================="
 
 git clone --branch "$WORKFLOW_BRANCH" --single-branch https://github.com/wso2/product-is product-is-$BUILDER_NUMBER
 
-disable_tests "$ENABLED_TESTS"
-
 if [ "$REPO" = "product-is" ]; then
 
   echo ""
@@ -116,6 +114,13 @@ if [ "$REPO" = "product-is" ]; then
     echo "::error::Applying diff failed."
     exit 1
   }
+
+  # Disable non-selected tests AFTER applying the PR diff, so the diff applies
+  # against a pristine testng.xml. disable_tests expects to run from the workspace
+  # root (its path is relative to product-is-$BUILDER_NUMBER).
+  cd ..
+  disable_tests "$ENABLED_TESTS"
+  cd product-is-$BUILDER_NUMBER
 
   echo "Last 3 changes:"
   COMMIT1=$(git log --oneline -1)
@@ -398,6 +403,8 @@ else
     echo ""
     cd ..
   fi
+
+  disable_tests "$ENABLED_TESTS"
 
   cd product-is-$BUILDER_NUMBER
 


### PR DESCRIPTION
## Purpose

Fixes `Applying diff failed.` in the **Integration Test Runner** workflow for PRs that modify a `<test>` block in `testng.xml`.

## Problem

In `.github/scripts/pr-builder.sh`, `disable_tests` ran **before** `git apply diff.diff`. `disable_tests` injects `enabled="false"` into every `<test>` block not in the runner's enabled list (via `sed`). When a PR's diff uses one of those `<test>` lines as hunk **context**, the already-mutated line no longer matches and `git apply` fails.

This only affects runners that disable the test the PR touches — e.g. a PR adding a class under `is-test-webhooks` applies cleanly on runner 1 (webhooks enabled) but fails on runners 2–4 (webhooks disabled).

## Fix

Apply the PR diff against a pristine `testng.xml` **first**, then run `disable_tests` on the result:

- Removed the unconditional `disable_tests` call that ran right after `git clone`.
- product-is branch: `disable_tests` now runs after `git apply` (with `cd` handling so its root-relative path resolves).
- Dependency-repo branch: `disable_tests` runs just before the product-is build (that branch's diff applies to the dependency repo, so it was never the source of the conflict — this preserves the original disabling behavior).

## Impact

- No change to which tests each runner runs — only the ordering of two steps swapped.
- CI helper script only; no product code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)