### PR TITLE
Update consent admin mode test for pending authorizations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -59,3 +59,5 @@ body:
         - label: "[New Configuration] Does this change introduce a new configuration?"
         - label: " ↳ Label `config` added"
         - label: " ↳ Configuration is properly documented"
+        - label: "[IAM CTL] Does this change affect the behavior of the IAM CTL tool?"
+        - label: " ↳ Necessary changes made in the IAM CTL tool"

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -53,3 +53,5 @@ body:
         - label: "[New Configuration] Does this change introduce a new configuration?"
         - label: " ↳ Label `config` added"
         - label: " ↳ Configuration is properly documented"
+        - label: "[IAM CTL] Does this change affect the behavior of the IAM CTL tool?"
+        - label: " ↳ Necessary changes made in the IAM CTL tool"

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -60,3 +60,5 @@ body:
         - label: "[New Configuration] Does this change introduce a new configuration?"
         - label: " ↳ Label `config` added"
         - label: " ↳ Configuration is properly documented"
+        - label: "[IAM CTL] Does this change affect the behavior of the IAM CTL tool?"
+        - label: " ↳ Necessary changes made in the IAM CTL tool"

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -46,3 +46,5 @@ body:
         - label: "[New Configuration] Does this change introduce a new configuration?"
         - label: " ↳ Label `config` added"
         - label: " ↳ Configuration is properly documented"
+        - label: "[IAM CTL] Does this change affect the behavior of the IAM CTL tool?"
+        - label: " ↳ Necessary changes made in the IAM CTL tool"

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2AdminModeTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/consent/management/v2/ConsentManagementV2AdminModeTest.java
@@ -483,8 +483,8 @@ public class ConsentManagementV2AdminModeTest extends ConsentManagementV2TestBas
 
     /**
      * Adding a new authorizer without a {@code state} must leave it PENDING. PENDING authorizations
-     * are not exposed in the response DTO, so the user must be absent from the authorization list
-     * while the recomputed consent state becomes PENDING.
+     * are exposed in the response DTO, so the user must be present in the authorization list with a
+     * PENDING state while the recomputed consent state becomes PENDING.
      */
     @Test
     public void testAdminAddAuthorizerWithoutStateRemainsPending() throws Exception {
@@ -500,7 +500,8 @@ public class ConsentManagementV2AdminModeTest extends ConsentManagementV2TestBas
                 .statusCode(HttpStatus.SC_OK)
                 .body("id", equalTo(consentId))
                 .body("state", equalTo("PENDING"))
-                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }", nullValue());
+                .body("authorizations.find { it.userId == '" + ADMIN_MODE_USER + "' }.state",
+                        equalTo("PENDING"));
     }
 
     /**


### PR DESCRIPTION
`testAdminAddAuthorizerWithoutStateRemainsPending` asserted that PENDING authorizations are absent from the response. With the new improvements, they are returned in the authorizations list.

Updated the assertion to expect the authorization with state `PENDING`, and updated the javadoc accordingly.

Related Issue: https://github.com/wso2/product-is/issues/28224