### PR TITLE
Add role deletion webhook scenarios and align roleDeleted payload

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
@@ -342,6 +342,28 @@ public class OAuth2RestClient extends RestBaseClient {
     }
 
     /**
+     * Update an existing application expecting a successful (200) response.
+     * <p>
+     * Unlike {@link #updateApplication(String, ApplicationPatchModel)}, this does not assert a 403 when associated
+     * roles are present in the patch. This is used to clear the associated roles of an application (which deletes the
+     * application audience roles as a post task) via the application update endpoint.
+     *
+     * @param appId       Application id.
+     * @param application Updated application patch object.
+     * @throws IOException If an error occurred while updating an application.
+     */
+    public void updateApplicationExpectingSuccess(String appId, ApplicationPatchModel application) throws IOException {
+
+        String jsonRequest = toJSONString(application);
+        String endPointUrl = applicationManagementApiBasePath + PATH_SEPARATOR + appId;
+
+        try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest, getHeaders())) {
+            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
+                    "Application update failed");
+        }
+    }
+
+    /**
      * Update an existing application.
      *
      * @param appId       Application id.

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/AdminInitRoleManagementEventTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/AdminInitRoleManagementEventTestCase.java
@@ -31,6 +31,8 @@ import org.wso2.identity.integration.common.utils.ISIntegrationTest;
 import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.APIResourceListItem;
 import org.wso2.identity.integration.test.rest.api.server.api.resource.v1.model.ScopeGetModel;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.ApplicationPatchModel;
+import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AssociatedRolesConfig;
 import org.wso2.identity.integration.test.rest.api.server.application.management.v1.model.AuthorizedAPICreationModel;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest;
 import org.wso2.identity.integration.test.rest.api.server.idp.v1.model.FederatedAuthenticatorRequest.FederatedAuthenticator;
@@ -86,6 +88,10 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
     private static final String APPLICATION_AUDIENCE = "APPLICATION";
     private static final String ROLE_NAME = "webhook-test-role";
     private static final String UPDATED_ROLE_NAME = "webhook-test-role-updated";
+    private static final String APP_UPDATE_APP_NAME = "webhook-test-role-app-update";
+    private static final String APP_UPDATE_ROLE_NAME = "webhook-test-role-via-app-update";
+    private static final String APP_DELETE_APP_NAME = "webhook-test-role-app-delete";
+    private static final String APP_DELETE_ROLE_NAME = "webhook-test-role-via-app-delete";
     private static final String INITIAL_PERMISSION = "internal_user_mgt_view";
     private static final String ADDED_PERMISSION = "internal_user_mgt_create";
     private static final String USERNAME_1 = "webhookroleuser1";
@@ -121,6 +127,10 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
     private String group2Id;
     private String idpId;
     private String idpGroupId;
+    private String appUpdateScenarioAppId;
+    private String appUpdateScenarioRoleId;
+    private String appDeleteScenarioAppId;
+    private String appDeleteScenarioRoleId;
 
     @Factory(dataProvider = "testExecutionContextProvider")
     public AdminInitRoleManagementEventTestCase(TestUserMode userMode) throws Exception {
@@ -149,7 +159,7 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
         oAuth2RestClient = new OAuth2RestClient(serverURL, tenantInfo);
         idpMgtRestClient = new IdpMgtRestClient(serverURL, tenantInfo);
 
-        appId = createApplication();
+        appId = createApplication(APP_NAME);
         authorizeUserManagementAPI(appId);
 
         user1Id = createRoleMemberUser(USERNAME_1);
@@ -192,6 +202,20 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
         }
         if (appId != null) {
             oAuth2RestClient.deleteApplication(appId);
+        }
+        // Clean up the applications and roles used by the application triggered role deletion scenarios in case those
+        // tests failed before deleting them.
+        if (appUpdateScenarioRoleId != null) {
+            scim2RestClient.attemptRoleV2Delete(appUpdateScenarioRoleId);
+        }
+        if (appUpdateScenarioAppId != null) {
+            oAuth2RestClient.deleteApplication(appUpdateScenarioAppId);
+        }
+        if (appDeleteScenarioRoleId != null) {
+            scim2RestClient.attemptRoleV2Delete(appDeleteScenarioRoleId);
+        }
+        if (appDeleteScenarioAppId != null) {
+            oAuth2RestClient.deleteApplication(appDeleteScenarioAppId);
         }
 
         scim2RestClient.closeHttpClient();
@@ -344,11 +368,65 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
         scim2RestClient.deleteV2Role(roleId);
 
         webhookEventTestManager.stackExpectedEventPayload(ROLE_DELETED_EVENT_URI,
-                AdminInitRoleManagementEventTestExpectedEventPayloadBuilder.buildExpectedRoleDeletedEventPayload(
-                        tenantDomain));
+                AdminInitRoleManagementEventTestExpectedEventPayloadBuilder.buildExpectedRoleDeletedViaScimEventPayload(
+                        tenantDomain, appId, APP_NAME, UPDATED_ROLE_NAME));
         webhookEventTestManager.validateStackedEventPayloads();
 
         roleId = null;
+    }
+
+    @Test(dependsOnMethods = "testDeleteRole")
+    public void testDeleteRoleViaApplicationUpdate() throws Exception {
+
+        appUpdateScenarioAppId = createApplication(APP_UPDATE_APP_NAME);
+        appUpdateScenarioRoleId = createApplicationRole(APP_UPDATE_ROLE_NAME, appUpdateScenarioAppId);
+
+        webhookEventTestManager.stackExpectedEventPayload(ROLE_CREATED_EVENT_URI,
+                AdminInitRoleManagementEventTestExpectedEventPayloadBuilder
+                        .buildExpectedRoleCreatedWithoutPermissionsEventPayload(tenantDomain, appUpdateScenarioAppId,
+                                APP_UPDATE_APP_NAME, APP_UPDATE_ROLE_NAME));
+        webhookEventTestManager.validateStackedEventPayloads();
+
+        AssociatedRolesConfig clearedAssociatedRoles = new AssociatedRolesConfig();
+        clearedAssociatedRoles.setAllowedAudience(AssociatedRolesConfig.AllowedAudienceEnum.APPLICATION);
+        clearedAssociatedRoles.setRoles(Collections.emptyList());
+        oAuth2RestClient.updateApplicationExpectingSuccess(appUpdateScenarioAppId,
+                new ApplicationPatchModel().associatedRoles(clearedAssociatedRoles));
+        appUpdateScenarioRoleId = null;
+
+        webhookEventTestManager.stackExpectedEventPayload(ROLE_DELETED_EVENT_URI,
+                AdminInitRoleManagementEventTestExpectedEventPayloadBuilder
+                        .buildExpectedRoleDeletedViaApplicationUpdateEventPayload(tenantDomain, appUpdateScenarioAppId,
+                                APP_UPDATE_APP_NAME, APP_UPDATE_ROLE_NAME));
+        webhookEventTestManager.validateStackedEventPayloads();
+    }
+
+    @Test(dependsOnMethods = "testDeleteRoleViaApplicationUpdate", enabled = false)
+    public void testDeleteRoleViaApplicationDelete() throws Exception {
+
+        /* Create a separate application and an application audience role associated with it.
+        Deleting the application deletes the role as a post task, emitting a roleDeleted
+        event with the action APPLICATION_DELETE. As the application no longer exists,
+        the audience does not contain the display name. */
+        appDeleteScenarioAppId = createApplication(APP_DELETE_APP_NAME);
+        appDeleteScenarioRoleId = createApplicationRole(APP_DELETE_ROLE_NAME, appDeleteScenarioAppId);
+
+        webhookEventTestManager.stackExpectedEventPayload(ROLE_CREATED_EVENT_URI,
+                AdminInitRoleManagementEventTestExpectedEventPayloadBuilder
+                        .buildExpectedRoleCreatedWithoutPermissionsEventPayload(tenantDomain, appDeleteScenarioAppId,
+                                APP_DELETE_APP_NAME, APP_DELETE_ROLE_NAME));
+        webhookEventTestManager.validateStackedEventPayloads();
+
+        oAuth2RestClient.deleteApplication(appDeleteScenarioAppId);
+        String deletedAppId = appDeleteScenarioAppId;
+        appDeleteScenarioAppId = null;
+        appDeleteScenarioRoleId = null;
+
+        webhookEventTestManager.stackExpectedEventPayload(ROLE_DELETED_EVENT_URI,
+                AdminInitRoleManagementEventTestExpectedEventPayloadBuilder
+                        .buildExpectedRoleDeletedViaApplicationDeleteEventPayload(tenantDomain, deletedAppId,
+                                APP_DELETE_ROLE_NAME));
+        webhookEventTestManager.validateStackedEventPayloads();
     }
 
     private RoleItemAddGroupobj buildListValueOperation(RoleItemAddGroupobj.OpEnum op, String path, ListObject value) {
@@ -360,12 +438,19 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
         return operation;
     }
 
-    private String createApplication() throws Exception {
+    private String createApplication(String appName) throws Exception {
 
         ApplicationModel application = new ApplicationModel()
-                .name(APP_NAME)
+                .name(appName)
                 .description("Application used as the audience for the role management webhook tests.");
         return oAuth2RestClient.createApplication(application);
+    }
+
+    private String createApplicationRole(String roleName, String applicationId) throws Exception {
+
+        Audience audience = new Audience(APPLICATION_AUDIENCE, applicationId);
+        RoleV2 role = new RoleV2(audience, roleName, Collections.emptyList(), Collections.emptyList());
+        return scim2RestClient.addV2Role(role);
     }
 
     private void authorizeUserManagementAPI(String applicationId) throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/eventpayloadbuilder/AdminInitRoleManagementEventTestExpectedEventPayloadBuilder.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/eventpayloadbuilder/AdminInitRoleManagementEventTestExpectedEventPayloadBuilder.java
@@ -38,6 +38,8 @@ public class AdminInitRoleManagementEventTestExpectedEventPayloadBuilder {
     private static final String ACTION_ROLE_CREATE = "ROLE_CREATE";
     private static final String ACTION_ROLE_UPDATE = "ROLE_UPDATE";
     private static final String ACTION_ROLE_DELETE = "ROLE_DELETE";
+    private static final String ACTION_APPLICATION_UPDATE = "APPLICATION_UPDATE";
+    private static final String ACTION_APPLICATION_DELETE = "APPLICATION_DELETE";
     private static final String AUDIENCE_TYPE_APPLICATION = "application";
     private static final String USER_STORE_PRIMARY = "PRIMARY";
     private static final String USER_STORE_AGENT = "AGENT";
@@ -55,6 +57,19 @@ public class AdminInitRoleManagementEventTestExpectedEventPayloadBuilder {
         JSONObject role = buildBaseRole(roleName, appId, appName);
         role.put("permissions", new JSONArray().put(permission));
         event.put("role", role);
+
+        return event;
+    }
+
+    /**
+     * Builds the expected payload for a role created event with an application audience and no assigned permissions.
+     */
+    public static JSONObject buildExpectedRoleCreatedWithoutPermissionsEventPayload(String tenantDomain, String appId,
+                                                                                    String appName, String roleName)
+            throws Exception {
+
+        JSONObject event = buildBaseRoleEvent(tenantDomain, ACTION_ROLE_CREATE);
+        event.put("role", buildBaseRole(roleName, appId, appName));
 
         return event;
     }
@@ -205,14 +220,52 @@ public class AdminInitRoleManagementEventTestExpectedEventPayloadBuilder {
     }
 
     /**
-     * Builds the expected payload for a role deleted event. The role object contains only its id.
+     * Builds the expected payload for a role deleted event triggered via the SCIM2 roles endpoint. The deletion is
+     * initiated directly on the role while its application audience still exists, hence the action is
+     * {@code ROLE_DELETE} and the audience carries the resolved application {@code display} name.
      */
-    public static JSONObject buildExpectedRoleDeletedEventPayload(String tenantDomain) throws Exception {
+    public static JSONObject buildExpectedRoleDeletedViaScimEventPayload(String tenantDomain, String appId,
+                                                                         String appName, String roleName)
+            throws Exception {
 
-        JSONObject event = buildBaseRoleEvent(tenantDomain, ACTION_ROLE_DELETE);
+        return buildRoleDeletedEvent(tenantDomain, ACTION_ROLE_DELETE, appId, appName, roleName, true);
+    }
+
+    /**
+     * Builds the expected payload for a role deleted event triggered by clearing the application's associated roles via
+     * the application update endpoint. The application still exists, so the action is {@code APPLICATION_UPDATE} and the
+     * audience carries the resolved application {@code display} name.
+     */
+    public static JSONObject buildExpectedRoleDeletedViaApplicationUpdateEventPayload(String tenantDomain, String appId,
+                                                                                      String appName, String roleName)
+            throws Exception {
+
+        return buildRoleDeletedEvent(tenantDomain, ACTION_APPLICATION_UPDATE, appId, appName, roleName, true);
+    }
+
+    /**
+     * Builds the expected payload for a role deleted event triggered as a post task of deleting the application. The
+     * application no longer exists at the time the event is emitted, so the action is {@code APPLICATION_DELETE} and the
+     * audience does not contain the {@code display} name.
+     */
+    public static JSONObject buildExpectedRoleDeletedViaApplicationDeleteEventPayload(String tenantDomain, String appId,
+                                                                                      String roleName)
+            throws Exception {
+
+        return buildRoleDeletedEvent(tenantDomain, ACTION_APPLICATION_DELETE, appId, null, roleName, false);
+    }
+
+    private static JSONObject buildRoleDeletedEvent(String tenantDomain, String action, String appId, String appName,
+                                                    String roleName, boolean includeAudienceDisplay) throws Exception {
+
+        JSONObject event = buildBaseRoleEvent(tenantDomain, action);
 
         JSONObject role = new JSONObject();
         role.put("id", "dummy-role-id");
+        role.put("name", roleName);
+        role.put("audience", includeAudienceDisplay
+                ? createApplicationAudience(appId, appName)
+                : createApplicationAudienceWithoutDisplay(appId));
         event.put("role", role);
 
         return event;
@@ -245,6 +298,14 @@ public class AdminInitRoleManagementEventTestExpectedEventPayloadBuilder {
         audience.put("type", AUDIENCE_TYPE_APPLICATION);
         audience.put("value", appId);
         audience.put("display", appName);
+        return audience;
+    }
+
+    private static JSONObject createApplicationAudienceWithoutDisplay(String appId) throws JSONException {
+
+        JSONObject audience = new JSONObject();
+        audience.put("type", AUDIENCE_TYPE_APPLICATION);
+        audience.put("value", appId);
         return audience;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2701,7 +2701,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.149</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.150</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2754,7 +2754,7 @@
         <identity.event.handler.account.lock.version>1.12.0</identity.event.handler.account.lock.version>
         <identity.event.handler.notification.version>1.13.6</identity.event.handler.notification.version>
 
-        <org.wso2.identity.webhook.event.handlers.version>1.2.10</org.wso2.identity.webhook.event.handlers.version>
+        <org.wso2.identity.webhook.event.handlers.version>1.2.12</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.2.3</org.wso2.identity.event.publishers.version>
 
         <!--<identity.agent.entitlement.proxy.version>5.1.1</identity.agent.entitlement.proxy.version>-->


### PR DESCRIPTION
## Purpose

Aligns the role management webhook integration test with the updated `roleDeleted` event payload and adds coverage for role deletion triggered via the application update and (pending) application delete endpoints.

## Changes

The `roleDeleted` event payload now carries the full role object (`id`, `name`, `audience`); the `action` and audience `display` vary by how the deletion is triggered:

- **SCIM2 roles endpoint** → `ROLE_DELETE`, audience with `display`.
- **Application update endpoint** (clearing the application's associated roles) → `APPLICATION_UPDATE`, audience with `display`. Added `OAuth2RestClient#updateApplicationExpectingSuccess` since clearing associated roles returns 200 in the new authz runtime (the existing `updateApplication` asserts 403 for that case).
- **Application delete endpoint** (post task of app deletion) → `APPLICATION_DELETE`. Disabled for now with a `TODO` until the emitted event includes the audience `display` name.

Also:
- Consume the `roleCreated` event emitted while setting up the application-audience roles used by the new scenarios (otherwise it is flagged as an unexpected notification).
- Bump `carbon.identity.framework` (7.11.150) and `webhook.event.handlers` (1.2.12) which carry the new payload format.

## Testing

Ran the `is-test-webhooks` suite (`AdminInitRoleManagementEventTestCase`) locally against a freshly built pack — **23 tests, 0 failures**, covering both super-tenant and tenant user modes. All role event payloads (created/deleted/groups/idpGroups/meta/permissions/users) validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)