### PR TITLE
Add multiple client secret fields to OpenIDConnectConfiguration test model

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OpenIDConnectConfiguration.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/rest/api/server/application/management/v1/model/OpenIDConnectConfiguration.java
@@ -32,6 +32,8 @@ public class OpenIDConnectConfiguration  {
   
     private String clientId;
     private String clientSecret;
+    private Long clientSecretExpiresAt;
+    private Boolean multipleClientSecretsConfigured;
 
 @XmlType(name="StateEnum")
 @XmlEnum(String.class)
@@ -126,6 +128,44 @@ public enum StateEnum {
     }
     public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+    }
+
+    /**
+    * The expiration time of the latest client secret, expressed in Unix epoch seconds. A value of 0 indicates that the secret never expires.
+    **/
+    public OpenIDConnectConfiguration clientSecretExpiresAt(Long clientSecretExpiresAt) {
+
+        this.clientSecretExpiresAt = clientSecretExpiresAt;
+        return this;
+    }
+
+    @ApiModelProperty(example = "1761568483", value = "The expiration time of the latest client secret, expressed in Unix epoch seconds. A value of 0 indicates that the secret never expires.")
+    @JsonProperty("clientSecretExpiresAt")
+    @Valid
+    public Long getClientSecretExpiresAt() {
+        return clientSecretExpiresAt;
+    }
+    public void setClientSecretExpiresAt(Long clientSecretExpiresAt) {
+        this.clientSecretExpiresAt = clientSecretExpiresAt;
+    }
+
+    /**
+    * Indicates if the application has more than one client secret.
+    **/
+    public OpenIDConnectConfiguration multipleClientSecretsConfigured(Boolean multipleClientSecretsConfigured) {
+
+        this.multipleClientSecretsConfigured = multipleClientSecretsConfigured;
+        return this;
+    }
+
+    @ApiModelProperty(example = "true", value = "Indicates if the application has more than one client secret.")
+    @JsonProperty("multipleClientSecretsConfigured")
+    @Valid
+    public Boolean getMultipleClientSecretsConfigured() {
+        return multipleClientSecretsConfigured;
+    }
+    public void setMultipleClientSecretsConfigured(Boolean multipleClientSecretsConfigured) {
+        this.multipleClientSecretsConfigured = multipleClientSecretsConfigured;
     }
 
     /**
@@ -582,6 +622,8 @@ public enum StateEnum {
         OpenIDConnectConfiguration openIDConnectConfiguration = (OpenIDConnectConfiguration) o;
         return Objects.equals(this.clientId, openIDConnectConfiguration.clientId) &&
             Objects.equals(this.clientSecret, openIDConnectConfiguration.clientSecret) &&
+            Objects.equals(this.clientSecretExpiresAt, openIDConnectConfiguration.clientSecretExpiresAt) &&
+            Objects.equals(this.multipleClientSecretsConfigured, openIDConnectConfiguration.multipleClientSecretsConfigured) &&
             Objects.equals(this.state, openIDConnectConfiguration.state) &&
             Objects.equals(this.grantTypes, openIDConnectConfiguration.grantTypes) &&
             Objects.equals(this.callbackURLs, openIDConnectConfiguration.callbackURLs) &&
@@ -608,7 +650,7 @@ public enum StateEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, hybridFlow, accessToken, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata, fapiProfile, issuer);
+        return Objects.hash(clientId, clientSecret, clientSecretExpiresAt, multipleClientSecretsConfigured, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, hybridFlow, accessToken, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata, fapiProfile, issuer);
     }
 
     @Override
@@ -619,6 +661,8 @@ public enum StateEnum {
 
         sb.append("    clientId: ").append(toIndentedString(clientId)).append("\n");
         sb.append("    clientSecret: ").append(toIndentedString(clientSecret)).append("\n");
+        sb.append("    clientSecretExpiresAt: ").append(toIndentedString(clientSecretExpiresAt)).append("\n");
+        sb.append("    multipleClientSecretsConfigured: ").append(toIndentedString(multipleClientSecretsConfigured)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("    grantTypes: ").append(toIndentedString(grantTypes)).append("\n");
         sb.append("    callbackURLs: ").append(toIndentedString(callbackURLs)).append("\n");


### PR DESCRIPTION
### Purpose

Add `clientSecretExpiresAt` and `multipleClientSecretsConfigured` to the application management v1 integration-test model (`OpenIDConnectConfiguration`), matching the API response introduced by the multiple client secrets feature 

### Related PRs
- https://github.com/wso2/identity-api-server/pull/1154
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3284

### Related Issue
- https://github.com/wso2/product-is/issues/28127

