### PR TITLE
Add batch mode and wait-for-server-start handling to conformance tests

### DIFF
--- a/.github/workflows/fapi-oidc-conformance-test.yml
+++ b/.github/workflows/fapi-oidc-conformance-test.yml
@@ -64,7 +64,7 @@ jobs:
           cd cloned-product-is
           git clone https://github.com/wso2/product-is
           cd product-is
-          mvn clean install -Dmaven.test.skip=true | tee mvn-build.log
+          mvn clean install -Dmaven.test.skip=true --batch-mode | tee mvn-build.log
 
           REPO_BUILD_STATUS=$(cat mvn-build.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
           echo "==========================================================="

--- a/.github/workflows/oidc-conformance-test.yml
+++ b/.github/workflows/oidc-conformance-test.yml
@@ -78,7 +78,7 @@ jobs:
           cd cloned-product-is
           git clone https://github.com/wso2/product-is
           cd product-is
-          mvn clean install -Dmaven.test.skip=true | tee mvn-build.log
+          mvn clean install -Dmaven.test.skip=true --batch-mode | tee mvn-build.log
 
           REPO_BUILD_STATUS=$(cat mvn-build.log | grep "\[INFO\] BUILD" | grep -oE '[^ ]+$')
           echo "==========================================================="

--- a/oidc-conformance-tests/configure_is.py
+++ b/oidc-conformance-tests/configure_is.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 import re
+import time
 import warnings
 import psutil
 import requests
@@ -36,6 +37,28 @@ headers = {
 path_to_is_zip = str(sys.argv[1])
 path_to_jacoco_agent = str(sys.argv[2])
 path_to_jacoco_exec = str(sys.argv[3])
+
+
+# wait until the server is serving requests before configuring it.
+def wait_for_server_ready():
+    url = constants.BASE_URL + "/api/health-check/v1.0/health"
+    max_attempts = 10
+    retry_interval = 15  # seconds; up to ~150s of readiness tolerance
+    print("\nWaiting for server to be ready")
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = requests.get(url=url, verify=False, timeout=10)
+            if response.status_code == 200 and "health" in (response.text or ""):
+                print("Server is ready (attempt %d)" % attempt)
+                return
+            print("Server not ready (attempt %d/%d): status=%s"
+                  % (attempt, max_attempts, response.status_code))
+        except Exception as error:
+            print("Server not ready (attempt %d/%d): %s" % (attempt, max_attempts, error))
+        time.sleep(retry_interval)
+
+    print("\nError: Server did not become ready after %d attempts." % max_attempts)
+    exit(1)
 
 
 # use dcr to register a client
@@ -357,6 +380,9 @@ def unpack_and_run(zip_file_name):
                 break
             if output:
                 print(output.strip())
+        # The "WSO2 Carbon started" line only means the OSGi runtime is up; wait
+        # until the web apps are actually serving requests before configuring.
+        wait_for_server_ready()
         rc = process.poll()
         return rc
     except FileNotFoundError:
@@ -485,7 +511,6 @@ if not is_process_running("wso2server"):
     unpack_and_run(path_to_is_zip)
 else:
     print("IS already running")
-
 
 dcr()
 subscribe_apis()

--- a/oidc-fapi-conformance-tests/configure_is_fapi.py
+++ b/oidc-fapi-conformance-tests/configure_is_fapi.py
@@ -1,4 +1,5 @@
 import re
+import time
 import warnings
 import psutil
 import requests
@@ -18,6 +19,27 @@ def decode_secret(secret):
     decoded_string=base64.b64decode(secret+"=").decode("utf-8")
     decoded_json = json.loads(decoded_string)
     return decoded_json
+
+# wait until the server is serving requests before configuring it.
+def wait_for_server_ready():
+    url = constants.BASE_URL + "/api/health-check/v1.0/health"
+    max_attempts = 10
+    retry_interval = 15  # seconds; up to ~150s of readiness tolerance
+    print("\nWaiting for server to be ready")
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = requests.get(url=url, verify=False, timeout=10)
+            if response.status_code == 200 and "health" in (response.text or ""):
+                print("Server is ready (attempt %d)" % attempt)
+                return
+            print("Server not ready (attempt %d/%d): status=%s"
+                  % (attempt, max_attempts, response.status_code))
+        except Exception as error:
+            print("Server not ready (attempt %d/%d): %s" % (attempt, max_attempts, error))
+        time.sleep(retry_interval)
+
+    print("\nError: Server did not become ready after %d attempts." % max_attempts)
+    exit(1)
 
 # use dcr to register a client
 def dcr(app_json):
@@ -206,6 +228,9 @@ def unpack_and_run():
                 break
             if output:
                 print(output.strip())
+        # The "WSO2 Carbon started" line only means the OSGi runtime is up; wait
+        # until the web apps are actually serving requests before configuring.
+        wait_for_server_ready()
         rc = process.poll()
         return rc
     except FileNotFoundError:


### PR DESCRIPTION
This pull request improves the reliability of the OIDC and FAPI conformance test setup by ensuring that the WSO2 Identity Server is fully ready to serve HTTP requests before proceeding with configuration steps. It also makes a minor update to the Maven build commands in the related GitHub Actions workflows to improve log output.

**Improvements to server readiness checks:**

* Added a `wait_for_server_ready()` function in both `configure_is.py` and `configure_is_fapi.py` to poll the server's health endpoint and wait until it is ready before running configuration steps. This prevents configuration attempts before the server is fully operational. [[1]](diffhunk://#diff-d9eaa39a9b2dcc98be3afc20347f23e915925f3f3820308581c1a7ab9eed3353R17) [[2]](diffhunk://#diff-d9eaa39a9b2dcc98be3afc20347f23e915925f3f3820308581c1a7ab9eed3353R42-R63) [[3]](diffhunk://#diff-d9eaa39a9b2dcc98be3afc20347f23e915925f3f3820308581c1a7ab9eed3353R383-R385) [[4]](diffhunk://#diff-8fba2b81e8dada75217ab2cc452c1c0ec00ca28f1db78c9deb22323781a4a970R2) [[5]](diffhunk://#diff-8fba2b81e8dada75217ab2cc452c1c0ec00ca28f1db78c9deb22323781a4a970R23-R43) [[6]](diffhunk://#diff-8fba2b81e8dada75217ab2cc452c1c0ec00ca28f1db78c9deb22323781a4a970R231-R233)

**Workflow enhancements:**

* Updated the Maven build command in `.github/workflows/oidc-conformance-test.yml` and `.github/workflows/fapi-oidc-conformance-test.yml` to use `--batch-mode`, which produces cleaner, non-interactive logs during CI builds. [[1]](diffhunk://#diff-702aa414472d3433c8725536f872f387f4e5fcc8bad4d4b9744778253c27503dL81-R81) [[2]](diffhunk://#diff-319395c7159d19a8d7bc956fe432a1c9c563fef1204f2af85d6e2e33712b5f13L67-R67)