### PR TITLE
Bump log4j2 from 2.25.4 to 2.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2996,7 +2996,7 @@
         <!--ws-trust-client-->
         <org.apache.velocity.version>1.7</org.apache.velocity.version>
         <org.xmlunit.version>2.6.3</org.xmlunit.version>
-        <org.apache.logging.log4j.version>2.25.4</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.25.5</org.apache.logging.log4j.version>
         <org.apache.log4j.wso2.version>1.2.17.wso2v1</org.apache.log4j.wso2.version>
 
         <project.scm.id>my-scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose

Addresses **CVE-2026-49844** (MEDIUM) — *Apache Log4j API: Malformed JSON output due to improper encoding* — https://avd.aquasec.com/nvd/cve-2026-49844

| Library | Installed | Fixed in |
|---|---|---|
| `org.apache.logging.log4j:log4j-api` | 2.25.4 | 2.25.5, 2.26.1 |

Stayed on the 2.25.x line rather than jumping to 2.26.1, to keep this a patch bump.

## Scope — this PR alone does not clear the finding

`org.apache.logging.log4j.version` here governs the `log4j-jul` and `log4j-core` dependencies declared in this pom. The `log4j-api-2.25.4.jar` that the scan actually flagged is shipped into the distribution `lib/` directory by **carbon-kernel**, driven by `version.log4j.core` in its `parent/pom.xml`.

Verified against a built IS 7.4.0-SNAPSHOT pack:

```
./lib/log4j-api-2.25.4.jar
./lib/log4j-core-2.25.4.jar
./lib/log4j-jcl-2.25.4.jar
```

So clearing the CVE needs both:
1. wso2/carbon-kernel#4618 — bumps `version.log4j.core` to 2.25.5, then a kernel release
2. A follow-up `carbon.kernel.version` bump here (currently 4.12.47)

This PR is the first half; it keeps the two log4j version properties consistent so the kernel bump does not reintroduce a mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)