### PR TITLE
Reuse updateApplication for clearing associated roles in role webhook test

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/OAuth2RestClient.java
@@ -342,28 +342,6 @@ public class OAuth2RestClient extends RestBaseClient {
     }
 
     /**
-     * Update an existing application expecting a successful (200) response.
-     * <p>
-     * Unlike {@link #updateApplication(String, ApplicationPatchModel)}, this does not assert a 403 when associated
-     * roles are present in the patch. This is used to clear the associated roles of an application (which deletes the
-     * application audience roles as a post task) via the application update endpoint.
-     *
-     * @param appId       Application id.
-     * @param application Updated application patch object.
-     * @throws IOException If an error occurred while updating an application.
-     */
-    public void updateApplicationExpectingSuccess(String appId, ApplicationPatchModel application) throws IOException {
-
-        String jsonRequest = toJSONString(application);
-        String endPointUrl = applicationManagementApiBasePath + PATH_SEPARATOR + appId;
-
-        try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest, getHeaders())) {
-            Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_OK,
-                    "Application update failed");
-        }
-    }
-
-    /**
      * Update an existing application.
      *
      * @param appId       Application id.
@@ -384,7 +362,8 @@ public class OAuth2RestClient extends RestBaseClient {
                 }
             }
             if (!isLegacyAuthzRuntimeEnabled()) {
-                if ((application.getAssociatedRoles() != null) && application.getAssociatedRoles().getRoles() != null) {
+                if ((application.getAssociatedRoles() != null) && application.getAssociatedRoles().getRoles() != null
+                        && !application.getAssociatedRoles().getRoles().isEmpty()) {
                     try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest,
                             getHeaders())) {
                         Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_FORBIDDEN,
@@ -424,7 +403,8 @@ public class OAuth2RestClient extends RestBaseClient {
                 }
             }
             if (!isLegacyAuthzRuntimeEnabled()) {
-                if ((application.getAssociatedRoles() != null) && application.getAssociatedRoles().getRoles() != null) {
+                if ((application.getAssociatedRoles() != null) && application.getAssociatedRoles().getRoles() != null
+                        && !application.getAssociatedRoles().getRoles().isEmpty()) {
                     try (CloseableHttpResponse response = getResponseOfHttpPatch(endPointUrl, jsonRequest,
                             getHeadersWithBearerToken(switchedM2MToken))) {
                         Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpServletResponse.SC_FORBIDDEN,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/AdminInitRoleManagementEventTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/AdminInitRoleManagementEventTestCase.java
@@ -390,7 +390,7 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
         AssociatedRolesConfig clearedAssociatedRoles = new AssociatedRolesConfig();
         clearedAssociatedRoles.setAllowedAudience(AssociatedRolesConfig.AllowedAudienceEnum.APPLICATION);
         clearedAssociatedRoles.setRoles(Collections.emptyList());
-        oAuth2RestClient.updateApplicationExpectingSuccess(appUpdateScenarioAppId,
+        oAuth2RestClient.updateApplication(appUpdateScenarioAppId,
                 new ApplicationPatchModel().associatedRoles(clearedAssociatedRoles));
         appUpdateScenarioRoleId = null;
 


### PR DESCRIPTION
Follow-up to #28157, addressing the review comment on `OAuth2RestClient` (*"Why can't we use the existing `updateApplication()`?"*).

Instead of the `updateApplicationExpectingSuccess` helper added in #28157, this refines the existing `updateApplication` (and `updateSubOrgApplication`) so that:
- patching an **empty** associated-roles list (clearing roles) is treated as a normal `200` update, and
- associating a **non-empty** roles list still asserts `403`.

The role management webhook test now clears associated roles through the existing `updateApplication`, and the duplicate `updateApplicationExpectingSuccess` is removed. The `getRoles() != null` guard is kept before `isEmpty()` in both methods to avoid an NPE when only `allowedAudience` is patched.

### Testing
- `is-test-webhooks` role suite: **23 tests, 0 failures** (super-tenant + tenant-user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)