### PR TITLE
Temporary ignore unknown fields in pre issue access token request object during serialization

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreIssueAccessTokenEvent.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/serviceextensions/model/PreIssueAccessTokenEvent.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.integration.test.serviceextensions.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -27,6 +28,7 @@ import java.util.Objects;
  * This class models the Event sent in the request payload to the API endpoint of a pre issue access token action.
  */
 @JsonDeserialize(builder = PreIssueAccessTokenEvent.Builder.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PreIssueAccessTokenEvent extends Event {
 
     private TokenRequest request;


### PR DESCRIPTION
## Purpose

$subject

Note: this will be reverted once the changes in https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3272 are merged and released.