### PR TITLE
Bumpe kernel and private-key-jwt version

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.47" useFeatures="true" includeLaunchers="true">
+version="4.12.48" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.47" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.47"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.48"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2841,7 +2841,7 @@
         <identity.agent.sso.version>5.5.9</identity.agent.sso.version>
         <identity.tool.samlsso.validator.version>5.5.13</identity.tool.samlsso.validator.version>
         <identity.oauth.addons.version>2.6.0</identity.oauth.addons.version>
-	    <identity.oauth.addons.token.handler.clientauth.jwt.version>2.6.8</identity.oauth.addons.token.handler.clientauth.jwt.version>
+	    <identity.oauth.addons.token.handler.clientauth.jwt.version>2.6.9</identity.oauth.addons.token.handler.clientauth.jwt.version>
 	    <identity.oauth.addons.token.handler.clientauth.mutualtls.version>2.6.5</identity.oauth.addons.token.handler.clientauth.mutualtls.version>
         <identity.oauth.addons.clientauth.privilegeduser.version>2.8.0</identity.oauth.addons.clientauth.privilegeduser.version>
         <org.wso2.carbon.extension.identity.x509certificate.version>1.2.0</org.wso2.carbon.extension.identity.x509certificate.version>
@@ -2857,7 +2857,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.47</carbon.kernel.version>
+        <carbon.kernel.version>4.12.48</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.2</identity.verification.version>


### PR DESCRIPTION
This pull request updates several version numbers across the project to incorporate the latest releases of key dependencies. These updates ensure compatibility and bring in any recent bug fixes or improvements from upstream components.

Dependency version updates:

* Updated the `carbon.kernel.version` property in `pom.xml` from `4.12.47` to `4.12.48`.
* Updated the `identity.oauth.addons.token.handler.clientauth.jwt.version` property in `pom.xml` from `2.6.8` to `2.6.9`.

Product and feature version alignment:

* Updated the `version` attribute in `modules/p2-profile-gen/carbon.product` from `4.12.47` to `4.12.48`.
* Updated the `org.wso2.carbon.core.runtime` feature version in `modules/p2-profile-gen/carbon.product` from `4.12.47` to `4.12.48`.