### PR TITLE
Show Old Enforce Fapi checkbox only when fapi feature is disabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2848,7 +2848,7 @@
         <conditional.authentication.functions.version>1.3.6</conditional.authentication.functions.version>
 
         <!-- Identity Portal Versions -->
-        <identity.apps.console.version>4.14.6</identity.apps.console.version>
+        <identity.apps.console.version>4.14.7</identity.apps.console.version>
         <identity.apps.myaccount.version>4.4.0</identity.apps.myaccount.version>
         <identity.apps.core.version>5.4.0</identity.apps.core.version>
         <identity.apps.tests.version>1.6.392</identity.apps.tests.version>


### PR DESCRIPTION
## Summary
- Restores the "Enforce Fapi" checkbox in the Applications Settings (DCR) page, which was removed in #10290 in favor of per-application FAPI profile selection.
- Gates its visibility behind the `fapi` feature flag (introduced in #10519): the checkbox is shown only when `console.fapi.enabled` is `false`, since when the flag is enabled, FAPI conformance is configured per-application instead of globally for DCR.

## Test plan
- [ ] Set `console.fapi.enabled = true` in deployment config and confirm the "Enforce Fapi" checkbox is hidden on the Applications Settings page.
- [ ] Set `console.fapi.enabled = false` (or leave unset) and confirm the checkbox renders, and toggling/saving it still calls the DCR config update API with `/enableFapiEnforcement`.