### PR TITLE
Bump Carbon Product and related dependency versions

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.48" useFeatures="true" includeLaunchers="true">
+version="4.12.49" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.48" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.48"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.49"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2701,11 +2701,11 @@
 
         <!--Carbon Identity Framework Version-->
 
-        <carbon.identity.framework.version>7.11.179</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.181</carbon.identity.framework.version>
 
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.version.range>
 
-        <identity.notification.push.version>1.2.3</identity.notification.push.version>
+        <identity.notification.push.version>1.2.4</identity.notification.push.version>
         <identity.notification.push.version.range>[1.0.0,2.0.0)</identity.notification.push.version.range>
 
         <identity.notification.push.provider.amazonsns.version>1.0.0</identity.notification.push.provider.amazonsns.version>
@@ -2722,7 +2722,7 @@
         <carbon.consent.mgt.version>2.9.19</carbon.consent.mgt.version>
 
         <!--Identity Governance Version-->
-        <identity.governance.version>1.16.34</identity.governance.version>
+        <identity.governance.version>1.16.35</identity.governance.version>
 
         <!--Identity Carbon Versions-->
         <identity.carbon.auth.saml2.version>5.12.4</identity.carbon.auth.saml2.version>
@@ -2857,7 +2857,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.48</carbon.kernel.version>
+        <carbon.kernel.version>4.12.49</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.2</identity.verification.version>


### PR DESCRIPTION
This pull request updates several dependencies and version numbers to keep the project up to date and ensure compatibility with the latest releases. The main focus is on bumping versions for core Carbon components and related identity modules.

**Dependency and Version Updates:**

*Carbon Core and Kernel:*
- Updated `carbon.kernel.version` from `4.12.48` to `4.12.49` in `pom.xml` and `carbon.product` files to use the latest kernel version. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2860-R2860) [[2]](diffhunk://#diff-fb626faa6458db1bcdb52bd7f2017cc2af23109ee2bb9b3644b2a0bece19af57L5-R5)
- Updated the `org.wso2.carbon.core.runtime` feature version from `4.12.48` to `4.12.49` in `carbon.product`.

*Identity Framework and Governance:*
- Bumped `carbon.identity.framework.version` from `7.11.179` to `7.11.181` for improved identity management features and bug fixes.
- Updated `identity.governance.version` from `1.16.34` to `1.16.35`.

*Notification Push Module:*
- Increased `identity.notification.push.version` from `1.2.3` to `1.2.4` to include the latest notification push changes.