### PR TITLE
Bump carbon kernel version 4.12.54

### DIFF
--- a/modules/p2-profile-gen/carbon.product
+++ b/modules/p2-profile-gen/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.12.53" useFeatures="true" includeLaunchers="true">
+version="4.12.54" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.12.53" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.12.53"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.12.54"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -2857,7 +2857,7 @@
         <charon.version>3.4.1</charon.version>
 
         <!-- Carbon Kernel -->
-        <carbon.kernel.version>4.12.53</carbon.kernel.version>
+        <carbon.kernel.version>4.12.54</carbon.kernel.version>
 
         <!-- Identity Verification -->
         <identity.verification.version>1.1.2</identity.verification.version>


### PR DESCRIPTION
This pull request updates the Carbon Kernel version used in the project from 4.12.53 to 4.12.54. The changes ensure that the product and its dependencies reference the latest version of the Carbon Kernel.

Version updates:

* Updated the `carbon.kernel.version` property in `pom.xml` to 4.12.54.
* Updated the `version` attribute and the `org.wso2.carbon.core.runtime` feature version in `modules/p2-profile-gen/carbon.product` to 4.12.54. [[1]](diffhunk://#diff-fb626faa6458db1bcdb52bd7f2017cc2af23109ee2bb9b3644b2a0bece19af57L5-R5) [[2]](diffhunk://#diff-fb626faa6458db1bcdb52bd7f2017cc2af23109ee2bb9b3644b2a0bece19af57L17-R17)