### PR TITLE
Fix BasicAuthHandler#getAuthenticationInfo() returning null in integration tests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/BasicAuthHandler.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/BasicAuthHandler.java
@@ -110,8 +110,13 @@ public class BasicAuthHandler implements AuthenticationHandler {
      *
      * @return AuthenticationInfo
      */
+    @Override
     public AuthenticationInfo getAuthenticationInfo() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
-    }
 
+        BasicAuthInfo basicAuthInfo = new BasicAuthInfo();
+        basicAuthInfo.setUserName(USER_NAME);
+        basicAuthInfo.setPassword(PASSWORD);
+        basicAuthInfo.setAuthorizationHeader(getBase64EncodedBasicAuthHeader(USER_NAME, PASSWORD));
+        return basicAuthInfo;
+    }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/BasicAuthHandlerTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/identity/integration/test/utils/BasicAuthHandlerTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.integration.test.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.charon.core.extensions.AuthenticationInfo;
+
+/**
+ * Unit test cases for {@link BasicAuthHandler}.
+ */
+public class BasicAuthHandlerTestCase {
+
+    @Test
+    public void testGetAuthenticationInfo() {
+
+        BasicAuthHandler basicAuthHandler = new BasicAuthHandler();
+        AuthenticationInfo authenticationInfo = basicAuthHandler.getAuthenticationInfo();
+
+        Assert.assertNotNull(authenticationInfo, "AuthenticationInfo should not be null.");
+        Assert.assertTrue(authenticationInfo instanceof BasicAuthInfo,
+                "AuthenticationInfo should be an instance of BasicAuthInfo.");
+
+        BasicAuthInfo basicAuthInfo = (BasicAuthInfo) authenticationInfo;
+        Assert.assertEquals(basicAuthInfo.getUserName(), "wso2charonAdmin",
+                "Username should match default charon admin username.");
+        Assert.assertEquals(basicAuthInfo.getPassword(), "charonAdmin123@wso2",
+                "Password should match default charon admin password.");
+
+        String expectedHeader = basicAuthHandler.getBase64EncodedBasicAuthHeader("wso2charonAdmin",
+                "charonAdmin123@wso2");
+        Assert.assertEquals(basicAuthInfo.getAuthorizationHeader(), expectedHeader,
+                "Authorization header should match expected base64 basic auth header.");
+        Assert.assertTrue(basicAuthInfo.getAuthorizationHeader().startsWith("Basic "),
+                "Authorization header should start with 'Basic ' prefix.");
+    }
+}

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/identity/ui/integration/test/utils/BasicAuthHandler.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/identity/ui/integration/test/utils/BasicAuthHandler.java
@@ -114,8 +114,13 @@ public class BasicAuthHandler implements AuthenticationHandler {
      *
      * @return AuthenticationInfo
      */
+    @Override
     public AuthenticationInfo getAuthenticationInfo() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
-    }
 
+        BasicAuthInfo basicAuthInfo = new BasicAuthInfo();
+        basicAuthInfo.setUserName(USER_NAME);
+        basicAuthInfo.setPassword(PASSWORD);
+        basicAuthInfo.setAuthorizationHeader(getBase64EncodedBasicAuthHeader(USER_NAME, PASSWORD));
+        return basicAuthInfo;
+    }
 }


### PR DESCRIPTION
Purpose
Resolves an issue where `BasicAuthHandler#getAuthenticationInfo()` in integration test modules returns `null`, risking `NullPointerException` errors in downstream test callers.

 Goals
Ensure `getAuthenticationInfo()` returns a valid, populated `BasicAuthInfo` object containing the default credentials (`USER_NAME`, `PASSWORD`) and the Base64-encoded `Authorization` header.

Approach
- Updated `getAuthenticationInfo()` in `modules/integration/tests-integration/tests-backend/.../BasicAuthHandler.java` and `modules/integration/tests-ui-integration/.../BasicAuthHandler.java` to instantiate and populate `BasicAuthInfo`.
- Added unit test `BasicAuthHandlerTestCase` in `tests-backend` verifying that `getAuthenticationInfo()` returns a non-null object with expected username, password, and header format.

### Related Issues
- Fixes #26893

### User stories
N/A

### Release note
N/A

### Documentation
N/A

### Automation tests
- Unit tests added: `BasicAuthHandlerTestCase`
- Test run results: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`

### Security checks
- Follows existing test credential patterns.
