### PR TITLE
Bump identity-event-handler-notification and smsotp dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2752,7 +2752,7 @@
 
         <!-- Identity Event Handler Versions -->
         <identity.event.handler.account.lock.version>1.12.0</identity.event.handler.account.lock.version>
-        <identity.event.handler.notification.version>1.13.8</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version>1.13.9</identity.event.handler.notification.version>
 
         <org.wso2.identity.webhook.event.handlers.version>1.2.13</org.wso2.identity.webhook.event.handlers.version>
         <org.wso2.identity.event.publishers.version>1.2.3</org.wso2.identity.event.publishers.version>
@@ -2815,7 +2815,7 @@
         <authenticator.magiclink.version>1.2.3</authenticator.magiclink.version>
         <authenticator.emailotp.version>4.2.0</authenticator.emailotp.version>
         <authenticator.local.auth.emailotp.version>1.2.5</authenticator.local.auth.emailotp.version>
-        <authenticator.local.auth.smsotp.version>1.1.10</authenticator.local.auth.smsotp.version>
+        <authenticator.local.auth.smsotp.version>1.1.11</authenticator.local.auth.smsotp.version>
         <authenticator.twitter.version>1.2.0</authenticator.twitter.version>
         <authenticator.x509.version>3.2.2</authenticator.x509.version>
         <identity.extension.utils>1.3.0</identity.extension.utils>


### PR DESCRIPTION
## Purpose

Pull in the released versions containing PASSWORD_CREDENTIAL (OAuth2 ROPC grant) authentication support for HTTP-based SMS/Email Notification Providers:

* `identity.event.handler.notification.version`: `1.13.8` -> `1.13.9`
* `authenticator.local.auth.smsotp.version`: `1.1.10` -> `1.1.11`

## Test plan

- [x] Verified both released versions resolve and the consuming modules (`identity-local-auth-smsotp`) compile and pass tests against them.
- [ ] CI build on this PR.