### PR TITLE
[Temporary] Bump framework, basicauth and fido for AUTHDIAG logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2701,7 +2701,7 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.173</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.174</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
@@ -2784,8 +2784,8 @@
         <provisioning.connector.scim2.version>2.1.6</provisioning.connector.scim2.version>
 
         <!-- Local Authenticator Versions -->
-        <identity.local.auth.basicauth.version>6.11.11</identity.local.auth.basicauth.version>
-        <identity.local.auth.fido.version>6.0.11</identity.local.auth.fido.version>
+        <identity.local.auth.basicauth.version>6.11.12</identity.local.auth.basicauth.version>
+        <identity.local.auth.fido.version>6.0.12</identity.local.auth.fido.version>
         <identity.local.auth.iwa.version>5.5.1</identity.local.auth.iwa.version>
 
         <!-- Custom Authenticator extension adapter -->


### PR DESCRIPTION
> **This is temporary. It picks up diagnostic logging that will be reverted once the flow is identified, and must not reach production.**

> **Blocked.** The three versions below do not exist yet — they are the current development versions
> of each component. This cannot build until all three PRs below are merged and released.

## Purpose

Pick up the temporary `AUTHDIAG` logging used to identify how the authenticated user's `userId` is
bound during an identifier-first + passkey login.

Tracking issue: wso2-enterprise/asgardeo-product#36685
Related: wso2-iam-internal#7857 (groups missing from the token)

## Version bumps

| component | from | to | PR |
|---|---|---|---|
| `carbon.identity.framework` | 7.11.173 | 7.11.174 | wso2/carbon-identity-framework#8242 |
| `identity.local.auth.basicauth` | 6.11.11 | 6.11.12 | wso2-extensions/identity-local-auth-basicauth#282 |
| `identity.local.auth.fido` | 6.0.11 | 6.0.12 | wso2-extensions/identity-local-auth-fido#182 |

## Order of operations

1. Merge the three component PRs
2. Release each component
3. Confirm the released versions match the table above, and correct this PR if a release lands on a
   different number
4. Merge this
