### PR TITLE
Fix Console Documentation link pointing to 7.2.0 docs

### DIFF
--- a/modules/distribution/src/repository/resources/conf/default.json
+++ b/modules/distribution/src/repository/resources/conf/default.json
@@ -75,7 +75,7 @@
   "legacy_authz_runtime.enable": false,
   "management_console_deprecation_banner.enable": true,
 
-  "console.doc_site_path": "https://is.docs.wso2.com/en/7.2.0",
+  "console.doc_site_path": "https://is.docs.wso2.com/en/7.3.0",
 
   "admin_service.deny_list": [
     "CarbonAppUploader",


### PR DESCRIPTION
## Summary

Fixes #28035.

`console.doc_site_path` in `modules/distribution/src/repository/resources/conf/default.json` was hardcoded to `https://is.docs.wso2.com/en/7.2.0`, so clicking Documentation in the Console header opened the previous release's docs instead of the current 7.3.0 docs.

## Change

Updated the value to `https://is.docs.wso2.com/en/7.3.0`.

## Test plan

- [x] Confirmed this was the only occurrence of the stale link in the repo (`grep -rn "is.docs.wso2.com/en/7.2.0"`).
- [ ] Maintainer to confirm 7.3.0 is the correct target (vs. `/en/latest` or similar), since I could not run a full IS pack and click through the Console in this environment.