### PR TITLE
Harden webhook test client and role event test teardown

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/WebhooksRestClient.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/restclients/WebhooksRestClient.java
@@ -80,6 +80,13 @@ public class WebhooksRestClient extends RestBaseClient {
 
                 LOG.info("Response body for webhook create request: {}", jsonResponse);
 
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode != 201 && statusCode != 200) {
+                    throw new WebhookManagementException(
+                            "Error occurred while creating webhook. Response status code: " + statusCode +
+                                    ". Response body: " + jsonResponse + ". ");
+                }
+
                 return objectMapper.readValue(jsonResponse, WebhookResponse.class);
             } else {
                 throw new WebhookManagementException(

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/AdminInitRoleManagementEventTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/webhooks/rolemanagement/AdminInitRoleManagementEventTestCase.java
@@ -218,10 +218,18 @@ public class AdminInitRoleManagementEventTestCase extends ISIntegrationTest {
             oAuth2RestClient.deleteApplication(appDeleteScenarioAppId);
         }
 
-        scim2RestClient.closeHttpClient();
-        oAuth2RestClient.closeHttpClient();
-        idpMgtRestClient.closeHttpClient();
-        webhookEventTestManager.teardown();
+        if (scim2RestClient != null) {
+            scim2RestClient.closeHttpClient();
+        }
+        if (oAuth2RestClient != null) {
+            oAuth2RestClient.closeHttpClient();
+        }
+        if (idpMgtRestClient != null) {
+            idpMgtRestClient.closeHttpClient();
+        }
+        if (webhookEventTestManager != null) {
+            webhookEventTestManager.teardown();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Improves robustness of the role-management webhook integration tests.

## Changes

- **`WebhooksRestClient`**: fail fast when the webhook create request returns a non-2xx status. Previously the client attempted to deserialize any 200-family body into a `WebhookResponse` and would produce confusing downstream failures on error responses. It now throws a `WebhookManagementException` with the status code and response body when the status is not `200`/`201`.
- **`AdminInitRoleManagementEventTestCase`**: null-guard the rest client teardown so that a partial setup failure no longer masks the real cause with an NPE during cleanup.

## Related

Follows up on the role-management webhook test work (#28143, #28157, #28159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)