### PR TITLE
Add integration tests for PASSWORD_CREDENTIAL auth on notification senders

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/auth/PasswordlessSMSOTPAuthTestCase.java
@@ -105,22 +105,26 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
 
     private TestUserMode userMode;
     private String apiVersion;
+    private Authentication.TypeEnum authType;
 
     @Factory(dataProvider = "testExecutionContextProvider")
-    public PasswordlessSMSOTPAuthTestCase(TestUserMode userMode, String apiVersion) {
+    public PasswordlessSMSOTPAuthTestCase(TestUserMode userMode, String apiVersion, Authentication.TypeEnum authType) {
 
         this.userMode = userMode;
         this.apiVersion = apiVersion;
+        this.authType = authType;
     }
 
     @DataProvider(name = "testExecutionContextProvider")
     public static Object[][] getTestExecutionContext() throws Exception {
 
         return new Object[][]{
-                {TestUserMode.SUPER_TENANT_USER, "v1"},
-                {TestUserMode.SUPER_TENANT_USER, "v2"},
-                {TestUserMode.TENANT_USER, "v1"},
-                {TestUserMode.TENANT_USER, "v2"},
+                {TestUserMode.SUPER_TENANT_USER, "v1", null},
+                {TestUserMode.SUPER_TENANT_USER, "v2", Authentication.TypeEnum.CLIENT_CREDENTIAL},
+                {TestUserMode.SUPER_TENANT_USER, "v2", Authentication.TypeEnum.PASSWORD_CREDENTIAL},
+                {TestUserMode.TENANT_USER, "v1", null},
+                {TestUserMode.TENANT_USER, "v2", Authentication.TypeEnum.CLIENT_CREDENTIAL},
+                {TestUserMode.TENANT_USER, "v2", Authentication.TypeEnum.PASSWORD_CREDENTIAL},
         };
     }
 
@@ -160,7 +164,7 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
 
         notificationSenderRestClient = new NotificationSenderRestClient(backendURL, tenantInfo);
         if (VERSION_2.equals(apiVersion)) {
-            notificationSenderRestClient.createSMSProviderV2(initSMSSenderV2());
+            notificationSenderRestClient.createSMSProviderV2(initSMSSenderV2(authType));
         } else {
             SMSSender smsSender = initSMSSender();
             notificationSenderRestClient.createSMSProvider(smsSender);
@@ -179,11 +183,10 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         return smsSender;
     }
 
-    private static String initSMSSenderV2() throws IOException {
+    private static String initSMSSenderV2(Authentication.TypeEnum authType) throws IOException {
 
         org.wso2.identity.integration.test.rest.api.server.notification.sender.v2.model.SMSSender smsSender =
-                SMSSenderRequestBuilder.createAddSMSSenderJSON(
-                        Authentication.TypeEnum.CLIENT_CREDENTIAL, SMSSenderTestBase.class);
+                SMSSenderRequestBuilder.createAddSMSSenderJSON(authType, SMSSenderTestBase.class);
 
         // Override provider URL to use MockSMSProvider
         smsSender.setProviderURL(MockSMSProvider.SMS_SENDER_URL);
@@ -224,6 +227,40 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
         assertNotNull(response);
         assertEquals(response.getStatusLine().getStatusCode(), 200);
         validateTokenRequest();
+    }
+
+    @Test(groups = "wso2.is", description = "Test that a second SMS OTP send reuses the cached refresh token " +
+            "instead of re-authenticating with the original grant from scratch",
+            dependsOnMethods = "testPasswordlessAuthentication")
+    public void testSecondSmsSendReusesRefreshToken() throws Exception {
+
+        if (!"v2".equals(apiVersion)) {
+            // No OAuth2 token handling for SMS sender v1.
+            return;
+        }
+
+        String firstAccessToken = mockOAuth2TokenServer.getLastAccessToken();
+
+        // Trigger a second, independent login to force a second SMS send.
+        sendAuthorizeRequest();
+        performUserLogin();
+        HttpResponse response = sendTokenRequestForCodeGrant();
+
+        assertNotNull(response);
+        assertEquals(response.getStatusLine().getStatusCode(), 200);
+
+        Map<String, String> secondRequestParams = mockOAuth2TokenServer.getLastRequestBodyContent();
+        assertEquals(secondRequestParams.get("grant_type"), "refresh_token",
+                "Second SMS send should reuse the cached refresh token instead of re-authenticating from scratch");
+
+        String secondAccessToken = mockOAuth2TokenServer.getLastAccessToken();
+        assertNotNull(secondAccessToken, "Access token should not be null");
+        assertTrue(!secondAccessToken.equals(firstAccessToken),
+                "Second send should use a newly refreshed access token, not the original one");
+
+        String authorizationHeader = mockSMSProvider.getHeader("Authorization");
+        assertTrue(authorizationHeader != null && authorizationHeader.startsWith("Bearer " + secondAccessToken),
+                "Second SMS send's Authorization header should carry the refreshed access token");
     }
 
     private void sendAuthorizeRequest() throws Exception {
@@ -340,18 +377,25 @@ public class PasswordlessSMSOTPAuthTestCase extends OIDCAbstractIntegrationTest 
             return;
         }
 
-        // Validate OAuth2 token request to MockOAuth2TokenServer for CLIENT_CREDENTIAL authentication
+        // Validate OAuth2 token request to MockOAuth2TokenServer for the configured authentication type
         String accessToken = mockOAuth2TokenServer.getLastAccessToken();
         Map<String, String> requestHeaders = mockOAuth2TokenServer.getLastRequestHeaders();
         Map<String, String> requestParams = mockOAuth2TokenServer.getLastRequestBodyContent();
 
-        assertEquals(requestHeaders.get("Authorization"), "Basic " + AuthenticationBuilder.ENCODED_CREDENTIAL);
+        if (Authentication.TypeEnum.PASSWORD_CREDENTIAL.equals(authType)) {
+            assertEquals(requestParams.get("grant_type"), "password");
+            assertEquals(requestParams.get("username"), AuthenticationBuilder.PASSWORD_CREDENTIAL_USERNAME);
+            assertEquals(requestParams.get("password"), AuthenticationBuilder.PASSWORD_CREDENTIAL_PASSWORD);
+            assertEquals(requestParams.get("scope"), URLEncoder.encode(
+                    AuthenticationBuilder.PASSWORD_CREDENTIAL_SCOPES, StandardCharsets.UTF_8));
+        } else {
+            assertEquals(requestHeaders.get("Authorization"), "Basic " + AuthenticationBuilder.ENCODED_CREDENTIAL);
+            assertEquals(requestParams.get("grant_type"), "client_credentials");
+            assertEquals(requestParams.get("scope"), URLEncoder.encode(
+                    AuthenticationBuilder.CLIENT_CREDENTIAL_SCOPES, StandardCharsets.UTF_8));
+        }
 
-        assertEquals(requestParams.get("grant_type"), "client_credentials");
-        assertEquals(requestParams.get("scope"), URLEncoder.encode(
-                AuthenticationBuilder.CLIENT_CREDENTIAL_SCOPES, StandardCharsets.UTF_8));
-
-        // Validate Authorization Bearer token header for CLIENT_CREDENTIAL authentication
+        // Validate Authorization Bearer token header carrying the token minted for the configured auth type
         String authorizationHeader = mockSMSProvider.getHeader("Authorization");
         assertNotNull(accessToken, "Access token should not be null");
         assertTrue(authorizationHeader != null && authorizationHeader.startsWith("Bearer " + accessToken),

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/MockHTTPEmailProvider.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/MockHTTPEmailProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.base;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformerV2;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wso2.identity.integration.common.utils.ISIntegrationTest;
+import org.wso2.identity.integration.test.util.Utils;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+/**
+ * Mock HTTP-based Email Provider for testing custom (non-SMTP) email delivery flows.
+ */
+public class MockHTTPEmailProvider {
+
+    public static final String EMAIL_SENDER_URL = "https://localhost:8094/email/send";
+    public static final String EMAIL_SENDER_PATH = "/email/send";
+
+    private WireMockServer wireMockServer;
+    private final AtomicReference<String> emailBody = new AtomicReference<>();
+    private final AtomicReference<Map<String, String>> headers = new AtomicReference<>(new HashMap<>());
+
+    public void start() {
+
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig()
+                .httpsPort(8094)
+                .httpDisabled(true)
+                .keystorePath(Paths.get(Utils.getResidentCarbonHome(), "repository", "resources", "security",
+                        ISIntegrationTest.KEYSTORE_NAME).toAbsolutePath().toString())
+                .keystorePassword("wso2carbon")
+                .keyManagerPassword("wso2carbon")
+                .extensions(
+                        new ResponseTemplateTransformer(null, true, null, null),
+                        new ResponseTransformerV2() {
+                            @Override
+                            public Response transform(Response response, ServeEvent serveEvent) {
+
+                                emailBody.set(serveEvent.getRequest().getBodyAsString());
+
+                                clearHeaders();
+                                Map<String, String> requestHeaders = new HashMap<>();
+                                serveEvent.getRequest().getHeaders().all().forEach(header -> {
+                                    requestHeaders.put(header.key(), header.firstValue());
+                                });
+                                headers.set(requestHeaders);
+
+                                return response;
+                            }
+
+                            @Override
+                            public boolean applyGlobally() {
+                                return false;
+                            }
+
+                            @Override
+                            public String getName() {
+                                return "email-capture-transformer";
+                            }
+                        }));
+
+        wireMockServer.start();
+        configureMockEndpoints();
+    }
+
+    public void stop() {
+
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    private void configureMockEndpoints() {
+
+        try {
+            wireMockServer.stubFor(post(urlEqualTo(EMAIL_SENDER_PATH))
+                    .willReturn(aResponse()
+                            .withTransformers("response-template", "email-capture-transformer")
+                            .withStatus(200)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get the full body of the last email send request.
+     *
+     * @return The last email request body.
+     */
+    public String getEmailBody() {
+
+        return emailBody.get();
+    }
+
+    /**
+     * Clear stored email body.
+     */
+    public void clearEmailBody() {
+
+        emailBody.set(null);
+    }
+
+    /**
+     * Get all headers received from the last email send request.
+     *
+     * @return Map of header names to header values.
+     */
+    public Map<String, String> getHeaders() {
+
+        return headers.get();
+    }
+
+    /**
+     * Get a specific header value from the last email send request.
+     *
+     * @param headerName The name of the header to retrieve.
+     * @return The header value, or null if not found.
+     */
+    public String getHeader(String headerName) {
+
+        return headers.get().get(headerName);
+    }
+
+    /**
+     * Clear stored headers.
+     */
+    public void clearHeaders() {
+
+        headers.set(new HashMap<>());
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/MockOAuth2TokenServer.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/base/MockOAuth2TokenServer.java
@@ -44,7 +44,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 /**
  * Mock OAuth2 Token Endpoint for testing OAuth2 flows.
- * Supports client_credentials and refresh_token grant types.
+ * Supports client_credentials, password and refresh_token grant types.
  */
 public class MockOAuth2TokenServer {
 
@@ -52,16 +52,19 @@ public class MockOAuth2TokenServer {
     public static final String TOKEN_ENDPOINT_PATH = "/oauth2/token";
     private static final int TOKEN_ENDPOINT_PORT = 8093;
     private static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+    private static final String GRANT_TYPE_PASSWORD = "password";
     private static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
     private static final int DEFAULT_EXPIRES_IN = 3600;
     private static final int DEFAULT_REFRESH_TOKEN_EXPIRES_IN = 86400;
-    
+
     // OAuth2 parameter names
     private static final String PARAM_GRANT_TYPE = "grant_type";
     private static final String PARAM_REFRESH_TOKEN = "refresh_token";
     private static final String PARAM_SCOPE = "scope";
     private static final String PARAM_CLIENT_ID = "client_id";
     private static final String PARAM_CLIENT_SECRET = "client_secret";
+    private static final String PARAM_USERNAME = "username";
+    private static final String PARAM_PASSWORD = "password";
     
     // OAuth2 response field names
     private static final String RESPONSE_ACCESS_TOKEN = "access_token";
@@ -242,6 +245,8 @@ public class MockOAuth2TokenServer {
             try {
                 if (GRANT_TYPE_CLIENT_CREDENTIALS.equals(grantType)) {
                     tokenResponse = handleClientCredentialsGrant(params, requestHeaders);
+                } else if (GRANT_TYPE_PASSWORD.equals(grantType)) {
+                    tokenResponse = handlePasswordGrant(params, requestHeaders);
                 } else if (GRANT_TYPE_REFRESH_TOKEN.equals(grantType)) {
                     tokenResponse = handleRefreshTokenGrant(params, requestHeaders);
                 } else {
@@ -265,6 +270,25 @@ public class MockOAuth2TokenServer {
             validateClientAuthentication(params, headers);
 
             // Generate and store new tokens
+            TokenPair tokens = generateAndStoreTokens();
+
+            return buildTokenResponse(tokens.accessToken, tokens.refreshToken, params.get(PARAM_SCOPE));
+        }
+
+        private JSONObject handlePasswordGrant(Map<String, String> params,
+                                                Map<String, String> headers) throws Exception {
+
+            // Validate client authentication.
+            validateClientAuthentication(params, headers);
+
+            // Validate resource owner credentials.
+            String username = params.get(PARAM_USERNAME);
+            String password = params.get(PARAM_PASSWORD);
+            if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
+                throw new Exception("username and password are required");
+            }
+
+            // Generate and store new tokens.
             TokenPair tokens = generateAndStoreTokens();
 
             return buildTokenResponse(tokens.accessToken, tokens.refreshToken, params.get(PARAM_SCOPE));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/EmailSenderSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/EmailSenderSuccessTest.java
@@ -649,4 +649,127 @@ public class EmailSenderSuccessTest extends EmailSenderTestBase {
 
         deleteEmailSenderAndValidate();
     }
+
+    @Test(dependsOnMethods = {"testDeleteSMTPEmailSenderWithClientCredentialAuth"})
+    public void testAddHTTPEmailSenderWithPasswordCredentialAuth() throws IOException {
+
+        String body = new Gson().toJson(EmailSenderRequestBuilder.createAddHTTPEmailSenderJSON(
+                AUTH_TYPE_PASSWORD_CREDENTIAL, this.getClass()));
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH, body);
+        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_CREATED)
+                    .header(HttpHeaders.LOCATION, notNullValue());
+            String location = response.getHeader(HttpHeaders.LOCATION);
+            assertNotNull(location);
+            emailNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
+            assertNotNull(emailNotificationSenderName);
+        } else {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
+        }
+    }
+
+    @Test(dependsOnMethods = {"testAddHTTPEmailSenderWithPasswordCredentialAuth"})
+    public void testGetHTTPEmailSenderWithPasswordCredentialAuth() {
+
+        Response response = getResponseOfGet(
+                NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH + PATH_SEPARATOR +
+                        emailNotificationSenderName);
+        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body("provider", equalTo(HTTP_PROVIDER))
+                    .body("providerURL", equalTo(HTTP_PROVIDER_URL))
+                    .body("authType", equalTo(AUTH_TYPE_PASSWORD_CREDENTIAL))
+                    .body(PROPERTY_CONTENT_TYPE, equalTo(HTTP_CONTENT_TYPE))
+                    .body(PROPERTY_HTTP_METHOD, equalTo(HTTP_CLIENT_METHOD))
+                    .body(PROPERTY_HTTP_HEADERS, equalTo(HTTP_HEADERS))
+                    .body(PROPERTY_CLIENT_ID, equalTo(PASSWORD_CREDENTIAL_CLIENT_ID))
+                    .body(PROPERTY_USERNAME, equalTo(PASSWORD_CREDENTIAL_USERNAME))
+                    .body(PROPERTY_TOKEN_ENDPOINT, equalTo(PASSWORD_CREDENTIAL_TOKEN_ENDPOINT))
+                    .body(PROPERTY_SCOPES, equalTo(PASSWORD_CREDENTIAL_SCOPES))
+                    .body(PROPERTY_CLIENT_SECRET, nullValue())
+                    .body(PROPERTY_PASSWORD, nullValue());
+        } else {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
+        }
+    }
+
+    @Test(dependsOnMethods = {"testGetHTTPEmailSenderWithPasswordCredentialAuth"})
+    public void testDeleteHTTPEmailSenderWithPasswordCredentialAuth() {
+
+        deleteEmailSenderAndValidate();
+    }
+
+    @Test(dependsOnMethods = {"testDeleteHTTPEmailSenderWithPasswordCredentialAuth"})
+    public void testAddSMTPEmailSenderWithPasswordCredentialAuth() throws IOException {
+
+        String body = new Gson().toJson(EmailSenderRequestBuilder.createAddSMTPEmailSenderJSON(
+                AUTH_TYPE_PASSWORD_CREDENTIAL, this.getClass()));
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH, body);
+        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_CREATED)
+                    .header(HttpHeaders.LOCATION, notNullValue());
+            String location = response.getHeader(HttpHeaders.LOCATION);
+            assertNotNull(location);
+            emailNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
+            assertNotNull(emailNotificationSenderName);
+        } else {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
+        }
+    }
+
+    @Test(dependsOnMethods = {"testAddSMTPEmailSenderWithPasswordCredentialAuth"})
+    public void testGetSMTPEmailSenderWithPasswordCredentialAuth() {
+
+        Response response = getResponseOfGet(
+                NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH + PATH_SEPARATOR +
+                        emailNotificationSenderName);
+        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body("smtpServerHost", equalTo(SMTP_SERVER_HOST))
+                    .body("smtpPort", equalTo(SMTP_PORT))
+                    .body("fromAddress", equalTo(SMTP_FROM_ADDRESS))
+                    .body("authType", equalTo(AUTH_TYPE_PASSWORD_CREDENTIAL))
+                    .body("properties", notNullValue())
+                    .body(PROPERTY_CLIENT_ID, equalTo(PASSWORD_CREDENTIAL_CLIENT_ID))
+                    .body(PROPERTY_USERNAME, equalTo(PASSWORD_CREDENTIAL_USERNAME))
+                    .body(PROPERTY_TOKEN_ENDPOINT, equalTo(PASSWORD_CREDENTIAL_TOKEN_ENDPOINT))
+                    .body(PROPERTY_SCOPES, equalTo(PASSWORD_CREDENTIAL_SCOPES))
+                    .body(PROPERTY_CLIENT_SECRET, nullValue())
+                    .body(PROPERTY_PASSWORD, nullValue());
+        } else {
+            response.then()
+                    .log().ifValidationFails()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
+        }
+    }
+
+    @Test(dependsOnMethods = {"testGetSMTPEmailSenderWithPasswordCredentialAuth"})
+    public void testDeleteSMTPEmailSenderWithPasswordCredentialAuth() {
+
+        deleteEmailSenderAndValidate();
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/EmailSenderSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/EmailSenderSuccessTest.java
@@ -713,8 +713,13 @@ public class EmailSenderSuccessTest extends EmailSenderTestBase {
     }
 
     @Test(dependsOnMethods = {"testDeleteHTTPEmailSenderWithPasswordCredentialAuth"})
-    public void testAddSMTPEmailSenderWithPasswordCredentialAuth() throws IOException {
+    public void testAddSMTPEmailSenderWithPasswordCredentialAuthIsRejected() throws IOException {
 
+        // PASSWORD_CREDENTIAL is restricted to HTTP-based email senders (identity-event-handler-notification#394):
+        // the SMTP send path (EmailEventAdapter) only implements CLIENT_CREDENTIAL via XOAUTH2, and accepting
+        // PASSWORD_CREDENTIAL here would leak the resource-owner username/password/clientId/clientSecret into
+        // the generated SMTP publisher config in plaintext (see NotificationSenderManagementServiceImpl
+        // #validateInputs).
         String body = new Gson().toJson(EmailSenderRequestBuilder.createAddSMTPEmailSenderJSON(
                 AUTH_TYPE_PASSWORD_CREDENTIAL, this.getClass()));
         Response response =
@@ -723,53 +728,12 @@ public class EmailSenderSuccessTest extends EmailSenderTestBase {
             response.then()
                     .log().ifValidationFails()
                     .assertThat()
-                    .statusCode(HttpStatus.SC_CREATED)
-                    .header(HttpHeaders.LOCATION, notNullValue());
-            String location = response.getHeader(HttpHeaders.LOCATION);
-            assertNotNull(location);
-            emailNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
-            assertNotNull(emailNotificationSenderName);
+                    .statusCode(HttpStatus.SC_BAD_REQUEST);
         } else {
             response.then()
                     .log().ifValidationFails()
                     .assertThat()
                     .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
         }
-    }
-
-    @Test(dependsOnMethods = {"testAddSMTPEmailSenderWithPasswordCredentialAuth"})
-    public void testGetSMTPEmailSenderWithPasswordCredentialAuth() {
-
-        Response response = getResponseOfGet(
-                NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH + PATH_SEPARATOR +
-                        emailNotificationSenderName);
-        if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenant)) {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_OK)
-                    .body("smtpServerHost", equalTo(SMTP_SERVER_HOST))
-                    .body("smtpPort", equalTo(SMTP_PORT))
-                    .body("fromAddress", equalTo(SMTP_FROM_ADDRESS))
-                    .body("authType", equalTo(AUTH_TYPE_PASSWORD_CREDENTIAL))
-                    .body("properties", notNullValue())
-                    .body(PROPERTY_CLIENT_ID, equalTo(PASSWORD_CREDENTIAL_CLIENT_ID))
-                    .body(PROPERTY_USERNAME, equalTo(PASSWORD_CREDENTIAL_USERNAME))
-                    .body(PROPERTY_TOKEN_ENDPOINT, equalTo(PASSWORD_CREDENTIAL_TOKEN_ENDPOINT))
-                    .body(PROPERTY_SCOPES, equalTo(PASSWORD_CREDENTIAL_SCOPES))
-                    .body(PROPERTY_CLIENT_SECRET, nullValue())
-                    .body(PROPERTY_PASSWORD, nullValue());
-        } else {
-            response.then()
-                    .log().ifValidationFails()
-                    .assertThat()
-                    .statusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
-        }
-    }
-
-    @Test(dependsOnMethods = {"testGetSMTPEmailSenderWithPasswordCredentialAuth"})
-    public void testDeleteSMTPEmailSenderWithPasswordCredentialAuth() {
-
-        deleteEmailSenderAndValidate();
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/EmailSenderTestBase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/EmailSenderTestBase.java
@@ -47,6 +47,7 @@ public class EmailSenderTestBase extends RESTAPIServerTestBase {
     public static final String AUTH_TYPE_BASIC = "BASIC";
     public static final String AUTH_TYPE_BEARER = "BEARER";
     public static final String AUTH_TYPE_CLIENT_CREDENTIAL = "CLIENT_CREDENTIAL";
+    public static final String AUTH_TYPE_PASSWORD_CREDENTIAL = "PASSWORD_CREDENTIAL";
     public static final String AUTH_TYPE_API_KEY = "API_KEY";
     public static final String AUTH_TYPE_NONE = "NONE";
 
@@ -57,6 +58,13 @@ public class EmailSenderTestBase extends RESTAPIServerTestBase {
     public static final String CLIENT_CREDENTIAL_CLIENT_ID = "test-client-id";
     public static final String CLIENT_CREDENTIAL_TOKEN_ENDPOINT = "https://example.com/oauth2/token";
     public static final String CLIENT_CREDENTIAL_SCOPES =
+            "internal_config_mgt_add internal_config_mgt_delete internal_config_mgt_list";
+
+    // Password Credential Auth constants
+    public static final String PASSWORD_CREDENTIAL_CLIENT_ID = "test-password-credential-client-id";
+    public static final String PASSWORD_CREDENTIAL_USERNAME = "test-password-credential-username";
+    public static final String PASSWORD_CREDENTIAL_TOKEN_ENDPOINT = "https://example.com/oauth2/token";
+    public static final String PASSWORD_CREDENTIAL_SCOPES =
             "internal_config_mgt_add internal_config_mgt_delete internal_config_mgt_list";
 
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/HTTPEmailNotificationRealDeliveryTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/HTTPEmailNotificationRealDeliveryTestCase.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.rest.api.server.notification.sender.v2;
+
+import com.google.gson.Gson;
+import io.restassured.response.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.identity.integration.test.base.MockHTTPEmailProvider;
+import org.wso2.identity.integration.test.base.MockOAuth2TokenServer;
+import org.wso2.identity.integration.test.recovery.model.v2.InitModel;
+import org.wso2.identity.integration.test.recovery.model.v2.RecoverModel;
+import org.wso2.identity.integration.test.recovery.model.v2.UserClaim;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.ConnectorsPatchReq;
+import org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.dto.PropertyReq;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v2.model.EmailSender;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v2.model.Properties;
+import org.wso2.identity.integration.test.rest.api.server.notification.sender.v2.util.EmailSenderRequestBuilder;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Email;
+import org.wso2.identity.integration.test.rest.api.user.common.model.Name;
+import org.wso2.identity.integration.test.rest.api.user.common.model.UserObject;
+import org.wso2.identity.integration.test.restclients.IdentityGovernanceRestClient;
+import org.wso2.identity.integration.test.restclients.PasswordRecoveryV2RestClient;
+import org.wso2.identity.integration.test.restclients.SCIM2RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Real end-to-end delivery test for the HTTP-based (non-SMTP) Email notification sender, covering
+ * CLIENT_CREDENTIAL and PASSWORD_CREDENTIAL authentication, and refresh-token reuse on a second send.
+ */
+public class HTTPEmailNotificationRealDeliveryTestCase extends EmailSenderTestBase {
+
+    private static final String CATEGORY_ID = "QWNjb3VudCBNYW5hZ2VtZW50";
+    private static final String CONNECTOR_ID = "YWNjb3VudC1yZWNvdmVyeQ";
+    private static final String TEST_USERNAME = "httpEmailRealDeliveryUser";
+    private static final String TEST_USER_PASSWORD = "Testuser@123";
+    private static final String TEST_USER_EMAIL = "httpemailrealdeliveryuser@wso2.com";
+
+    private final String senderAuthType;
+
+    private MockHTTPEmailProvider mockHTTPEmailProvider;
+    private MockOAuth2TokenServer mockOAuth2TokenServer;
+    private IdentityGovernanceRestClient identityGovernanceRestClient;
+    private SCIM2RestClient scim2RestClient;
+    private PasswordRecoveryV2RestClient passwordRecoveryV2RestClient;
+
+    private String userId;
+
+    @Factory(dataProvider = "authTypeProvider")
+    public HTTPEmailNotificationRealDeliveryTestCase(String senderAuthType) throws Exception {
+
+        super.init(TestUserMode.TENANT_ADMIN);
+        this.context = isServer;
+        this.authenticatingUserName = context.getContextTenant().getTenantAdmin().getUserName();
+        this.authenticatingCredential = context.getContextTenant().getTenantAdmin().getPassword();
+        this.tenant = context.getContextTenant().getDomain();
+        this.senderAuthType = senderAuthType;
+    }
+
+    @DataProvider(name = "authTypeProvider")
+    public static Object[][] getAuthTypes() {
+
+        return new Object[][]{
+                {AUTH_TYPE_CLIENT_CREDENTIAL},
+                {AUTH_TYPE_PASSWORD_CREDENTIAL},
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.testInit(API_VERSION, swaggerDefinition, tenant);
+
+        mockHTTPEmailProvider = new MockHTTPEmailProvider();
+        mockHTTPEmailProvider.start();
+
+        mockOAuth2TokenServer = new MockOAuth2TokenServer();
+        mockOAuth2TokenServer.start();
+
+        identityGovernanceRestClient = new IdentityGovernanceRestClient(backendURL, tenantInfo);
+        scim2RestClient = new SCIM2RestClient(serverURL, tenantInfo);
+        passwordRecoveryV2RestClient = new PasswordRecoveryV2RestClient(serverURL, tenantInfo);
+
+        updateNotificationPasswordRecoveryStatus(true);
+
+        UserObject userInfo = new UserObject()
+                .userName(TEST_USERNAME)
+                .password(TEST_USER_PASSWORD)
+                .name(new Name().givenName("HTTP").familyName("EmailUser"))
+                .addEmail(new Email().value(TEST_USER_EMAIL));
+        userId = scim2RestClient.createUser(userInfo);
+
+        String body = new Gson().toJson(buildHTTPEmailSender(senderAuthType));
+        Response response = getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH,
+                body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void atEnd() throws Exception {
+
+        getResponseOfDelete(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + EMAIL_SENDERS_PATH +
+                PATH_SEPARATOR + EMAIL_SENDER_NAME);
+
+        scim2RestClient.deleteUser(userId);
+        updateNotificationPasswordRecoveryStatus(false);
+
+        identityGovernanceRestClient.closeHttpClient();
+        scim2RestClient.closeHttpClient();
+        passwordRecoveryV2RestClient.closeHttpClient();
+
+        mockHTTPEmailProvider.stop();
+        mockOAuth2TokenServer.clearData();
+        mockOAuth2TokenServer.stop();
+
+        super.testConclude();
+    }
+
+    @Test(groups = "wso2.is", description = "Test real password recovery email delivery via a custom HTTP " +
+            "provider secured with an OAuth2 grant")
+    public void testRealEmailDeliveryWithOAuth2() throws Exception {
+
+        triggerPasswordRecoveryEmail();
+
+        String accessToken = mockOAuth2TokenServer.getLastAccessToken();
+        Map<String, String> requestParams = mockOAuth2TokenServer.getLastRequestBodyContent();
+
+        assertNotNull(accessToken, "Access token should not be null");
+        if (AUTH_TYPE_PASSWORD_CREDENTIAL.equals(senderAuthType)) {
+            assertEquals(requestParams.get("grant_type"), "password");
+        } else {
+            assertEquals(requestParams.get("grant_type"), "client_credentials");
+        }
+
+        String authorizationHeader = mockHTTPEmailProvider.getHeader("Authorization");
+        assertTrue(authorizationHeader != null && authorizationHeader.startsWith("Bearer " + accessToken),
+                "Authorization header should contain the Bearer token minted for the configured auth type");
+        assertNotNull(mockHTTPEmailProvider.getEmailBody(), "Email body should have been delivered");
+    }
+
+    @Test(groups = "wso2.is", description = "Test that a second email send reuses the cached refresh token " +
+            "instead of re-authenticating from scratch", dependsOnMethods = "testRealEmailDeliveryWithOAuth2")
+    public void testSecondEmailSendReusesRefreshToken() throws Exception {
+
+        String firstAccessToken = mockOAuth2TokenServer.getLastAccessToken();
+
+        triggerPasswordRecoveryEmail();
+
+        Map<String, String> secondRequestParams = mockOAuth2TokenServer.getLastRequestBodyContent();
+        assertEquals(secondRequestParams.get("grant_type"), "refresh_token",
+                "Second email send should reuse the cached refresh token instead of re-authenticating from scratch");
+
+        String secondAccessToken = mockOAuth2TokenServer.getLastAccessToken();
+        assertNotNull(secondAccessToken, "Access token should not be null");
+        assertTrue(!secondAccessToken.equals(firstAccessToken),
+                "Second send should use a newly refreshed access token, not the original one");
+
+        String authorizationHeader = mockHTTPEmailProvider.getHeader("Authorization");
+        assertTrue(authorizationHeader != null && authorizationHeader.startsWith("Bearer " + secondAccessToken),
+                "Second email send's Authorization header should carry the refreshed access token");
+    }
+
+    private void triggerPasswordRecoveryEmail() throws Exception {
+
+        UserClaim usernameClaim = new UserClaim()
+                .uri("http://wso2.org/claims/username")
+                .value(TEST_USERNAME);
+        InitModel initModel = new InitModel().claims(List.of(usernameClaim));
+
+        RecoverModel recoverModel = passwordRecoveryV2RestClient.init(initModel, "EMAIL");
+        assertNotNull(recoverModel, "Recovery model should not be null");
+        assertTrue(StringUtils.isNotBlank(recoverModel.getChannelId()), "Channel ID should not be blank");
+        assertTrue(StringUtils.isNotBlank(recoverModel.getRecoveryCode()), "Recovery code should not be blank");
+
+        String flowConfirmationCode = passwordRecoveryV2RestClient.recover(recoverModel);
+        assertTrue(StringUtils.isNotBlank(flowConfirmationCode), "Flow confirmation code should not be blank");
+    }
+
+    private EmailSender buildHTTPEmailSender(String authType) throws Exception {
+
+        EmailSender emailSender = EmailSenderRequestBuilder.createAddHTTPEmailSenderJSON(authType, getClass());
+        emailSender.setProviderURL(MockHTTPEmailProvider.EMAIL_SENDER_URL);
+
+        for (Properties property : emailSender.getProperties()) {
+            if ("tokenEndpoint".equals(property.getKey())) {
+                property.setValue(MockOAuth2TokenServer.TOKEN_ENDPOINT_URL);
+            }
+        }
+
+        return emailSender;
+    }
+
+    private void updateNotificationPasswordRecoveryStatus(boolean enable) throws Exception {
+
+        ConnectorsPatchReq connectorsPatchReq = new ConnectorsPatchReq();
+        connectorsPatchReq.setOperation(ConnectorsPatchReq.OperationEnum.UPDATE);
+
+        PropertyReq enablePasswordRecovery = new PropertyReq()
+                .name("Recovery.Notification.Password.Enable")
+                .value(enable ? "true" : "false");
+        PropertyReq enableEmailLinkRecovery = new PropertyReq()
+                .name("Recovery.Notification.Password.emailLink.Enable")
+                .value(enable ? "true" : "false");
+
+        connectorsPatchReq.addProperties(enablePasswordRecovery);
+        connectorsPatchReq.addProperties(enableEmailLinkRecovery);
+
+        identityGovernanceRestClient.updateConnectors(CATEGORY_ID, CONNECTOR_ID, connectorsPatchReq);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/SMSSenderFailureTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/SMSSenderFailureTest.java
@@ -327,6 +327,141 @@ public class SMSSenderFailureTest extends SMSSenderTestBase {
     }
 
     @Test
+    public void testAddSmsSenderWithMissingPasswordCredentialClientId() throws IOException {
+
+        // Create SMS sender with PASSWORD_CREDENTIAL auth but missing clientId
+        String body = "{"
+                + "\"provider\": \"Custom\","
+                + "\"providerURL\": \"https://example.sms.sender\","
+                + "\"contentType\": \"JSON\","
+                + "\"authentication\": {"
+                + "  \"type\": \"PASSWORD_CREDENTIAL\","
+                + "  \"properties\": {"
+                + "    \"clientSecret\": \"testSecret\","
+                + "    \"username\": \"testUsername\","
+                + "    \"password\": \"testPassword\","
+                + "    \"tokenEndpoint\": \"https://auth.example.com/token\""
+                + "  }"
+                + "},"
+                + "\"properties\": ["
+                + "  {\"key\": \"body\", \"value\": \"{\\\"content\\\": {{body}}, \\\"to\\\": {{mobile}} }\"}"
+                + "]"
+                + "}";
+
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60012");
+    }
+
+    @Test
+    public void testAddSmsSenderWithMissingPasswordCredentialClientSecret() throws IOException {
+
+        // Create SMS sender with PASSWORD_CREDENTIAL auth but missing clientSecret
+        String body = "{"
+                + "\"provider\": \"Custom\","
+                + "\"providerURL\": \"https://example.sms.sender\","
+                + "\"contentType\": \"JSON\","
+                + "\"authentication\": {"
+                + "  \"type\": \"PASSWORD_CREDENTIAL\","
+                + "  \"properties\": {"
+                + "    \"clientId\": \"testClient\","
+                + "    \"username\": \"testUsername\","
+                + "    \"password\": \"testPassword\","
+                + "    \"tokenEndpoint\": \"https://auth.example.com/token\""
+                + "  }"
+                + "},"
+                + "\"properties\": ["
+                + "  {\"key\": \"body\", \"value\": \"{\\\"content\\\": {{body}}, \\\"to\\\": {{mobile}} }\"}"
+                + "]"
+                + "}";
+
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60012");
+    }
+
+    @Test
+    public void testAddSmsSenderWithMissingPasswordCredentialUsername() throws IOException {
+
+        // Create SMS sender with PASSWORD_CREDENTIAL auth but missing username
+        String body = "{"
+                + "\"provider\": \"Custom\","
+                + "\"providerURL\": \"https://example.sms.sender\","
+                + "\"contentType\": \"JSON\","
+                + "\"authentication\": {"
+                + "  \"type\": \"PASSWORD_CREDENTIAL\","
+                + "  \"properties\": {"
+                + "    \"clientId\": \"testClient\","
+                + "    \"clientSecret\": \"testSecret\","
+                + "    \"password\": \"testPassword\","
+                + "    \"tokenEndpoint\": \"https://auth.example.com/token\""
+                + "  }"
+                + "},"
+                + "\"properties\": ["
+                + "  {\"key\": \"body\", \"value\": \"{\\\"content\\\": {{body}}, \\\"to\\\": {{mobile}} }\"}"
+                + "]"
+                + "}";
+
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60012");
+    }
+
+    @Test
+    public void testAddSmsSenderWithMissingPasswordCredentialPassword() throws IOException {
+
+        // Create SMS sender with PASSWORD_CREDENTIAL auth but missing password
+        String body = "{"
+                + "\"provider\": \"Custom\","
+                + "\"providerURL\": \"https://example.sms.sender\","
+                + "\"contentType\": \"JSON\","
+                + "\"authentication\": {"
+                + "  \"type\": \"PASSWORD_CREDENTIAL\","
+                + "  \"properties\": {"
+                + "    \"clientId\": \"testClient\","
+                + "    \"clientSecret\": \"testSecret\","
+                + "    \"username\": \"testUsername\","
+                + "    \"tokenEndpoint\": \"https://auth.example.com/token\""
+                + "  }"
+                + "},"
+                + "\"properties\": ["
+                + "  {\"key\": \"body\", \"value\": \"{\\\"content\\\": {{body}}, \\\"to\\\": {{mobile}} }\"}"
+                + "]"
+                + "}";
+
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60012");
+    }
+
+    @Test
+    public void testAddSmsSenderWithMissingPasswordCredentialTokenEndpoint() throws IOException {
+
+        // Create SMS sender with PASSWORD_CREDENTIAL auth but missing tokenEndpoint
+        String body = "{"
+                + "\"provider\": \"Custom\","
+                + "\"providerURL\": \"https://example.sms.sender\","
+                + "\"contentType\": \"JSON\","
+                + "\"authentication\": {"
+                + "  \"type\": \"PASSWORD_CREDENTIAL\","
+                + "  \"properties\": {"
+                + "    \"clientId\": \"testClient\","
+                + "    \"clientSecret\": \"testSecret\","
+                + "    \"username\": \"testUsername\","
+                + "    \"password\": \"testPassword\""
+                + "  }"
+                + "},"
+                + "\"properties\": ["
+                + "  {\"key\": \"body\", \"value\": \"{\\\"content\\\": {{body}}, \\\"to\\\": {{mobile}} }\"}"
+                + "]"
+                + "}";
+
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        validateErrorResponse(response, HttpStatus.SC_BAD_REQUEST, "NSM-60012");
+    }
+
+    @Test
     public void testUpdateSmsSenderWithInvalidAuthentication() throws IOException {
 
         // First create a valid SMS sender

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/SMSSenderSuccessTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/SMSSenderSuccessTest.java
@@ -274,6 +274,47 @@ public class SMSSenderSuccessTest extends SMSSenderTestBase {
         testDeleteSmsSender();
     }
 
+    @Test(dependsOnMethods = {"testGetSMSSenderWithClientCredentialAuth"})
+    public void testAddSmsSenderWithPasswordCredentialAuth() throws IOException, InterruptedException {
+
+        String body = new Gson().toJson(SMSSenderRequestBuilder.createAddSMSSenderJSON(
+                Authentication.TypeEnum.PASSWORD_CREDENTIAL, this.getClass()));
+        Response response =
+                getResponseOfPost(NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH, body);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+                .header(HttpHeaders.LOCATION, notNullValue());
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        assertNotNull(location);
+        smsNotificationSenderName = location.substring(location.lastIndexOf("/") + 1);
+        assertNotNull(smsNotificationSenderName);
+    }
+
+    @Test(dependsOnMethods = {"testAddSmsSenderWithPasswordCredentialAuth"})
+    public void testGetSMSSenderWithPasswordCredentialAuth() {
+
+        Response response = getResponseOfGet(
+                NOTIFICATION_SENDER_API_BASE_PATH + PATH_SEPARATOR + SMS_SENDERS_PATH + PATH_SEPARATOR +
+                        smsNotificationSenderName);
+        response.then()
+                .log().ifValidationFails()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("authentication.type", equalTo("PASSWORD_CREDENTIAL"))
+                .body("authentication.properties.clientId",
+                        equalTo(AuthenticationBuilder.PASSWORD_CREDENTIAL_CLIENT_ID))
+                .body("authentication.properties.clientSecret", nullValue())
+                .body("authentication.properties.username",
+                        equalTo(AuthenticationBuilder.PASSWORD_CREDENTIAL_USERNAME))
+                .body("authentication.properties.password", nullValue())
+                .body("authentication.properties.tokenEndpoint", equalTo(MockOAuth2TokenServer.TOKEN_ENDPOINT_URL))
+                .body("authentication.properties.scopes", equalTo(AuthenticationBuilder.PASSWORD_CREDENTIAL_SCOPES));
+
+        testDeleteSmsSender();
+    }
+
     private void testDeleteSmsSender() {
 
         Response response =

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/model/Authentication.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/model/Authentication.java
@@ -42,6 +42,8 @@ public class Authentication {
     public enum TypeEnum {
         @SerializedName("CLIENT_CREDENTIAL")
         CLIENT_CREDENTIAL("CLIENT_CREDENTIAL"),
+        @SerializedName("PASSWORD_CREDENTIAL")
+        PASSWORD_CREDENTIAL("PASSWORD_CREDENTIAL"),
         @SerializedName("BASIC")
         BASIC("BASIC"),
         @SerializedName("API_KEY")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/util/AuthenticationBuilder.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/util/AuthenticationBuilder.java
@@ -36,6 +36,13 @@ public class AuthenticationBuilder {
     public static final String ENCODED_CREDENTIAL = "dGVzdENsaWVudElkOnRlc3RDbGllbnRTZWNyZXQ=";
     public static final String CLIENT_CREDENTIAL_SCOPES = "read+write";
 
+    // Password Credential Auth constants
+    public static final String PASSWORD_CREDENTIAL_CLIENT_ID = "testPasswordCredentialClientId";
+    public static final String PASSWORD_CREDENTIAL_CLIENT_SECRET = "testPasswordCredentialClientSecret";
+    public static final String PASSWORD_CREDENTIAL_USERNAME = "testPasswordCredentialUsername";
+    public static final String PASSWORD_CREDENTIAL_PASSWORD = "testPasswordCredentialPassword";
+    public static final String PASSWORD_CREDENTIAL_SCOPES = "read+write";
+
     // API Key Auth constants
     public static final String API_KEY_HEADER = "test-api-header";
     public static final String API_KEY_VALUE = "test-api-key-12345";
@@ -46,7 +53,7 @@ public class AuthenticationBuilder {
     /**
      * Creates a sample Authentication object based on the specified authentication type.
      *
-     * @param authType the authentication type (BASIC, CLIENT_CREDENTIAL, API_KEY, BEARER, NONE)
+     * @param authType the authentication type (BASIC, CLIENT_CREDENTIAL, PASSWORD_CREDENTIAL, API_KEY, BEARER, NONE)
      * @return Authentication object configured for the specified authentication type with sample values
      */
     public static Authentication createSampleAuth(Authentication.TypeEnum authType) {
@@ -56,6 +63,10 @@ public class AuthenticationBuilder {
             case CLIENT_CREDENTIAL:
                 return createClientCredentialAuth(CLIENT_CREDENTIAL_CLIENT_ID, CLIENT_CREDENTIAL_CLIENT_SECRET,
                         MockOAuth2TokenServer.TOKEN_ENDPOINT_URL, CLIENT_CREDENTIAL_SCOPES);
+            case PASSWORD_CREDENTIAL:
+                return createPasswordCredentialAuth(PASSWORD_CREDENTIAL_CLIENT_ID, PASSWORD_CREDENTIAL_CLIENT_SECRET,
+                        PASSWORD_CREDENTIAL_USERNAME, PASSWORD_CREDENTIAL_PASSWORD,
+                        MockOAuth2TokenServer.TOKEN_ENDPOINT_URL, PASSWORD_CREDENTIAL_SCOPES);
             case API_KEY:
                 return createApiKeyAuth(API_KEY_HEADER, API_KEY_VALUE);
             case BEARER:
@@ -99,6 +110,33 @@ public class AuthenticationBuilder {
         authentication.setType(Authentication.TypeEnum.CLIENT_CREDENTIAL);
         authentication.putPropertiesItem("clientId", clientId);
         authentication.putPropertiesItem("clientSecret", clientSecret);
+        authentication.putPropertiesItem("tokenEndpoint", tokenEndpoint);
+        if (scopes != null && !scopes.isEmpty()) {
+            authentication.putPropertiesItem("scopes", scopes);
+        }
+        return authentication;
+    }
+
+    /**
+     * Create a PASSWORD_CREDENTIAL authentication object
+     *
+     * @param clientId Client ID
+     * @param clientSecret Client secret
+     * @param username Resource owner username
+     * @param password Resource owner password
+     * @param tokenEndpoint Token endpoint URL
+     * @param scopes Scopes (optional)
+     * @return Authentication object configured for PASSWORD_CREDENTIAL auth
+     */
+    public static Authentication createPasswordCredentialAuth(String clientId, String clientSecret, String username,
+                                                                String password, String tokenEndpoint, String scopes) {
+
+        Authentication authentication = new Authentication();
+        authentication.setType(Authentication.TypeEnum.PASSWORD_CREDENTIAL);
+        authentication.putPropertiesItem("clientId", clientId);
+        authentication.putPropertiesItem("clientSecret", clientSecret);
+        authentication.putPropertiesItem("username", username);
+        authentication.putPropertiesItem("password", password);
         authentication.putPropertiesItem("tokenEndpoint", tokenEndpoint);
         if (scopes != null && !scopes.isEmpty()) {
             authentication.putPropertiesItem("scopes", scopes);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/util/EmailSenderRequestBuilder.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/notification/sender/v2/util/EmailSenderRequestBuilder.java
@@ -44,6 +44,15 @@ public class EmailSenderRequestBuilder {
     public static final String CLIENT_CREDENTIAL_SCOPES =
             "internal_config_mgt_add internal_config_mgt_delete internal_config_mgt_list";
 
+    // Password Credential Auth constants
+    public static final String PASSWORD_CREDENTIAL_CLIENT_ID = "test-password-credential-client-id";
+    public static final String PASSWORD_CREDENTIAL_CLIENT_SECRET = "test-password-credential-client-secret";
+    public static final String PASSWORD_CREDENTIAL_USERNAME = "test-password-credential-username";
+    public static final String PASSWORD_CREDENTIAL_PASSWORD = "test-password-credential-password";
+    public static final String PASSWORD_CREDENTIAL_TOKEN_ENDPOINT = "https://example.com/oauth2/token";
+    public static final String PASSWORD_CREDENTIAL_SCOPES =
+            "internal_config_mgt_add internal_config_mgt_delete internal_config_mgt_list";
+
     // Bearer Auth constants
     public static final String BEARER_ACCESS_TOKEN = "test-bearer-token";
 
@@ -151,6 +160,14 @@ public class EmailSenderRequestBuilder {
                 properties.add(createProperty("clientSecret", CLIENT_CREDENTIAL_CLIENT_SECRET));
                 properties.add(createProperty("tokenEndpoint", CLIENT_CREDENTIAL_TOKEN_ENDPOINT));
                 properties.add(createProperty("scopes", CLIENT_CREDENTIAL_SCOPES));
+                break;
+            case "PASSWORD_CREDENTIAL":
+                properties.add(createProperty("clientId", PASSWORD_CREDENTIAL_CLIENT_ID));
+                properties.add(createProperty("clientSecret", PASSWORD_CREDENTIAL_CLIENT_SECRET));
+                properties.add(createProperty("userName", PASSWORD_CREDENTIAL_USERNAME));
+                properties.add(createProperty("password", PASSWORD_CREDENTIAL_PASSWORD));
+                properties.add(createProperty("tokenEndpoint", PASSWORD_CREDENTIAL_TOKEN_ENDPOINT));
+                properties.add(createProperty("scopes", PASSWORD_CREDENTIAL_SCOPES));
                 break;
             case "BEARER":
                 properties.add(createProperty("accessToken", BEARER_ACCESS_TOKEN));

--- a/pom.xml
+++ b/pom.xml
@@ -2752,7 +2752,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.12.0</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.13.8</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.13.10</identity.event.handler.notification.version>
 
         <org.wso2.identity.webhook.event.handlers.version>1.2.13</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.2.3</org.wso2.identity.event.publishers.version>
@@ -2815,7 +2815,7 @@
         <authenticator.magiclink.version>1.2.3</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.2.0</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.2.5</authenticator.local.auth.emailotp.version>
-        <authenticator.local.auth.smsotp.version>1.1.10</authenticator.local.auth.smsotp.version>
+        <authenticator.local.auth.smsotp.version>1.1.11</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.2.0</authenticator.twitter.version>
         <authenticator.x509.version>3.2.2</authenticator.x509.version>
         <identity.extension.utils>1.3.0</identity.extension.utils>
@@ -2835,7 +2835,7 @@
 
         <!-- Identity REST API feature -->
         <identity.api.dispatcher.version>2.0.19</identity.api.dispatcher.version>
-        <identity.server.api.version>1.6.38</identity.server.api.version>
+        <identity.server.api.version>1.6.39</identity.server.api.version>
         <identity.user.api.version>1.5.15</identity.user.api.version>
 
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2868,7 +2868,7 @@
         <carbon.registry.version>4.10.3</carbon.registry.version>
         <carbon.multitenancy.version>4.14.2</carbon.multitenancy.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
-        <carbon.analytics-common.version>5.5.9</carbon.analytics-common.version>
+        <carbon.analytics-common.version>5.5.11</carbon.analytics-common.version>
         <carbon.dashboards.version>2.0.27</carbon.dashboards.version>
         <carbon.healthcheck.version>1.4.0</carbon.healthcheck.version>
 


### PR DESCRIPTION
## Summary

Adds integration test coverage for the `PASSWORD_CREDENTIAL` authentication type on SMS and Email notification senders (v2 REST API), which is being introduced by:
- wso2-extensions/identity-event-handler-notification#394
- wso2/identity-api-server#1157
- wso2/carbon-analytics-common#926
- wso2-extensions/identity-local-auth-smsotp#78

Related tracking issue: wso2/product-is#28270

## Changes

- `MockOAuth2TokenServer`: added support for the `password` grant type (validates client auth plus `username`/`password` params), alongside the existing `client_credentials`/`refresh_token` support.
- SMS senders (`SMSSenderSuccessTest`, `SMSSenderFailureTest`, `AuthenticationBuilder`, test-local `Authentication` model): added `PASSWORD_CREDENTIAL` success path (create/get/delete, asserting secrets are never returned) and 5 negative cases for each required property (`clientId`, `clientSecret`, `username`, `password`, `tokenEndpoint`).
- Email senders (`EmailSenderSuccessTest`, `EmailSenderTestBase`, `EmailSenderRequestBuilder`): added `PASSWORD_CREDENTIAL` success paths for both HTTP-based and SMTP-based senders, mirroring the existing `CLIENT_CREDENTIAL` coverage (including the super-tenant `405` branching already present for Email).
- Bumped `identity.event.handler.notification.version` (1.13.10), `authenticator.local.auth.smsotp.version` (1.1.11), `identity.server.api.version` (1.6.39), and `carbon.analytics-common.version` (5.5.11) to pick up the released fixes from the PRs above.

### Real end-to-end delivery coverage (new)

The changes above only verified sender config CRUD/validation - creation succeeds, secrets are masked correctly - never that a real send actually goes out with the right token attached. Added:

- **SMS**: extended the existing real login-triggered send test (`PasswordlessSMSOTPAuthTestCase`) to cover `PASSWORD_CREDENTIAL` alongside the existing `CLIENT_CREDENTIAL` case - a real passwordless-OTP login now drives an actual SMS send under both auth types, asserting the mock gateway receives the correct `Bearer` token minted via the matching OAuth2 grant (`password` vs `client_credentials`).
- **HTTP-based Email**: added a new `MockHTTPEmailProvider` (mirrors the existing `MockSMSProvider`) plus `HTTPEmailNotificationRealDeliveryTestCase`, parametrized over `CLIENT_CREDENTIAL`/`PASSWORD_CREDENTIAL`. Triggers a real send via the password-recovery-notification governance connector (`recovery/password/init` + `recover`, EMAIL channel) and asserts the same Bearer-token/grant-type correctness at the mock gateway.
- **Refresh-token reuse**: both of the above now also assert that a *second* send reuses the cached refresh token (`grant_type=refresh_token`) with a freshly-issued access token, rather than re-authenticating from scratch - regression coverage for `HTTPEventAdapter.fetchOrRefreshToken`.

## Test plan

- [x] `mvn test-compile` on `modules/integration/tests-integration/tests-backend` — compiles cleanly.
- [ ] Full TestNG run of the new real-delivery test classes against a live server - not yet completed here, since this module's automation harness provisions its own fresh server rather than pointing at an already-patched one; pending a CI run (or separate harness work) for a green-run confirmation. All four dependency versions above are released, so the tests exercise real, released code once run.
