### PR TITLE
Fix ProvisioningTestCase user collision on shared external database

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/provisioning/ProvisioningTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/provisioning/ProvisioningTestCase.java
@@ -145,27 +145,40 @@ public class ProvisioningTestCase extends ISIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void atEnd() throws Exception {
 
-        for (int portOff = 0; portOff < 2; portOff++) {
-            ServiceProvider serviceProvider = applicationManagementServiceClients.get(portOff)
-                    .getApplication("wso2carbon-local-sp");
-            if (serviceProvider != null) {
-                serviceProvider.setOutboundProvisioningConfig(new OutboundProvisioningConfig());
-                applicationManagementServiceClients.get(portOff).updateApplicationData(serviceProvider);
+        List<Exception> cleanupErrors = new ArrayList<Exception>();
+        try {
+            for (int portOff = 0; portOff < 2; portOff++) {
+                try {
+                    ServiceProvider serviceProvider = applicationManagementServiceClients.get(portOff)
+                            .getApplication("wso2carbon-local-sp");
+                    if (serviceProvider != null) {
+                        serviceProvider.setOutboundProvisioningConfig(new OutboundProvisioningConfig());
+                        applicationManagementServiceClients.get(portOff).updateApplicationData(serviceProvider);
+                    }
+                    identityProviderMgtServiceClients.get(portOff).deleteIdP(SAMPLE_IDENTITY_PROVIDER_NAME + "_"
+                            + Integer.toString(portOff));
+                } catch (Exception e) {
+                    cleanupErrors.add(e);
+                }
             }
-            identityProviderMgtServiceClients.get(portOff).deleteIdP(SAMPLE_IDENTITY_PROVIDER_NAME + "_" + Integer
-                    .toString(portOff));
+        } finally {
+            deleteUserIfExists(PORT_OFFSET_0, userName, cleanupErrors);
+            deleteUserIfExists(PORT_OFFSET_1, userName2, cleanupErrors);
+            deleteUserIfExists(PORT_OFFSET_2, userName, cleanupErrors);
+            deleteUserIfExists(PORT_OFFSET_2, userName2, cleanupErrors);
         }
 
-        // Remove the users created (directly and via outbound provisioning) so that a shared/persistent
-        // external database does not retain them for subsequent test runs, which would otherwise cause
-        // "UserAlreadyExistingUsername" failures on the next run.
-        deleteUserIfExists(PORT_OFFSET_0, userName);
-        deleteUserIfExists(PORT_OFFSET_1, userName2);
-        deleteUserIfExists(PORT_OFFSET_2, userName);
-        deleteUserIfExists(PORT_OFFSET_2, userName2);
+        if (!cleanupErrors.isEmpty()) {
+            StringBuilder message = new StringBuilder("Errors occurred while cleaning up ProvisioningTestCase: ");
+            for (Exception e : cleanupErrors) {
+                message.append(e.getMessage()).append("; ");
+            }
+            log.error(message.toString());
+            throw new Exception(message.toString(), cleanupErrors.get(0));
+        }
     }
 
-    private void deleteUserIfExists(int portOffset, String userNameToDelete) {
+    private void deleteUserIfExists(int portOffset, String userNameToDelete, List<Exception> cleanupErrors) {
 
         try {
             UserManagementClient userManagementClient = userMgtServiceClients.get(portOffset);
@@ -173,8 +186,7 @@ public class ProvisioningTestCase extends ISIntegrationTest {
                 userManagementClient.deleteUser(userNameToDelete);
             }
         } catch (Exception e) {
-            log.warn("Error while deleting user: " + userNameToDelete + " from server with port offset: "
-                    + portOffset, e);
+            cleanupErrors.add(e);
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/provisioning/ProvisioningTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/provisioning/ProvisioningTestCase.java
@@ -123,7 +123,7 @@ public class ProvisioningTestCase extends ISIntegrationTest {
 
         createServiceClientsForServers(sessionCookie, PORT_OFFSET_0, new CommonConstants.AdminClients[]{
                 CommonConstants.AdminClients.APPLICATION_MANAGEMENT_SERVICE_CLIENT, CommonConstants.AdminClients
-                .IDENTITY_PROVIDER_MGT_SERVICE_CLIENT});
+                .IDENTITY_PROVIDER_MGT_SERVICE_CLIENT, CommonConstants.AdminClients.USER_MANAGEMENT_CLIENT});
 
         createServiceClientsForServers(null, PORT_OFFSET_1, new CommonConstants.AdminClients[]{
                 CommonConstants.AdminClients.APPLICATION_MANAGEMENT_SERVICE_CLIENT, CommonConstants.AdminClients
@@ -154,6 +154,27 @@ public class ProvisioningTestCase extends ISIntegrationTest {
             }
             identityProviderMgtServiceClients.get(portOff).deleteIdP(SAMPLE_IDENTITY_PROVIDER_NAME + "_" + Integer
                     .toString(portOff));
+        }
+
+        // Remove the users created (directly and via outbound provisioning) so that a shared/persistent
+        // external database does not retain them for subsequent test runs, which would otherwise cause
+        // "UserAlreadyExistingUsername" failures on the next run.
+        deleteUserIfExists(PORT_OFFSET_0, userName);
+        deleteUserIfExists(PORT_OFFSET_1, userName2);
+        deleteUserIfExists(PORT_OFFSET_2, userName);
+        deleteUserIfExists(PORT_OFFSET_2, userName2);
+    }
+
+    private void deleteUserIfExists(int portOffset, String userNameToDelete) {
+
+        try {
+            UserManagementClient userManagementClient = userMgtServiceClients.get(portOffset);
+            if (userManagementClient != null && isUserExists(portOffset, userNameToDelete)) {
+                userManagementClient.deleteUser(userNameToDelete);
+            }
+        } catch (Exception e) {
+            log.warn("Error while deleting user: " + userNameToDelete + " from server with port offset: "
+                    + portOffset, e);
         }
     }
 
@@ -400,7 +421,12 @@ public class ProvisioningTestCase extends ISIntegrationTest {
 
     private boolean isUserExists(String userName) throws Exception {
 
-        FlaggedName[] nameList = userMgtServiceClients.get(PORT_OFFSET_2).listAllUsers(userName, 100);
+        return isUserExists(PORT_OFFSET_2, userName);
+    }
+
+    private boolean isUserExists(int portOffset, String userName) throws Exception {
+
+        FlaggedName[] nameList = userMgtServiceClients.get(portOffset).listAllUsers(userName, 100);
         for (FlaggedName name : nameList) {
             if (name.getItemName().contains(userName)) {
                 return true;


### PR DESCRIPTION
## Summary

Fixes #22140.

`createUser()` and `createUserForSecondServer()` in `ProvisioningTestCase` create SCIM users both directly and indirectly through outbound SCIM provisioning, but `atEnd()` only cleaned up the IDP and SP outbound provisioning config, never the users themselves.

With the default isolated H2 database, each test run starts from a fresh DB, so this went unnoticed. Against an external database shared across the test server instances, the users created by a prior run persist, so `createUserForSecondServer()` fails on the next run with `UserAlreadyExistingUsername` when it tries to create `testProvisioningUser2`, since it already exists in the shared database.

## Change

- Added a `USER_MANAGEMENT_CLIENT` for the port-offset-0 server so its created user can be managed for cleanup.
- Generalized `isUserExists(String)` into `isUserExists(int portOffset, String userName)` so existence can be checked against any of the three test server instances.
- Added `deleteUserIfExists(int portOffset, String userName)` and called it from `atEnd()` to remove both the directly created users and the users landed via outbound provisioning, so the test is safe to rerun against a shared/persistent external database.

## Test plan

- [x] `mvn compile` on `modules/integration/tests-integration/tests-backend` succeeds with this change (BUILD SUCCESS).
- [x] CI / maintainer to confirm `ProvisioningTestCase` passes end-to-end against both H2 and an external database, since running the full multi-server integration suite wasn't possible in this environment.